### PR TITLE
chore(prettier): add .prettierrc file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}


### PR DESCRIPTION
This change adds a `.prettierrc` file to the project.

From looking at the existing code and #8, the current style seems to match `prettier` defaults except for `trailingComma` which is set to `"all"`. By specifying only that override, `prettier` will respect its default values for all other rules.

This allows `plugin:prettier/recommended` to know what to recommend, and prevents anyone with a global `.prettierrc` in their local env (like me 😁) from constantly overwriting the expected style.