### PR TITLE
Implementation-agnostic linking for @thunderstore/components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,11 @@
   ],
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true }
+    ]
   },
   "overrides": [
     {

--- a/apps/nextjs/LinkLibrary.tsx
+++ b/apps/nextjs/LinkLibrary.tsx
@@ -1,0 +1,48 @@
+/**
+ * Define how links should be rendered in @thunderstore/nextjs.
+ *
+ * Links included in @thunderstore/components are defined in the
+ * LinkLibrary interface. Since @thunderstore/components aims to be
+ * implmentation-agnostic, it doesn't know how they should be rendered.
+ * It's up the app to define the rendering methods and provide them via
+ * a context provider.
+ *
+ * To be consistent, it's not a bad idea to render the links defifned in
+ * @thunderstore/nextjs with the same Link component defined here.
+ */
+import {
+  Link as ChakraLink,
+  LinkProps as ChakraLinkProps,
+} from "@chakra-ui/react";
+import {
+  LinkLibrary,
+  thunderstoreLinkProps,
+  ThunderstoreLinkProps,
+} from "@thunderstore/components";
+import NextLink from "next/link";
+
+interface LinkProps extends ChakraLinkProps, ThunderstoreLinkProps {
+  url: string;
+}
+
+export const Link = (props: LinkProps): React.ReactElement => {
+  const { url, children, ...chakraProps } = props;
+
+  for (const key in thunderstoreLinkProps) {
+    delete chakraProps[key as keyof ThunderstoreLinkProps];
+  }
+
+  return (
+    <NextLink href={url} passHref>
+      <ChakraLink {...chakraProps}>{children}</ChakraLink>
+    </NextLink>
+  );
+};
+
+const library: LinkLibrary = {
+  Anonymous: (p) => Link(p),
+  Index: (p) => Link({ ...p, url: "/" }),
+  Package: (p) => Link({ ...p, url: `/c/${p.community}/p/${p.package}` }),
+};
+
+export { library as LinkLibrary };

--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { AppProps } from "next/app";
-import { RootWrapper, theme } from "@thunderstore/components";
+import { LinkingProvider, RootWrapper, theme } from "@thunderstore/components";
+import { LinkLibrary } from "../LinkLibrary";
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
@@ -10,7 +11,9 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
           process.env.NEXT_PUBLIC_API_URL || "https://thunderstore.io/api/",
       }}
     >
-      <Component {...pageProps} />
+      <LinkingProvider value={LinkLibrary}>
+        <Component {...pageProps} />
+      </LinkingProvider>
     </RootWrapper>
   );
 }

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,3 +1,6 @@
+import { LinkingProvider, RootWrapper, theme } from "@thunderstore/components";
+import { LinkLibrary } from "../LinkLibrary";
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -15,3 +18,20 @@ export const parameters = {
     ],
   },
 };
+
+export const decorators = [
+  (Story) => (
+    <RootWrapper
+      theme={theme}
+      thunderstoreProviderValue={{
+        apiUrl:
+          process.env.NEXT_PUBLIC_API_URL || "https://thunderstore.io/api/",
+        useNextJS: false,
+      }}
+    >
+      <LinkingProvider value={LinkLibrary}>
+        <Story />
+      </LinkingProvider>
+    </RootWrapper>
+  ),
+];

--- a/apps/storybook/LinkLibrary.tsx
+++ b/apps/storybook/LinkLibrary.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable prettier/prettier */
+import {
+  Link as ChakraLink,
+  LinkProps as ChakraLinkProps,
+} from "@chakra-ui/react";
+import {
+  LinkLibrary,
+  thunderstoreLinkProps,
+  ThunderstoreLinkProps,
+} from "@thunderstore/components";
+
+interface LinkProps extends ChakraLinkProps, ThunderstoreLinkProps {
+  url: string;
+}
+
+const Link = (props: LinkProps): React.ReactElement => {
+  const { url, children, ...chakraProps } = props;
+
+  for (const key in thunderstoreLinkProps) {
+    delete chakraProps[key as keyof ThunderstoreLinkProps];
+  }
+
+  // Render links as spans so clicking them does nothing.
+  return (
+    <ChakraLink href={url} {...chakraProps} as="span">
+      {children}
+    </ChakraLink>
+  );
+};
+
+const library: LinkLibrary = {
+  Anonymous: (p) => Link(p),
+  Index: (p) => Link({ ...p, url: "/" }),
+  Package: (p) => Link({ ...p, url: `/c/${p.community}/p/${p.package}` }),
+};
+
+export { library as LinkLibrary };

--- a/packages/components/src/components/LinkingProvider.tsx
+++ b/packages/components/src/components/LinkingProvider.tsx
@@ -1,0 +1,76 @@
+/**
+ * Implementation-agnostic context provider for navigation.
+ *
+ * @thunderstore/components aims to be reusable. Therefore the links
+ * used in the components, by default, render nothing. It's up to the
+ * app using the components to define how the links are rendered and
+ * inject the definitions with a context provider that wraps the
+ * components:
+ *
+ * 1. Create "myLinkLib" that implements the provided LinkLibrary interface.
+ * 2. Wrap the components with <LinkingProvider value={myLinkLib}>.
+ * 3. Components automatically use myLinkLib to determine how they
+ *    should render any links the contain.
+ *
+ * To add a new link type, follow the 4 steps defined below.
+ */
+import React, { ReactElement as RE } from "react";
+
+// STEP 1 of adding new link definitions:
+// If the new link uses any props not already listed here, add them.
+export interface ThunderstoreLinkProps {
+  community?: string;
+  package?: string;
+}
+
+// STEP 2 of adding new link definitions:
+// If any new properties were added to ThunderstoreLinkProps, add a
+// dummy value for them here (the value doesn't matter). This is used to
+// strip the props so they don't get passed to HTML elements in React
+// implementations. Second, redundant declaration as an object is
+// required since the stripping is done during runtime.
+export const thunderstoreLinkProps: ThunderstoreLinkProps = {
+  community: "",
+  package: "",
+};
+
+// Accepting any and all props is required to keep the linking
+// implementation-agnostic. E.g. an implementation with Chakra has all
+// kinds of custom properties.
+interface AnyProps {
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+type NoRequiredProps = (props: AnyProps) => RE | null;
+
+// STEP 3 of adding bew link definitions:
+// Declare and document any links used in the components here.
+export interface LinkLibrary {
+  /** Creates a link pointing to URL prop */
+  Anonymous: (props: AnyProps & { url: string }) => RE | null;
+  /** Site's frontpage */
+  Index: NoRequiredProps;
+  /** Package's detail view */
+  Package: (
+    props: AnyProps & { community: string; package: string }
+  ) => RE | null;
+}
+
+const noop = () => null;
+
+// STEP 4 of adding new link definitions:
+// Define the link as no-op for default implementation.
+const library: LinkLibrary = {
+  Anonymous: noop,
+  Index: noop,
+  Package: noop,
+};
+
+// Define LinkingContext with the no-op LinkLibrary as the default
+// value. If no overriding provider is defined in the context where the
+// components are used, they will use this default implementation, which
+// means the links are not rendered at all.
+export const LinkingContext = React.createContext(library);
+LinkingContext.displayName = "LinkingContext";
+
+export const LinkingProvider = LinkingContext.Provider;

--- a/packages/components/src/components/LinkingProvider.tsx
+++ b/packages/components/src/components/LinkingProvider.tsx
@@ -12,7 +12,7 @@
  * 3. Components automatically use myLinkLib to determine how they
  *    should render any links the contain.
  *
- * To add a new link type, follow the 4 steps defined below.
+ * To add a new link type, follow the 4 required steps defined below.
  */
 import React, { ReactElement as RE } from "react";
 
@@ -37,7 +37,7 @@ export const thunderstoreLinkProps: ThunderstoreLinkProps = {
 // Accepting any and all props is required to keep the linking
 // implementation-agnostic. E.g. an implementation with Chakra has all
 // kinds of custom properties.
-interface AnyProps {
+export interface AnyProps {
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
@@ -65,6 +65,9 @@ const library: LinkLibrary = {
   Index: noop,
   Package: noop,
 };
+
+// OPTIONAL STEP 5 of adding new link definitions:
+// Add the link to ./Links.tsx for easier importing.
 
 // Define LinkingContext with the no-op LinkLibrary as the default
 // value. If no overriding provider is defined in the context where the

--- a/packages/components/src/components/Links.tsx
+++ b/packages/components/src/components/Links.tsx
@@ -1,0 +1,21 @@
+/**
+ * Ease-of-use wrapper for links defined in LinkingProvider.tsx. Allows
+ * importing link components directly instead of having to manually call
+ * useContext. LinkingContext can also be used "manually" if one so
+ * wishes.
+ */
+import React from "react";
+import { LinkingContext, LinkLibrary } from "./LinkingProvider";
+
+const wrap = <T extends keyof LinkLibrary>(key: T): LinkLibrary[T] => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, react/display-name
+  return (props: any) => {
+    const Links = React.useContext(LinkingContext);
+    const Link = Links[key];
+    return <Link {...props} />;
+  };
+};
+
+export const AnonymousLink = wrap("Anonymous");
+export const IndexLink = wrap("Index");
+export const PackageLink = wrap("Package");

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,6 +2,7 @@ export { theme } from "./theme";
 export { ThunderstoreProvider } from "./components/ThunderstoreProvider";
 export * from "./components/CommunityPicker";
 export * from "./components/FileUpload";
+export * from "./components/LinkingProvider";
 export * from "./components/Markdown";
 export * from "./components/PackageUpload";
 export * from "./components/RootWrapper";


### PR DESCRIPTION
Differences to proof-of-concept v2:

* [AnyProps](https://github.com/thunderstore-io/thunderstore-ui/commit/0035f47e436cd96538da8fb38f40a46e2ce04cc4#diff-cd76e2f9ce49485cabb251ae7796bb3f36a5ac6c773ac383159133fc999afa5fR41) uses `any` as suggested.
* Rather than use named `Output` type, use plain `ReactElement | null` instead ([example](https://github.com/thunderstore-io/thunderstore-ui/commit/0035f47e436cd96538da8fb38f40a46e2ce04cc4#diff-cd76e2f9ce49485cabb251ae7796bb3f36a5ac6c773ac383159133fc999afa5fR44)). I felt the `Output` unnecessary obfuscated the true return type in IDEs (at least VS Code).
* `Links.tsx` now uses a [wrapper function](https://github.com/thunderstore-io/thunderstore-ui/commit/e76c6dca461c889d365d9c0be46d680d88aa0d6f#diff-d6b620b573ded152e28a0407eadb68f4fdb64d09c52731b460816114df9c87d4R10-R17) to slightly reduce boilerplate code
* Added proper comments and commit messages
* Removed the dummy `TopBar` component used to showcase the functionality
* Added [LinkingProvider implementation](https://github.com/thunderstore-io/thunderstore-ui/commit/38bffad1327d7410b2c5154dd510a24a89209920) for Storybook