### PR TITLE
@thunderstore/storybook: fix wandering human readable date

### DIFF
--- a/apps/storybook/stories/components/PackageActions.stories.tsx
+++ b/apps/storybook/stories/components/PackageActions.stories.tsx
@@ -10,6 +10,8 @@ const Template: ComponentStory<typeof PackageActions> = (args) => (
   <PackageActions {...args} />
 );
 
+const lastWeek = new Date(Date.now() - 604800000);
+
 const Actions = Template.bind({});
 Actions.args = {
   communityIdentifier: "riskofrain2",
@@ -18,7 +20,7 @@ Actions.args = {
   downloadCount: 245111867,
   downloadUrl: "/",
   installUrl: "/",
-  lastUpdated: "2022-01-01",
+  lastUpdated: lastWeek,
   packageName: "ChefMod",
   ratingScore: 32,
   renderFullWidth: false,


### PR DESCRIPTION
Story's content used a fixed date, which caused the human readable
output to wander from "2 months ago" to "3 months ago" and so on. This
triggered unnecessary and misleading need for a review in Chromatic.

The story now uses dynamic date, which causes the human readable
format to remain as "last week".