### PR TITLE
Fix Next.js app build process

### DIFF
--- a/packages/dapper/package.json
+++ b/packages/dapper/package.json
@@ -11,16 +11,17 @@
     "test": "jest --watch"
   },
   "dependencies": {
+    "@babel/runtime": "^7.17.0",
     "@types/react": "^17.0.38",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "zod": "^3.14.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
-    "ts-jest": "^27.1.4",
-    "zod": "^3.14.4"
+    "ts-jest": "^27.1.4"
   }
 }


### PR DESCRIPTION
Build process failed due to errors in Dapper's package.json file:

* Add @babel/runtime required by preconstruct
* Move zod from devDependencies to dependencies

Refs TS-318