### PR TITLE
WIP implementation for authentication, pt 5

### DIFF
--- a/apps/nextjs/components/SessionContext.tsx
+++ b/apps/nextjs/components/SessionContext.tsx
@@ -1,0 +1,80 @@
+import { createContext, FC, useContext, useState } from "react";
+
+import { StorageManager } from "utils/storage";
+
+interface ContextInterface {
+  /** Remove sessionId from provider's state and localStorage. */
+  clearSessionId: () => void;
+  /** Fetch sessionId from provider's state or localStorage. */
+  sessionId?: string;
+  /** Store sessionId in provider's state and localStorage. */
+  setSessionId: (sessionId?: string) => void;
+}
+
+const SessionContext = createContext<ContextInterface | null>(null);
+const ID_KEY = "id";
+
+/**
+ * For managing data API's session id.
+ *
+ * This app has two backend: Next.js backend mostly used for SSR, and
+ * Django API backend for fetching actual data. The session id for
+ * authenticating with the latter is stored in the localStorage, and
+ * should be accessed via this convenience provider.
+ */
+export const SessionProvider: FC = (props) => {
+  const [_sessionId, _setSessionId] = useState<string>();
+  const _storage = new StorageManager("Session");
+
+  if (_sessionId === undefined) {
+    const storedId = _storage.safeGetValue(ID_KEY);
+
+    if (storedId) {
+      _setSessionId(storedId);
+    }
+  }
+
+  const setSessionId = (sessionId?: string) => {
+    _setSessionId(sessionId);
+
+    if (sessionId) {
+      _storage.setValue(ID_KEY, sessionId);
+    } else {
+      _storage.removeValue(ID_KEY);
+    }
+  };
+
+  const clearSessionId = () => {
+    _setSessionId(undefined);
+    _storage.removeValue(ID_KEY);
+  };
+
+  const value = {
+    clearSessionId,
+    sessionId: _sessionId,
+    setSessionId,
+  };
+
+  return (
+    <SessionContext.Provider value={value}>
+      {props.children}
+    </SessionContext.Provider>
+  );
+};
+
+/**
+ * For accessing data API's session id.
+ *
+ * * sessionId?: string
+ * * setSessionId: (sessionId: string) => void
+ * * clearSessionId: () => void
+ */
+export const useSession = (): ContextInterface => {
+  const contextState = useContext(SessionContext);
+
+  if (contextState === null) {
+    throw new Error("useSession must be used within a SessionProvider tag");
+  }
+
+  return contextState;
+};

--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProps } from "next/app";
 import { LinkingProvider, RootWrapper, theme } from "@thunderstore/components";
 import { Dapper, DapperProvider } from "@thunderstore/dapper";
 
+import { SessionProvider } from "components/SessionContext";
 import { LinkLibrary } from "LinkLibrary";
 import { API_DOMAIN } from "utils/constants";
 
@@ -14,11 +15,13 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
           process.env.NEXT_PUBLIC_API_URL || "https://thunderstore.io/api/",
       }}
     >
-      <DapperProvider dapper={new Dapper(API_DOMAIN)}>
-        <LinkingProvider value={LinkLibrary}>
-          <Component {...pageProps} />
-        </LinkingProvider>
-      </DapperProvider>
+      <SessionProvider>
+        <DapperProvider dapper={new Dapper(API_DOMAIN)}>
+          <LinkingProvider value={LinkLibrary}>
+            <Component {...pageProps} />
+          </LinkingProvider>
+        </DapperProvider>
+      </SessionProvider>
     </RootWrapper>
   );
 }

--- a/apps/nextjs/utils/storage.ts
+++ b/apps/nextjs/utils/storage.ts
@@ -19,6 +19,15 @@ export class StorageManager {
     this._storage.removeItem(this._addNamespace(key));
   }
 
+  /** Returns null if storage is unavailable or it contained no value. */
+  safeGetValue(key: string): string | null {
+    try {
+      return this.getValue(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
   setValue(key: string, value: string): void {
     this._storage.setItem(this._addNamespace(key), value);
   }


### PR DESCRIPTION
Implemented in earlier commits (in this repo and backend repo):

1. User clicks an authentication link
2. User's browser stores a "state token" to local storage (for CSRF
   prevention) and redirects to OAuth provider's endpoint for login
3. After login, browser is redirected to client-side page, with query
   parameters containing the state token (which is validated) and a
   "code token"
4. Client-side page sends a request to Next.js API endpoint, which
   creates another request containing the code token and a "shared
   secret token" (for brute force prevention). For security reasons
   the latter token is not available client-side, which is why this
   sidestep is required
5. Next.js API endpoint sends the request to Django API endpoint
6. Django API endpoint validates the shared secret token
7. The endpoint sends a request containing the code token to OAuth
   provider, and receives an "access token"
8. The endpoint queries user's information from another API using the
   access token for authentication
9. If no account is found with the received information, one is created
10. Endpoint creates a session for the identified user
11. Endpoint returns session id to Next.js API endpoint

This commit implements the following steps of the authentication flow:

12. Next.js API endpoint relays the session id to the client-side page
13. Client-side page stores the session id

In future commits:

14. Client uses session id in the following requests

Refs TS-230, TS-356