### PR TITLE
WIP implementation for authentication, pt 6

### DIFF
--- a/apps/nextjs/hooks/useFreshProps.ts
+++ b/apps/nextjs/hooks/useFreshProps.ts
@@ -1,0 +1,44 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+import { useSession } from "components/SessionContext";
+
+/**
+ * Refresh page contents from data API if user is authenticated.
+ *
+ * The session id used to authenticate the user for the data API is
+ * stored in the localStorage and thus isn't available when Next.js
+ * renders the initial page on the server-side. This hook can be used to
+ * refetch the data on the client-side in case the user is
+ * authenticated.
+ *
+ * Note: to avoid unnecessary requests, this should be used only on
+ * pages where the contents can actually differ between an authenticated
+ * and unauthenticated user.
+ *
+ * @param setProps method for storing response contents in React state
+ * @param dapperMethod data fetching method provided by Dapper
+ * @param dapperParams array of parameters passed to dapperMethod
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useFreshProps<T extends (...args: any) => any>(
+  setProps: Dispatch<SetStateAction<Awaited<ReturnType<T>>>>,
+  dapperMethod: T,
+  dapperParams: Parameters<T>
+): void {
+  const { sessionId } = useSession();
+  const [hasRun, setHasRun] = useState(false);
+
+  useEffect(() => {
+    if (hasRun || sessionId === undefined) {
+      return;
+    }
+
+    const fetchData = async () => {
+      const props = await dapperMethod(...dapperParams);
+      setProps(props);
+    };
+
+    fetchData();
+    setHasRun(true);
+  }, [dapperMethod, dapperParams, hasRun, sessionId, setHasRun, setProps]);
+}

--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -2,11 +2,11 @@ import { AppProps } from "next/app";
 import { LinkingProvider, RootWrapper, theme } from "@thunderstore/components";
 import { Dapper, DapperProvider } from "@thunderstore/dapper";
 
-import { SessionProvider } from "components/SessionContext";
+import { SessionProvider, useSession } from "components/SessionContext";
 import { LinkLibrary } from "LinkLibrary";
 import { API_DOMAIN } from "utils/constants";
 
-function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+export default function ThunderstoreApp(appProps: AppProps): JSX.Element {
   return (
     <RootWrapper
       theme={theme}
@@ -16,14 +16,21 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
       }}
     >
       <SessionProvider>
-        <DapperProvider dapper={new Dapper(API_DOMAIN)}>
-          <LinkingProvider value={LinkLibrary}>
-            <Component {...pageProps} />
-          </LinkingProvider>
-        </DapperProvider>
+        <Substack {...appProps} />
       </SessionProvider>
     </RootWrapper>
   );
 }
 
-export default MyApp;
+function Substack({ Component, pageProps }: AppProps): JSX.Element {
+  const { sessionId } = useSession();
+  const dapper = new Dapper(API_DOMAIN, sessionId);
+
+  return (
+    <DapperProvider dapper={dapper}>
+      <LinkingProvider value={LinkLibrary}>
+        <Component {...pageProps} />
+      </LinkingProvider>
+    </DapperProvider>
+  );
+}

--- a/apps/nextjs/pages/c/[community]/p/[namespace]/[package]/index.tsx
+++ b/apps/nextjs/pages/c/[community]/p/[namespace]/[package]/index.tsx
@@ -1,18 +1,14 @@
 import {
   PackageActions,
-  PackageActionsProps,
-  PackageDependency,
   PackageHeader,
-  PackageHeaderProps,
   PackageInfo,
-  PackageInfoProps,
   PackageRequirements,
-  PackageVersion,
   PackageVersions,
 } from "@thunderstore/components";
-import { Dapper } from "@thunderstore/dapper";
+import { Dapper, useDapper } from "@thunderstore/dapper";
 import { useMediaQuery } from "@thunderstore/hooks";
 import { GetServerSideProps } from "next";
+import { useState } from "react";
 
 import { Background } from "components/Background";
 import {
@@ -20,18 +16,19 @@ import {
   FULL_WIDTH_BREAKPOINT,
   LayoutWrapper,
 } from "components/Wrapper";
+import { useFreshProps } from "hooks/useFreshProps";
 import { API_DOMAIN } from "utils/constants";
 
-interface PageProps
-  extends PackageActionsProps,
-    PackageHeaderProps,
-    PackageInfoProps {
-  coverImage: string | null;
-  requirements: PackageDependency[];
-  versions: PackageVersion[];
-}
+type PageProps = Awaited<ReturnType<Dapper["getPackage"]>>;
 
-export default function PackageDetailPage(props: PageProps): JSX.Element {
+export default function PackageDetailPage(props_: PageProps): JSX.Element {
+  const [props, setProps] = useState(props_);
+  const dapper = useDapper();
+  useFreshProps(setProps, dapper.getPackage.bind(dapper), [
+    props_.communityIdentifier,
+    props_.namespace,
+    props_.packageName,
+  ]);
   const { coverImage, markdown, packageName, requirements, versions } = props;
   const isFullWidth = useMediaQuery(`(min-width: ${FULL_WIDTH_BREAKPOINT})`);
 

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -10,6 +10,8 @@ import { getPackage, GetPackage } from "./methods/package";
 import { QsArray, serializeQueryString } from "./queryString";
 
 export interface DapperInterface {
+  sessionId?: string;
+
   getCommunityPackageListing: GetCommunityPackageListing;
   getFrontpage: GetFrontpage;
   getPackage: GetPackage;
@@ -18,9 +20,11 @@ export interface DapperInterface {
 export class Dapper implements DapperInterface {
   readonly apiDomain: string;
   readonly apiPath = "api/experimental/frontend";
+  readonly sessionId?: string;
 
-  constructor(domain: string) {
+  constructor(domain: string, sessionId?: string) {
     this.apiDomain = domain.endsWith("/") ? domain.slice(0, -1) : domain;
+    this.sessionId = sessionId;
   }
 
   /**
@@ -30,10 +34,14 @@ export class Dapper implements DapperInterface {
     url: string,
     schema: T
   ): Promise<z.infer<T>> {
+    const settings: RequestInit = this.sessionId
+      ? { headers: { authorization: `Session ${this.sessionId}` } }
+      : {};
+
     let response;
 
     try {
-      response = await fetch(url);
+      response = await fetch(url, settings);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Data fetching error";
       throw new DapperError(msg, url, DapperError.FETCH_ERROR);


### PR DESCRIPTION
Implemented in earlier commits (in this repo and backend repo):

1. User clicks an authentication link
2. User's browser stores a "state token" to local storage (for CSRF
   prevention) and redirects to OAuth provider's endpoint for login
3. After login, browser is redirected to client-side page, with query
   parameters containing the state token (which is validated) and a
   "code token"
4. Client-side page sends a request to Next.js API endpoint, which
   creates another request containing the code token and a "shared
   secret token" (for brute force prevention). For security reasons
   the latter token is not available client-side, which is why this
   sidestep is required
5. Next.js API endpoint sends the request to Django API endpoint
6. Django API endpoint validates the shared secret token
7. The endpoint sends a request containing the code token to OAuth
   provider, and receives an "access token"
8. The endpoint queries user's information from another API using the
   access token for authentication
9. If no account is found with the received information, one is created
10. Endpoint creates a session for the identified user
11. Endpoint returns session id to Next.js API endpoint
12. Next.js API endpoint relays the session id to the client-side page
13. Client-side page stores the session id

This commit implements the following steps of the authentication flow:

14. Client uses session id in the following requests

Refs TS-230, TS-357