### PR TITLE
@thunderstore/components: make whole CommunityCard clickable

### DIFF
--- a/packages/components/src/components/CommunityCard.tsx
+++ b/packages/components/src/components/CommunityCard.tsx
@@ -22,7 +22,18 @@ export interface CommunityCardProps {
 export const CommunityCard: React.FC<CommunityCardProps> = (props) => {
   const { downloadCount, identifier, imageSrc, packageCount, name } = props;
   return (
-    <Box bg="ts.blue" {...borderStyles} borderWidth={2} w={360}>
+    <CommunityLink
+      community={identifier}
+      bg="ts.blue"
+      {...borderStyles}
+      borderWidth={2}
+      transition="border 100ms linear"
+      w={360}
+      _hover={{
+        borderColor: "ts.lightBlue.115",
+        textDecoration: "none",
+      }}
+    >
       <MaybeImage imageSrc={imageSrc} height="110px" />
 
       <Text
@@ -31,12 +42,7 @@ export const CommunityCard: React.FC<CommunityCardProps> = (props) => {
         fontWeight={700}
         p="20px 20px 14px 20px"
       >
-        <CommunityLink
-          community={identifier}
-          _hover={{ textDecoration: "underline solid white 2px" }}
-        >
-          {name}
-        </CommunityLink>
+        {name}
       </Text>
 
       <Flex
@@ -56,13 +62,9 @@ export const CommunityCard: React.FC<CommunityCardProps> = (props) => {
           </Box>
         </Flex>
         <Spacer />
-        <Box>
-          <CommunityLink community={identifier}>
-            <ChevronRight {...iconStyles} mr="0" />
-          </CommunityLink>
-        </Box>
+        <ChevronRight {...iconStyles} mr="0" mt="2px" />
       </Flex>
-    </Box>
+    </CommunityLink>
   );
 };
 

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -18,6 +18,7 @@ const blue = "#242e48";
 const coolGray = "#93a0c2";
 const darkBlue = "#17213b";
 const lightBlue = "#353e58";
+const lightBlue115 = "#49567a"; // Lightened by 15%.
 const orange = "#ffa96b";
 const white = "#fff";
 
@@ -30,6 +31,7 @@ export const theme = extendTheme({
       coolGray,
       darkBlue,
       lightBlue,
+      "lightBlue.115": lightBlue115,
       orange,
       white,
     },


### PR DESCRIPTION
Initially only the name of the community and a chevron icon functioned
as an anchor element, now the whole card does. Therefore underlining
the community name on mouse hover didn't really work anymore - now the
hovered card has a slightly lighter border color to make it stand out.

Refs TS-388