### PR TITLE
@thunderstore/components: make PackageCard image clickable

### DIFF
--- a/packages/components/src/components/PackageCard.tsx
+++ b/packages/components/src/components/PackageCard.tsx
@@ -55,11 +55,17 @@ export const PackageCard: React.FC<PackageCardProps> = (props) => {
       w={270}
       pos="relative"
     >
-      <MaybeImage
-        borderRadius="3px 3px 0 0"
-        height="200px"
-        imageSrc={imageSrc}
-      />
+      <PackageLink
+        community={communityIdentifier}
+        namespace={namespace}
+        package={packageName}
+      >
+        <MaybeImage
+          borderRadius="3px 3px 0 0"
+          height="200px"
+          imageSrc={imageSrc}
+        />
+      </PackageLink>
       <PinnedTag isPinned={isPinned} />
 
       <Flex


### PR DESCRIPTION
The image on a PackageCard component works as a link to the package's
detail page. The overlays, e.g. "pinned" tag is not clickable to avoid
confusion.

Refs TS-336