### PR TITLE
@thunderstore/nextjs: validate session id read from localStorage

### DIFF
--- a/apps/nextjs/hooks/useFreshProps.ts
+++ b/apps/nextjs/hooks/useFreshProps.ts
@@ -30,11 +30,17 @@ export function useFreshProps<T extends (...args: any) => any>(
   dapperMethod: T,
   dapperParams: Parameters<T>
 ): WithDid404<Awaited<ReturnType<T>>> {
-  const { sessionId } = useSession();
+  const { isReady, sessionId } = useSession();
   const [props, setProps] = useState(initialProps);
   const [hasRun, setHasRun] = useState(false);
 
   useEffect(() => {
+    // Postpone sending the request if the session id stored in
+    // localStorage isn't validated yet.
+    if (!isReady) {
+      return;
+    }
+
     // If the unauthenticated server-side request resulted in 404 and
     // the user isn't authenticated, there's no point redoing the request.
     if (initialProps.did404 && sessionId === undefined) {
@@ -61,6 +67,7 @@ export function useFreshProps<T extends (...args: any) => any>(
     dapperParams,
     hasRun,
     initialProps.did404,
+    isReady,
     sessionId,
     setHasRun,
     setProps,


### PR DESCRIPTION
When user authenticates, the session id is stored in SessionProvider's
internal state for quick access and localStorage for retention. When
the session id is read from the localStorage, API backend is pinged to
check if the session is still valid.

Consumers of the SessionProvider context should check the provided
isSessionIdValidated flag before attempting to use the sessionId e.g.
in API calls.

Refs TS-230, TS-358