### PR TITLE
@thunderstore/sertra: make mod selection modal an actual modal

### DIFF
--- a/apps/sertra/components/mod-selector/button.tsx
+++ b/apps/sertra/components/mod-selector/button.tsx
@@ -2,26 +2,20 @@ import { PropsWithChildren } from "react";
 
 import styles from "./button.module.css";
 
-interface ButtonBaseProps {
+interface ButtonProps extends PropsWithChildren {
+  onClick?: () => void;
+}
+
+interface ButtonBaseProps extends ButtonProps {
   className: string;
 }
-const ButtonBase: React.FC<PropsWithChildren<ButtonBaseProps>> = ({
-  children,
-  className,
-}) => {
-  return <button className={className}>{children}</button>;
-};
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ButtonProps {}
-export const ButtonPrimary: React.FC<PropsWithChildren<ButtonProps>> = ({
-  children,
-}) => {
-  return <ButtonBase className={styles.buttonPrimary}>{children}</ButtonBase>;
-};
+const ButtonBase: React.FC<ButtonBaseProps> = (props) => <button {...props} />;
 
-export const ButtonSecondary: React.FC<PropsWithChildren<ButtonProps>> = ({
-  children,
-}) => {
-  return <ButtonBase className={styles.buttonSecondary}>{children}</ButtonBase>;
-};
+export const ButtonPrimary: React.FC<ButtonProps> = (props) => (
+  <ButtonBase className={styles.buttonPrimary} {...props} />
+);
+
+export const ButtonSecondary: React.FC<ButtonProps> = (props) => (
+  <ButtonBase className={styles.buttonSecondary} {...props} />
+);

--- a/apps/sertra/components/mod-selector/iconButton.tsx
+++ b/apps/sertra/components/mod-selector/iconButton.tsx
@@ -1,9 +1,9 @@
-import { DetailedHTMLProps } from "react";
+import { DetailedHTMLProps, ReactNode } from "react";
 
 import styles from "./iconButton.module.css";
 
 interface IconButtonProps {
-  content: string;
+  content: ReactNode;
   buttonProps?: DetailedHTMLProps<
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement

--- a/apps/sertra/components/mod-selector/modal.module.css
+++ b/apps/sertra/components/mod-selector/modal.module.css
@@ -1,7 +1,26 @@
-.modal {
+.background {
+  visibility: hidden;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 100vw;
   border-radius: var(--border-radius-normal);
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.background.visible {
+  visibility: visible;
+  display: flex;
+}
+
+.modal {
   display: flex;
   flex-direction: column;
+  width: 71.25rem;
   overflow: hidden;
 }
 
@@ -17,6 +36,11 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+}
+
+.headerTitle svg {
+  width: 1.375rem;
+  height: 1.375rem;
 }
 
 .headerContent {

--- a/apps/sertra/components/mod-selector/modal.tsx
+++ b/apps/sertra/components/mod-selector/modal.tsx
@@ -1,4 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { PropsWithChildren, useMemo, useState } from "react";
 
 import { ButtonPrimary, ButtonSecondary } from "./button";
@@ -8,20 +9,29 @@ import { ModListRow } from "./list";
 import styles from "./modal.module.css";
 import { SearchBox } from "./search";
 
-interface ModalHeaderProps {
-  title?: string;
-  enableCloseButton?: boolean;
+interface Closable {
+  close: () => void;
 }
-export const ModalHeader: React.FC<PropsWithChildren<ModalHeaderProps>> = ({
+
+interface ModalHeaderProps extends PropsWithChildren, Closable {
+  title?: string;
+}
+
+export const ModalHeader: React.FC<ModalHeaderProps> = ({
   children,
+  close,
   title,
-  enableCloseButton = true,
 }) => {
   return (
     <div className={styles.header}>
       <div className={styles.headerTitle}>
         <div>{title && <h2>{title}</h2>}</div>
-        <div>{enableCloseButton && <IconButton content={"X"} />}</div>
+        <div>
+          <IconButton
+            content={<FontAwesomeIcon icon={faXmark} />}
+            buttonProps={{ onClick: close }}
+          />
+        </div>
       </div>
       {children && <div className={styles.headerContent}>{children}</div>}
     </div>
@@ -32,18 +42,18 @@ export const ModalContent: React.FC<PropsWithChildren> = ({ children }) => {
   return <div className={styles.content}>{children}</div>;
 };
 
-export const ModalFooter: React.FC<unknown> = () => {
+export const ModalFooter: React.FC<Closable> = ({ close }) => {
   return (
     <div className={styles.footer}>
       <div className={styles.footerButtonRow}>
-        <ButtonSecondary>Cancel</ButtonSecondary>
+        <ButtonSecondary onClick={close}>Cancel</ButtonSecondary>
         <ButtonPrimary>Done</ButtonPrimary>
       </div>
     </div>
   );
 };
 
-export const NoModsSelectedNotice: React.FC<unknown> = () => {
+export const NoModsSelectedNotice: React.FC = () => {
   return (
     <div className={styles.noMods}>
       <FontAwesomeIcon
@@ -58,7 +68,12 @@ export const NoModsSelectedNotice: React.FC<unknown> = () => {
   );
 };
 
-export const ModSelectorModal = () => {
+interface ModSelectorProps extends Closable {
+  visible: boolean;
+}
+
+export const ModSelectorModal: React.FC<ModSelectorProps> = (props) => {
+  const { visible, close } = props;
   const [selectedMods, setSelectedMods] = useState<ModPackage[]>([]);
 
   const selectableMods: ModPackage[] = useMemo(() => {
@@ -82,33 +97,35 @@ export const ModSelectorModal = () => {
   }, [selectedMods, setSelectedMods]);
 
   return (
-    <div className={styles.modal}>
-      <ModalHeader title={"Mods"}>
-        <SearchBox
-          placeholder={"Search mods..."}
-          options={selectableMods}
-          renderOption={(option) => (
-            <ModListRow modPackage={option} showControls={false} />
-          )}
-          keyExtractor={(option) => option.id}
-          onSelect={selectMod}
-        />
-      </ModalHeader>
-      <ModalContent>
-        {!selectedMods.length && <NoModsSelectedNotice />}
-        {!!selectedMods.length &&
-          selectedMods.map((data) => {
-            return (
-              <ModListRow
-                key={data.id}
-                modPackage={data}
-                showControls={true}
-                onDelete={deselectMod}
-              />
-            );
-          })}
-      </ModalContent>
-      <ModalFooter />
+    <div className={`${styles.background} ${visible ? styles.visible : ""}`}>
+      <div className={styles.modal}>
+        <ModalHeader title={"Mods"} close={close}>
+          <SearchBox
+            placeholder={"Search mods..."}
+            options={selectableMods}
+            renderOption={(option) => (
+              <ModListRow modPackage={option} showControls={false} />
+            )}
+            keyExtractor={(option) => option.id}
+            onSelect={selectMod}
+          />
+        </ModalHeader>
+        <ModalContent>
+          {!selectedMods.length && <NoModsSelectedNotice />}
+          {!!selectedMods.length &&
+            selectedMods.map((data) => {
+              return (
+                <ModListRow
+                  key={data.id}
+                  modPackage={data}
+                  showControls={true}
+                  onDelete={deselectMod}
+                />
+              );
+            })}
+        </ModalContent>
+        <ModalFooter close={close} />
+      </div>
     </div>
   );
 };

--- a/apps/sertra/components/mod-selector/modal.tsx
+++ b/apps/sertra/components/mod-selector/modal.tsx
@@ -73,7 +73,7 @@ interface ModSelectorProps extends Closable {
 }
 
 export const ModSelectorModal: React.FC<ModSelectorProps> = (props) => {
-  const { visible, close } = props;
+  const { close, visible } = props;
   const [selectedMods, setSelectedMods] = useState<ModPackage[]>([]);
 
   const selectableMods: ModPackage[] = useMemo(() => {

--- a/apps/sertra/pages/create.tsx
+++ b/apps/sertra/pages/create.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps, NextPage } from "next";
-import { useState } from "react";
+import { FC, PropsWithChildren, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { SWRConfig } from "swr";
 
@@ -18,6 +18,11 @@ export const getStaticProps: GetStaticProps = async () => {
     revalidate: 10,
   };
 };
+
+type Wrapper = FC<PropsWithChildren>;
+const Row: Wrapper = (props) => <div className={styles.row} {...props} />;
+const ColSm: Wrapper = (props) => <div className={styles.colSm} {...props} />;
+const ColLg: Wrapper = (props) => <div className={styles.colLg} {...props} />;
 
 type Inputs = {
   serverName: string;
@@ -66,76 +71,105 @@ const SubmitServer: NextPage<{ swrFallback: { [key: string]: unknown } }> = ({
       <h1 className={styles.formHeader}>Submit Server</h1>
 
       <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
-        <div className={styles.row}>
-          <label htmlFor={"game"}>Game</label>
-          <select id={"game"} className={styles.input}>
-            <option value={"v-rising"}>V Rising</option>
-          </select>
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"game"}>Game</label>
+          </ColSm>
+          <ColLg>
+            <select id={"game"} className={styles.input}>
+              <option value={"v-rising"}>V Rising</option>
+            </select>
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor={"serverName"}>Server Name</label>
-          <input
-            className={styles.input}
-            id={"serverName"}
-            type={"text"}
-            {...register("serverName", { required: true })}
-          />
-          {/* TODO: Add styling here */}
-          {errors.serverName?.type === "required" && "Server name is required"}
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"serverName"}>Server Name</label>
+          </ColSm>
+          <ColLg>
+            <input
+              className={styles.input}
+              id={"serverName"}
+              type={"text"}
+              {...register("serverName", { required: true })}
+            />
+            {/* TODO: Add styling here */}
+            {errors.serverName?.type === "required" &&
+              "Server name is required"}
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor={"connectionInfo"}>Connection Info</label>
-          <input
-            className={styles.input}
-            id={"connectionInfo"}
-            type={"text"}
-            {...register("connectionInfo", { required: true })}
-          />
-          {/* TODO: Add styling here */}
-          {errors.connectionInfo?.type === "required" &&
-            "Connection info is required"}
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"connectionInfo"}>Connection Info</label>
+          </ColSm>
+          <ColLg>
+            <input
+              className={styles.input}
+              id={"connectionInfo"}
+              type={"text"}
+              {...register("connectionInfo", { required: true })}
+            />
+            {/* TODO: Add styling here */}
+            {errors.connectionInfo?.type === "required" &&
+              "Connection info is required"}
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor={"description"}>Description</label>
-          <textarea
-            className={styles.textarea}
-            id={"description"}
-            {...register("description")}
-          />
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"description"}>Description</label>
+          </ColSm>
+          <ColLg>
+            <textarea
+              className={styles.textarea}
+              id={"description"}
+              {...register("description")}
+            />
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor={"mode"}>Mode</label>
-          <select className={styles.input} id={"mode"} {...register("mode")}>
-            <option value={"pvp"}>PvP</option>
-            <option value={"pve"}>PvE</option>
-          </select>
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"mode"}>Mode</label>
+          </ColSm>
+          <ColLg>
+            <select className={styles.input} id={"mode"} {...register("mode")}>
+              <option value={"pvp"}>PvP</option>
+              <option value={"pve"}>PvE</option>
+            </select>
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor="mods">Mods</label>
-          <button
-            id="mods"
-            className={styles.selectMods}
-            type="button"
-            onClick={() => setModalVisible(true)}
-          >
-            Select Mods
-          </button>
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor="mods">Mods</label>
+          </ColSm>
+          <ColLg>
+            <button
+              id="mods"
+              className={styles.selectMods}
+              type="button"
+              onClick={() => setModalVisible(true)}
+            >
+              Select Mods
+            </button>
+          </ColLg>
+        </Row>
 
-        <div className={styles.row}>
-          <label htmlFor={"isPasswordProtected"}>Password Protected</label>
-          <input
-            className={styles.checkbox}
-            id={"isPasswordProtected"}
-            type={"checkbox"}
-            {...register("isPasswordProtected")}
-          />
-        </div>
+        <Row>
+          <ColSm>
+            <label htmlFor={"isPasswordProtected"}>Password Protected</label>
+          </ColSm>
+          <ColLg>
+            <input
+              className={styles.checkbox}
+              id={"isPasswordProtected"}
+              type={"checkbox"}
+              {...register("isPasswordProtected")}
+            />
+          </ColLg>
+        </Row>
 
         <button id={styles.submit}>Submit</button>
       </form>

--- a/apps/sertra/pages/create.tsx
+++ b/apps/sertra/pages/create.tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps, NextPage } from "next";
-import { SWRConfig } from "swr";
+import { useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
+import { SWRConfig } from "swr";
 
 import { getPackageList } from "../api/hooks";
 import { ApiURLs, TsApiURLs } from "../api/urls";
@@ -30,6 +31,7 @@ type Inputs = {
 const SubmitServer: NextPage<{ swrFallback: { [key: string]: unknown } }> = ({
   swrFallback,
 }) => {
+  const [modalVisible, setModalVisible] = useState(false);
   const {
     register,
     handleSubmit,
@@ -56,7 +58,10 @@ const SubmitServer: NextPage<{ swrFallback: { [key: string]: unknown } }> = ({
 
   return (
     <SWRConfig value={{ fallback: swrFallback }}>
-      <ModSelectorModal />
+      <ModSelectorModal
+        close={() => setModalVisible(false)}
+        visible={modalVisible}
+      />
 
       <h1 className={styles.formHeader}>Submit Server</h1>
 
@@ -111,10 +116,15 @@ const SubmitServer: NextPage<{ swrFallback: { [key: string]: unknown } }> = ({
         </div>
 
         <div className={styles.row}>
-          <label htmlFor={"mods"}>Mods</label>
-          <select className={styles.input} id={"mods"} {...register("mods")}>
-            {/* TODO: Populate */}
-          </select>
+          <label htmlFor="mods">Mods</label>
+          <button
+            id="mods"
+            className={styles.selectMods}
+            type="button"
+            onClick={() => setModalVisible(true)}
+          >
+            Select Mods
+          </button>
         </div>
 
         <div className={styles.row}>

--- a/apps/sertra/styles/SubmitServer.module.css
+++ b/apps/sertra/styles/SubmitServer.module.css
@@ -19,8 +19,17 @@
   gap: 0.75rem;
 }
 
-.row label {
+.colSm {
   flex: 0 0 14.5rem;
+}
+
+.colLg {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.row label {
   font-weight: 700;
   line-height: 2.75rem;
 }

--- a/apps/sertra/styles/SubmitServer.module.css
+++ b/apps/sertra/styles/SubmitServer.module.css
@@ -49,6 +49,14 @@ select.input {
   resize: none;
 }
 
+.selectMods {
+  padding: 0.25em 1em;
+  border: 1px solid var(--accent-primary);
+  font: 700 0.875em/1.2 var(--font-family-body);
+  color: var(--accent-primary);
+  background: var(--bg-regular);
+}
+
 .checkbox {
   flex: 0 0 2.75rem;
   margin: 0;


### PR DESCRIPTION
This PR just makes the modal a modal, and adds wrapper divs for the
form to ensure proper layout. There's much it could improve, especially
for component reusability (modals, buttons), but those are left outside
the scope to get the MVP done.

