### PR TITLE
Sertra: Fix NextJS build

### DIFF
--- a/apps/sertra/pages/index.tsx
+++ b/apps/sertra/pages/index.tsx
@@ -2,25 +2,24 @@ import type { GetStaticProps, NextPage } from "next";
 import Head from "next/head";
 import { SWRConfig } from "swr";
 
-import { getServerListings } from "../api/hooks";
-import { ApiURLs } from "../api/urls";
 import { ServerList } from "../components/ServerList";
 import styles from "../components/ServerList.module.css";
 
 export const getStaticProps: GetStaticProps = async () => {
   const fallback: { [key: string]: unknown } = {};
 
-  try {
-    fallback[ApiURLs.ServerList] = await getServerListings();
-  } catch (e) {
-    console.error(e);
-    fallback[ApiURLs.ServerList] = {
-      count: 0,
-      next: null,
-      previous: null,
-      results: [],
-    };
-  }
+  // TODO: Re-enable once API is available
+  // try {
+  //   fallback[ApiURLs.ServerList] = await getServerListings();
+  // } catch (e) {
+  //   console.error(e);
+  //   fallback[ApiURLs.ServerList] = {
+  //     count: 0,
+  //     next: null,
+  //     previous: null,
+  //     results: [],
+  //   };
+  // }
 
   return {
     props: {

--- a/apps/sertra/pages/server/[id].tsx
+++ b/apps/sertra/pages/server/[id].tsx
@@ -8,7 +8,6 @@ import {
   ServerListingData,
   ListingMod,
 } from "../../api/models";
-import { ApiURLs } from "../../api/urls";
 import { LaunchingModManPopup } from "../../components/LaunchingModManPopup";
 import { ModCard } from "../../components/ModCard";
 import { FetchListingData } from "../../api/calls";
@@ -17,20 +16,21 @@ import { ServerInstructions } from "../../components/ServerInstructions";
 import styles from "../../styles/ServerDetail.module.css";
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  let listings = {
+  const listings = {
     count: 0,
     next: null,
     previous: null,
     results: [],
   };
 
-  try {
-    listings = await (await fetch(ApiURLs.ServerList)).json();
-  } catch (e) {
-    console.error(e);
-  }
+  // TODO: Re-enable once API is up
+  // try {
+  //   listings = await (await fetch(ApiURLs.ServerList)).json();
+  // } catch (e) {
+  //   console.error(e);
+  // }
 
-  const paths = listings?.results.map((listing: ServerListingData) => ({
+  const paths = listings.results.map((listing: ServerListingData) => ({
     params: { id: listing.id },
   }));
 


### PR DESCRIPTION
The Sertra NextJS build was failing due to a NextJS imposed timeout if an API request was taking too long. As such, disable the API request entirely as adding a custom timeout to fetch is non-trivial.