### PR TITLE
Cyberstorm: Improve serverside rendering

### DIFF
--- a/apps/cyberstorm-nextjs/README.md
+++ b/apps/cyberstorm-nextjs/README.md
@@ -31,8 +31,11 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Bundle analyzer
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+To run the bundle analyzer, set the `ANALYZE=true` environment variable before building.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Example:
+```
+ANALYZE=true yarn run build
+```

--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
@@ -1,14 +1,16 @@
 import { PackageDependantsLayout } from "@thunderstore/cyberstorm";
 import { getPackageDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";
-import { useParams } from "next/navigation";
 
-export default function Page() {
-  const router = useParams();
+export default function Page({
+  params,
+}: {
+  params: { community: string; namespace: string; package: string };
+}) {
   const packageData = getPackageDummyData(
     "1337",
-    router["community"].toString(),
-    router["namespace"].toString(),
-    router["package"].toString()
+    params.community,
+    params.namespace,
+    params.package
   );
 
   return <PackageDependantsLayout packageData={packageData} />;

--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PackageDependantsLayout } from "@thunderstore/cyberstorm";
 import { getPackageDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";
 import { useParams } from "next/navigation";

--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PackageDetailLayout } from "@thunderstore/cyberstorm";
 import { useParams } from "next/navigation";
 

--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
@@ -1,14 +1,15 @@
 import { PackageDetailLayout } from "@thunderstore/cyberstorm";
-import { useParams } from "next/navigation";
 
-export default function Page() {
-  const router = useParams();
-
+export default function Page({
+  params,
+}: {
+  params: { community: string; namespace: string; package: string };
+}) {
   return (
     <PackageDetailLayout
-      community={router["community"].toString()}
-      namespace={router["namespace"].toString()}
-      packageName={router["package"].toString()}
+      community={params.community}
+      namespace={params.namespace}
+      packageName={params.package}
     />
   );
 }

--- a/apps/cyberstorm-nextjs/app/c/[community]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PackageListLayout } from "@thunderstore/cyberstorm";
 import { useParams } from "next/navigation";
 

--- a/apps/cyberstorm-nextjs/app/c/[community]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/page.tsx
@@ -1,5 +1,4 @@
 import { PackageListLayout } from "@thunderstore/cyberstorm";
-import { useParams } from "next/navigation";
 
 export type User = {
   id: number;
@@ -7,12 +6,6 @@ export type User = {
   email: string;
 };
 
-// This page is very WIP, it's purpose for now is to demonstrate doing
-// a React Query Data fetch.
-
-export default function Page() {
-  const router = useParams();
-  const communityId = router ? router["community"].toString() : "";
-
-  return <PackageListLayout communityId={communityId} />;
+export default function Page({ params }: { params: { community: string } }) {
+  return <PackageListLayout communityId={params.community} />;
 }

--- a/apps/cyberstorm-nextjs/app/communities/page.tsx
+++ b/apps/cyberstorm-nextjs/app/communities/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { CommunityListLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/developers/manifest-validator/page.tsx
+++ b/apps/cyberstorm-nextjs/app/developers/manifest-validator/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { ManifestValidatorLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/developers/markdown-preview/page.tsx
+++ b/apps/cyberstorm-nextjs/app/developers/markdown-preview/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { MarkdownPreviewLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/developers/package-format-docs/page.tsx
+++ b/apps/cyberstorm-nextjs/app/developers/package-format-docs/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PackageFormatDocsLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/developers/upload-package/page.tsx
+++ b/apps/cyberstorm-nextjs/app/developers/upload-package/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PackageUploadLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/page.tsx
+++ b/apps/cyberstorm-nextjs/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { HomeLayout } from "@thunderstore/cyberstorm";
 
 export default function RootLayout() {

--- a/apps/cyberstorm-nextjs/app/privacy-policy/page.tsx
+++ b/apps/cyberstorm-nextjs/app/privacy-policy/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { PrivacyPolicyLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/settings/page.tsx
+++ b/apps/cyberstorm-nextjs/app/settings/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { SettingsLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/t/[team]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/t/[team]/page.tsx
@@ -1,9 +1,5 @@
-import { useParams } from "next/navigation";
 import { TeamLayout } from "@thunderstore/cyberstorm";
 
-export default function Page() {
-  const router = useParams();
-  const teamId = router ? router["team"].toString() : "";
-
-  return <TeamLayout teamId={teamId} />;
+export default function Page({ params }: { params: { team: string } }) {
+  return <TeamLayout teamId={params.team} />;
 }

--- a/apps/cyberstorm-nextjs/app/t/[team]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/t/[team]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { useParams } from "next/navigation";
 import { TeamLayout } from "@thunderstore/cyberstorm";
 

--- a/apps/cyberstorm-nextjs/app/teams/[team]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/teams/[team]/page.tsx
@@ -1,9 +1,5 @@
 import { TeamSettingsLayout } from "@thunderstore/cyberstorm";
-import { useParams } from "next/navigation";
 
-export default function Page() {
-  const router = useParams();
-  const teamId = router ? router["team"].toString() : "";
-
-  return <TeamSettingsLayout teamId={teamId} />;
+export default function Page({ params }: { params: { team: string } }) {
+  return <TeamSettingsLayout teamId={params.team} />;
 }

--- a/apps/cyberstorm-nextjs/app/teams/[team]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/teams/[team]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { TeamSettingsLayout } from "@thunderstore/cyberstorm";
 import { useParams } from "next/navigation";
 

--- a/apps/cyberstorm-nextjs/app/teams/page.tsx
+++ b/apps/cyberstorm-nextjs/app/teams/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { TeamsLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/terms-of-service/page.tsx
+++ b/apps/cyberstorm-nextjs/app/terms-of-service/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { TermsOfServiceLayout } from "@thunderstore/cyberstorm";
 
 export default function Page() {

--- a/apps/cyberstorm-nextjs/app/u/[user]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/u/[user]/page.tsx
@@ -1,9 +1,5 @@
-import { useParams } from "next/navigation";
 import { UserProfileLayout } from "@thunderstore/cyberstorm";
 
-export default function Page() {
-  const router = useParams();
-  const userId = router ? router["user"].toString() : "";
-
-  return <UserProfileLayout userId={userId} />;
+export default function Page({ params }: { params: { user: string } }) {
+  return <UserProfileLayout userId={params.user} />;
 }

--- a/apps/cyberstorm-nextjs/app/u/[user]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/u/[user]/page.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { useParams } from "next/navigation";
 import { UserProfileLayout } from "@thunderstore/cyberstorm";
 

--- a/apps/cyberstorm-nextjs/next.config.js
+++ b/apps/cyberstorm-nextjs/next.config.js
@@ -1,12 +1,21 @@
 const withPreconstruct = require("@preconstruct/next");
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig = withPreconstruct({
   reactStrictMode: true,
   transpilePackages: ["react"],
   experimental: {
     serverActions: true,
   },
-};
+});
 
-module.exports = withPreconstruct(nextConfig);
+let result = nextConfig;
+
+if (process.env.ANALYZE === "true") {
+  const withBundleAnalyzer = require("@next/bundle-analyzer")({
+    enabled: process.env.ANALYZE === "true",
+  });
+  result = withBundleAnalyzer(result);
+}
+
+module.exports = result;

--- a/apps/cyberstorm-nextjs/package.json
+++ b/apps/cyberstorm-nextjs/package.json
@@ -26,6 +26,7 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^13.4.9",
     "@tanstack/eslint-plugin-query": "^4.29.4"
   }
 }

--- a/apps/cyberstorm-nextjs/utils/SessionContext.tsx
+++ b/apps/cyberstorm-nextjs/utils/SessionContext.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Router from "next/router";
 import {
   createContext,

--- a/apps/cyberstorm-nextjs/utils/hydrate.client.tsx
+++ b/apps/cyberstorm-nextjs/utils/hydrate.client.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Hydrate as RQHydrate, HydrateProps } from "react-query";
 
 function Hydrate(props: HydrateProps) {

--- a/packages/cyberstorm/src/components/DataTable/DataTable.tsx
+++ b/packages/cyberstorm/src/components/DataTable/DataTable.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { CSSProperties, ReactNode, useState } from "react";
 import styles from "./DataTable.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/packages/cyberstorm/src/components/Footer/Footer.tsx
+++ b/packages/cyberstorm/src/components/Footer/Footer.tsx
@@ -23,7 +23,7 @@ import { ThunderstoreLogoHorizontal } from "../../svg/svg";
 import { Tooltip } from "../Tooltip/Tooltip";
 
 const AD_IMAGE_SRC = "/images/tsmm_screenshot.png";
-const DISCORD_URL = "https://discord.gg/5MbXZvd";
+const DISCORD_URL = "https://discord.thunderstore.io/";
 const GITHUB_URL = "https://github.com/thunderstore-io/thunderstore-ui";
 const REDDIT_URL = "https://www.reddit.com/r/thunderstore";
 

--- a/packages/cyberstorm/src/components/Header/Header.tsx
+++ b/packages/cyberstorm/src/components/Header/Header.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import styles from "./Header.module.css";
 import { DropDown, DropDownDivider, DropDownItem } from "../DropDown/DropDown";
 import { Button, PlainButton } from "../Button/Button";

--- a/packages/cyberstorm/src/components/Layout/Developers/ManifestValidator/ManifestValidatorLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/Developers/ManifestValidator/ManifestValidatorLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styles from "./ManifestValidatorLayout.module.css";
 import { SettingItem } from "../../../SettingItem/SettingItem";
 import { TextInput } from "../../../TextInput/TextInput";

--- a/packages/cyberstorm/src/components/Layout/Developers/MarkdownPreview/MarkdownPreviewLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/Developers/MarkdownPreview/MarkdownPreviewLayout.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { SettingItem } from "../../../SettingItem/SettingItem";
 import { BreadCrumbs } from "../../../BreadCrumbs/BreadCrumbs";
 import { MarkdownPreviewLink } from "../../../Links/Links";

--- a/packages/cyberstorm/src/components/Layout/Developers/PackageUpload/PackageUploadLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/Developers/PackageUpload/PackageUploadLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styles from "./PackageUploadLayout.module.css";
 import { Title } from "../../../Title/Title";
 import { BreadCrumbs } from "../../../BreadCrumbs/BreadCrumbs";

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { CommunitiesLink, CommunityLink, PackageLink } from "../../Links/Links";
 import { getCommunityDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageVersions/PackageVersions.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageVersions/PackageVersions.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import styles from "./PackageVersions.module.css";
 import { Button } from "../../../Button/Button";
 import { DataTable } from "../../../DataTable/DataTable";

--- a/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CommunitiesLink, CommunityLink } from "../../Links/Links";

--- a/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
@@ -85,7 +85,7 @@ export function PackageListLayout(props: PackageListLayoutProps) {
               key="meta-link"
               leftIcon={<FontAwesomeIcon icon={faDiscord} fixedWidth />}
               label="Join our community"
-              externalUrl="https://discord.gg/5MbXZvd"
+              externalUrl="https://discord.thunderstore.io/"
               size="bold"
             />,
           ]}

--- a/packages/cyberstorm/src/components/Layout/TeamLayout/TeamLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamLayout/TeamLayout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import styles from "./TeamLayout.module.css";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { TeamLink } from "../../Links/Links";

--- a/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamMembers/TeamMembers.tsx
+++ b/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamMembers/TeamMembers.tsx
@@ -52,7 +52,6 @@ export function TeamMemberList(props: TeamMemberListProps) {
               triggerFontSize="medium"
               options={userRoles}
               value={teamMember.role}
-              onChange={() => console.log("asd")}
             />
           </div>
         ),

--- a/packages/cyberstorm/src/components/Layout/Teams/TeamsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/Teams/TeamsLayout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import styles from "./TeamsLayout.module.css";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { TeamsLink } from "../../Links/Links";

--- a/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
@@ -1,4 +1,3 @@
-"use client";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { UserLink } from "../../Links/Links";
 import { getUserDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";

--- a/packages/cyberstorm/src/components/Links/LinkLibrary.tsx
+++ b/packages/cyberstorm/src/components/Links/LinkLibrary.tsx
@@ -1,4 +1,4 @@
-import { LinkLibrary } from "@thunderstore/cyberstorm";
+import { LinkLibrary } from "./LinkingProvider";
 import React from "react";
 
 interface CyberstormLinkProps {

--- a/packages/cyberstorm/src/components/Links/Links.tsx
+++ b/packages/cyberstorm/src/components/Links/Links.tsx
@@ -1,3 +1,4 @@
+"use client";
 /**
  * Ease-of-use wrapper for links defined in LinkingProvider.tsx. Allows
  * importing link components directly instead of having to manually call

--- a/packages/cyberstorm/src/components/Markdown/Markdown.tsx
+++ b/packages/cyberstorm/src/components/Markdown/Markdown.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 
 interface MarkdownProps {

--- a/packages/cyberstorm/src/components/TextAreaInput/TextAreaInput.tsx
+++ b/packages/cyberstorm/src/components/TextAreaInput/TextAreaInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import styles from "./TextAreaInput.module.css";
 

--- a/packages/cyberstorm/src/components/TextInput/TextInput.tsx
+++ b/packages/cyberstorm/src/components/TextInput/TextInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { ReactNode } from "react";
 import styles from "./TextInput.module.css";
 

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -1,49 +1,136 @@
-export * from "./components/Button/Button";
-export * from "./components/CodeBox/CodeBox";
-export * from "./components/BreadCrumbs/BreadCrumbs";
-export * from "./components/CopyButton/CopyButton";
-export * from "./components/Dialog/Dialog";
-export * from "./components/DropDown/DropDown";
-export * from "./components/Footer/Footer";
-export * from "./components/Header/Header";
-export * from "./components/Link/Link";
-export * from "./components/Links/LinkingProvider";
-export * from "./components/Links/Links";
-export * from "./components/Markdown/Markdown";
-export * from "./components/MenuItem/MenuItem";
-export * from "./components/MetaItem/MetaItem";
-export * from "./components/MetaInfoItem/MetaInfoItem";
-export * from "./components/MetaInfoItemList/MetaInfoItemList";
-export * from "./components/PackageCard/PackageCard";
-export * from "./components/PackageIcon/PackageIcon";
-export * from "./components/Pagination/Pagination";
-export * from "./components/Pagination/PaginationButton";
-export * from "./components/Providers";
-export * from "./components/Select/Select";
-export * from "./components/Tabs/Tabs";
-export * from "./components/Tag/Tag";
-export * from "./components/TextInput/TextInput";
-export * from "./components/TextAreaInput/TextAreaInput";
-export * from "./components/Title/Title";
-export * from "./components/Tooltip/Tooltip";
+export {
+  Button,
+  type ButtonProps,
+  PlainButton,
+  type PlainButtonProps,
+} from "./components/Button/Button";
+export { CodeBox, type CodeBoxProps } from "./components/CodeBox/CodeBox";
+export {
+  BreadCrumbs,
+  DefaultHomeCrumb,
+} from "./components/BreadCrumbs/BreadCrumbs";
+export { CopyButton } from "./components/CopyButton/CopyButton";
+export { Dialog } from "./components/Dialog/Dialog";
+export {
+  DropDown,
+  DropDownItem,
+  DropDownDivider,
+} from "./components/DropDown/DropDown";
+export { Footer } from "./components/Footer/Footer";
+export { Header } from "./components/Header/Header";
+export { Link, type LinkProps } from "./components/Link/Link";
+export {
+  LinkingProvider,
+  type LinkLibrary,
+  LinkingContext,
+  type ThunderstoreLinkProps,
+  thunderstoreLinkProps,
+} from "./components/Links/LinkingProvider";
+export {
+  AnonymousLink,
+  CommunitiesLink,
+  CommunityLink,
+  CommunityPackagesLink,
+  IndexLink,
+  PackageDependantsLink,
+  ManifestValidatorLink,
+  PackageLink,
+  PackageUploadLink,
+  PackageVersionLink,
+  MarkdownPreviewLink,
+  PackageFormatDocsLink,
+  PrivacyPolicyLink,
+  SettingsLink,
+  TeamSettingsLink,
+  TeamLink,
+  TeamsLink,
+  UserLink,
+  TermsOfServiceLink,
+} from "./components/Links/Links";
+export { Markdown } from "./components/Markdown/Markdown";
+export { MenuItem, type MenuItemProps } from "./components/MenuItem/MenuItem";
+export { MetaItem, type MetaItemProps } from "./components/MetaItem/MetaItem";
+export {
+  MetaInfoItem,
+  type MetaInfoItemProps,
+} from "./components/MetaInfoItem/MetaInfoItem";
+export {
+  MetaInfoItemList,
+  type MetaInfoItemListProps,
+} from "./components/MetaInfoItemList/MetaInfoItemList";
+export {
+  PackageCard,
+  type PackageCardProps,
+} from "./components/PackageCard/PackageCard";
+export {
+  PackageIcon,
+  type PackageIconProps,
+} from "./components/PackageIcon/PackageIcon";
+export {
+  Pagination,
+  type PaginationProps,
+} from "./components/Pagination/Pagination";
+export {
+  PaginationButton,
+  type PaginationButtonProps,
+} from "./components/Pagination/PaginationButton";
+export { CyberstormProviders } from "./components/Providers";
+export {
+  Select,
+  type SelectOption,
+  type SelectProps,
+} from "./components/Select/Select";
+export { Tabs, type TabsProps } from "./components/Tabs/Tabs";
+export { Tag, type TagProps } from "./components/Tag/Tag";
+export {
+  TextInput,
+  type TextInputProps,
+} from "./components/TextInput/TextInput";
+export {
+  TextAreaInput,
+  type TextAreaInputProps,
+} from "./components/TextAreaInput/TextAreaInput";
+export { Title, type TitleProps } from "./components/Title/Title";
+export { Tooltip, type TooltipProps } from "./components/Tooltip/Tooltip";
 
-export * from "./components/Layout/CommunityListLayout/CommunityListLayout";
-export * from "./components/Layout/HomeLayout/HomeLayout";
-export * from "./components/Layout/PackageDetailLayout/PackageDetailLayout";
-export * from "./components/Layout/PackageDependantsLayout/PackageDependantsLayout";
-export * from "./components/Layout/PackageListLayout/PackageListLayout";
-export * from "./components/Layout/Settings/SettingsLayout";
-export * from "./components/Layout/Teams/TeamSettings/TeamSettingsLayout";
-export * from "./components/Layout/Teams/TeamsLayout";
-export * from "./components/Layout/TeamLayout/TeamLayout";
-export * from "./components/Layout/UserProfileLayout/UserProfileLayout";
+export { CommunityListLayout } from "./components/Layout/CommunityListLayout/CommunityListLayout";
+export { HomeLayout } from "./components/Layout/HomeLayout/HomeLayout";
+export {
+  PackageDetailLayout,
+  type PackageDetailLayoutProps,
+} from "./components/Layout/PackageDetailLayout/PackageDetailLayout";
+export {
+  PackageDependantsLayout,
+  type PackageDependantsLayoutProps,
+} from "./components/Layout/PackageDependantsLayout/PackageDependantsLayout";
+export {
+  PackageListLayout,
+  type PackageListLayoutProps,
+} from "./components/Layout/PackageListLayout/PackageListLayout";
+export {
+  SettingsLayout,
+  type SettingsLayoutProps,
+} from "./components/Layout/Settings/SettingsLayout";
+export {
+  TeamSettingsLayout,
+  type TeamSettingsLayoutProps,
+} from "./components/Layout/Teams/TeamSettings/TeamSettingsLayout";
+export { TeamsLayout } from "./components/Layout/Teams/TeamsLayout";
+export {
+  TeamLayout,
+  type TeamLayoutProps,
+} from "./components/Layout/TeamLayout/TeamLayout";
+export {
+  UserProfileLayout,
+  type UserProfileLayoutProps,
+} from "./components/Layout/UserProfileLayout/UserProfileLayout";
 
-export * from "./components/Layout/Developers/ManifestValidator/ManifestValidatorLayout";
-export * from "./components/Layout/Developers/MarkdownPreview/MarkdownPreviewLayout";
-export * from "./components/Layout/Developers/PackageFormatDocs/PackageFormatDocsLayout";
-export * from "./components/Layout/Developers/PackageUpload/PackageUploadLayout";
+export { ManifestValidatorLayout } from "./components/Layout/Developers/ManifestValidator/ManifestValidatorLayout";
+export { MarkdownPreviewLayout } from "./components/Layout/Developers/MarkdownPreview/MarkdownPreviewLayout";
+export { PackageFormatDocsLayout } from "./components/Layout/Developers/PackageFormatDocs/PackageFormatDocsLayout";
+export { PackageUploadLayout } from "./components/Layout/Developers/PackageUpload/PackageUploadLayout";
 
-export * from "./components/Layout/SimplePages/InternalServerError/InternalServerErrorLayout";
-export * from "./components/Layout/SimplePages/NotFound/NotFoundLayout";
-export * from "./components/Layout/SimplePages/PrivacyPolicy/PrivacyPolicyLayout";
-export * from "./components/Layout/SimplePages/TermsOfService/TermsOfServiceLayout";
+export { InternalServerErrorLayout } from "./components/Layout/SimplePages/InternalServerError/InternalServerErrorLayout";
+export { NotFoundLayout } from "./components/Layout/SimplePages/NotFound/NotFoundLayout";
+export { PrivacyPolicyLayout } from "./components/Layout/SimplePages/PrivacyPolicy/PrivacyPolicyLayout";
+export { TermsOfServiceLayout } from "./components/Layout/SimplePages/TermsOfService/TermsOfServiceLayout";

--- a/packages/cyberstorm/src/svg/svg.tsx
+++ b/packages/cyberstorm/src/svg/svg.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export function ThunderstoreLogo() {
   return (
     <svg

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,6 +3067,13 @@
     pump "^3.0.0"
     tar-fs "^2.1.1"
 
+"@next/bundle-analyzer@^13.4.9":
+  version "13.4.9"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-13.4.9.tgz#06b8faf0a72f2f3b35815e644a8c9a560f90266a"
+  integrity sha512-T/nSgXmhAx8Wy2qPGr9P3AcLwlFCMbA7DuYNCm7BdF10Sk74S0bJ1b3ygq+306dBwKRWV5Lj80sYzWzZ5/rwgQ==
+  dependencies:
+    webpack-bundle-analyzer "4.7.0"
+
 "@next/env@13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.3.0.tgz#cc2e49f03060a4684ce7ec7fd617a21bc5b9edba"
@@ -3295,6 +3302,11 @@
     loader-utils "^2.0.4"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
 "@popperjs/core@^2.9.3":
   version "2.11.7"
@@ -5767,10 +5779,20 @@ acorn-walk@^7.1.1, acorn-walk@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.0.4:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.2"
@@ -7774,6 +7796,11 @@ downshift@^6.1.7:
     react-is "^17.0.2"
     tslib "^2.3.0"
 
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
+
 duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -9500,6 +9527,13 @@ gunzip-maybe@^1.4.2:
     peek-stream "^1.1.0"
     pumpify "^1.3.3"
     through2 "^2.0.3"
+
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
 
 handlebars@^4.7.7:
   version "4.7.7"
@@ -12382,6 +12416,11 @@ mri@^1.1.0, mri@^1.2.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -12852,6 +12891,11 @@ open@^9.1.0:
     define-lazy-prop "^3.0.0"
     is-inside-container "^1.0.0"
     is-wsl "^2.2.0"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -14564,6 +14608,15 @@ simple-update-notifier@^1.0.0:
   dependencies:
     semver "~7.0.0"
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -15500,6 +15553,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 tough-cookie@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
@@ -16232,6 +16290,21 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webpack-bundle-analyzer@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz#33c1c485a7fcae8627c547b5c3328b46de733c66"
+  integrity sha512-j9b8ynpJS4K+zfO5GGwsAcQX4ZHpWV+yRiHDiL+bE0XHJ8NiPYLTNVQdlFYWxtpg9lfAQNlwJg16J9AJtFSXRg==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
@@ -16447,7 +16520,7 @@ ws@^6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.4.6:
+ws@^7.3.1, ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
Improve the serverside rendering by moving `"use client"` declarations as high up in the element tree as possible (to the layer that actually uses client-only features).

There's still room for improvement by splitting larger files/components apart, allowing for a more precise client-only boundary to be set.

This PR also includes a few other fixes related to SSR and prod builds.