### PR TITLE
Actions: Disable auto-deploy workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,20 +95,21 @@ jobs:
       - name: Build @thunderstore/cyberstorm-nextjs
         run: yarn workspace @thunderstore/cyberstorm-nextjs build
 
-  deploy:
-    name: Trigger deploy
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-    strategy:
-      matrix:
-        app: [nextjs, sertra]
-    steps:
-      - name: Call deployment workflow
-        run: |
-          curl \
-            -X POST \
-            -u "${{ secrets.DEPLOY_WORKFLOW_DISPATCH_USER }}:${{ secrets.DEPLOY_WORKFLOW_DISPATCH_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            ${{ secrets.DEPLOY_WORKFLOW_DISPATCH_URL }} \
-            -d '{"ref": "master", "inputs": {"sourceOrg": "${{ github.repository_owner }}", "sourceRepo": "${{ github.event.repository.name }}", "appName": "${{ matrix.app }}", "environment": "dev"}}'
+#  TODO: Enable but as a separate job once needed
+#  deploy:
+#    name: Trigger deploy
+#    runs-on: ubuntu-latest
+#    needs: [test]
+#    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+#    strategy:
+#      matrix:
+#        app: [nextjs, sertra]
+#    steps:
+#      - name: Call deployment workflow
+#        run: |
+#          curl \
+#            -X POST \
+#            -u "${{ secrets.DEPLOY_WORKFLOW_DISPATCH_USER }}:${{ secrets.DEPLOY_WORKFLOW_DISPATCH_PAT }}" \
+#            -H "Accept: application/vnd.github.v3+json" \
+#            ${{ secrets.DEPLOY_WORKFLOW_DISPATCH_URL }} \
+#            -d '{"ref": "master", "inputs": {"sourceOrg": "${{ github.repository_owner }}", "sourceRepo": "${{ github.event.repository.name }}", "appName": "${{ matrix.app }}", "environment": "dev"}}'


### PR DESCRIPTION
Disable the auto-deply workflow trigger, as it's not actively used for anything but generates noise in error reports in the infra repo.