### PR TITLE
CS: Create a DummyDapper implementation

### DIFF
--- a/apps/cyberstorm-nextjs/dapper/client.tsx
+++ b/apps/cyberstorm-nextjs/dapper/client.tsx
@@ -1,11 +1,13 @@
 "use client";
 import React from "react";
 
-import { Dapper, DapperProvider } from "@thunderstore/dapper/src";
-import { API_DOMAIN } from "@/utils/constants";
+import { DapperProvider } from "@thunderstore/dapper/src";
+import { DummyDapper } from "@thunderstore/dapper/src/implementations/dummy/DummyDapper";
 
 export function ClientDapper(props: React.PropsWithChildren) {
-  const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
+  // import { API_DOMAIN } from "@/utils/constants";
+  // const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
+  const dapperConstructor = () => new DummyDapper();
   return (
     <DapperProvider dapperConstructor={dapperConstructor}>
       <>{props.children}</>

--- a/apps/cyberstorm-nextjs/dapper/server.tsx
+++ b/apps/cyberstorm-nextjs/dapper/server.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 
-import { Dapper, DapperProvider } from "@thunderstore/dapper/src";
-import { API_DOMAIN } from "@/utils/constants";
+import { DapperProvider } from "@thunderstore/dapper/src";
+import { DummyDapper } from "@thunderstore/dapper/src/implementations/dummy/DummyDapper";
+// import { API_DOMAIN } from "@/utils/constants";
 
 export function ServerDapper(props: React.PropsWithChildren) {
-  const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
+  // const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
+  const dapperConstructor = () => new DummyDapper();
   return (
     <DapperProvider dapperConstructor={dapperConstructor}>
       <>{props.children}</>

--- a/apps/cyberstorm-nextjs/package.json
+++ b/apps/cyberstorm-nextjs/package.json
@@ -23,6 +23,7 @@
     "next": "^13.4.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-promise-suspense": "^0.3.4",
     "typescript": "5.0.4"
   },
   "devDependencies": {

--- a/apps/cyberstorm-storybook/.storybook/preview.js
+++ b/apps/cyberstorm-storybook/.storybook/preview.js
@@ -4,9 +4,9 @@ import { ReactQueryDevtools } from "react-query/devtools";
 import { LinkLibrary } from "../LinkLibrary";
 import { LinkingProvider, CyberstormProviders } from "@thunderstore/cyberstorm";
 import "@thunderstore/cyberstorm-styles";
-import { Dapper, DapperProvider } from "@thunderstore/dapper/src";
-import { SessionProvider, useSession } from "../SessionContext";
-import { API_DOMAIN } from "../constants";
+import { DapperProvider } from "@thunderstore/dapper/src";
+import { SessionProvider } from "../SessionContext";
+import { DummyDapper } from "@thunderstore/dapper/src/implementations/dummy/DummyDapper";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -47,8 +47,7 @@ export const decorators = [
 ];
 
 function Substack({ children }) {
-  const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
-
+  const dapperConstructor = () => new DummyDapper();
   return (
     <DapperProvider dapperConstructor={dapperConstructor}>
       <LinkingProvider value={LinkLibrary}>{children}</LinkingProvider>

--- a/apps/nextjs/pages/c/[communityIdentifier]/p/[namespace]/[packageName]/index.tsx
+++ b/apps/nextjs/pages/c/[communityIdentifier]/p/[namespace]/[packageName]/index.tsx
@@ -85,7 +85,7 @@ const getServerSideProps_: GetServerSideProps = async (context) => {
   }
 
   const dapper = new Dapper(API_DOMAIN);
-  const props = await dapper.getPackage(
+  const props = await dapper.getOldPackage(
     communityIdentifier,
     namespace,
     packageName

--- a/packages/cyberstorm/package.json
+++ b/packages/cyberstorm/package.json
@@ -35,6 +35,7 @@
     "react": "^18.2.0",
     "react-data-table-component": "^7.5.3",
     "react-dom": "^18.2.0",
+    "react-promise-suspense": "^0.3.4",
     "styled-components": "^6.0.0-rc.5"
   },
   "devDependencies": {

--- a/packages/cyberstorm/src/components/Layout/BaseLayout/PageHeader/PageHeader.tsx
+++ b/packages/cyberstorm/src/components/Layout/BaseLayout/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@ import { Title } from "../../../Title/Title";
 export interface PageHeaderProps {
   image?: ReactElement;
   title: string;
-  description?: string;
+  description?: string | null;
   meta?: ReactElement[];
 }
 

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -5,11 +5,12 @@ import {
   PackageLink,
   UserLink,
 } from "../../Links/Links";
-import { getCommunityDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";
 import { Package } from "@thunderstore/dapper/src/schema";
 import { BaseLayout } from "../BaseLayout/BaseLayout";
 import PackageSearchLayout from "../PackageSearchLayout/PackageSearchLayout";
 import styles from "./PackageDependantsLayout.module.css";
+import { useDapper } from "@thunderstore/dapper";
+import usePromise from "react-promise-suspense";
 
 export interface PackageDependantsLayoutProps {
   isLoading?: boolean;
@@ -22,20 +23,22 @@ export interface PackageDependantsLayoutProps {
 export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
   const { packageData } = props;
 
-  const communityData = getCommunityData(packageData.community);
+  const dapper = useDapper();
+  const communityData = usePromise(dapper.getCommunity, [
+    packageData.community,
+  ]);
 
   return (
     <BaseLayout
       backGroundImageSource={
-        communityData.backgroundImageSource
-          ? communityData.backgroundImageSource
-          : "/images/community_bg.png"
+        communityData.community.background_image_url ||
+        "/images/community_bg.png"
       }
       breadCrumb={
         <BreadCrumbs>
           <CommunitiesLink>Communities</CommunitiesLink>
-          <CommunityLink community={communityData.name}>
-            {communityData.name}
+          <CommunityLink community={communityData.community.name}>
+            {communityData.community.name}
           </CommunityLink>
           <PackageLink
             community={packageData.community}
@@ -63,13 +66,11 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
           ) : null}
         </div>
       }
-      mainContent={<PackageSearchLayout communityId={communityData.name} />}
+      mainContent={
+        <PackageSearchLayout communityId={communityData.community.name} />
+      }
     />
   );
 }
 
 PackageDependantsLayout.displayName = "PackageDependantsLayout";
-
-function getCommunityData(communityId: string) {
-  return getCommunityDummyData(communityId);
-}

--- a/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageListLayout/PackageListLayout.tsx
@@ -1,7 +1,6 @@
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CommunitiesLink, CommunityLink } from "../../Links/Links";
-import { getCommunityDummyData } from "@thunderstore/dapper/src/implementations/dummy/generate";
 import { PackagePreview } from "@thunderstore/dapper/src/schema";
 import { BaseLayout } from "../BaseLayout/BaseLayout";
 import { MetaItem } from "../../MetaItem/MetaItem";
@@ -16,6 +15,8 @@ import { faDiscord } from "@fortawesome/free-brands-svg-icons";
 import { PageHeader } from "../BaseLayout/PageHeader/PageHeader";
 import { CommunityImage } from "../../CommunityImage/CommunityImage";
 import PackageSearchLayout from "../PackageSearchLayout/PackageSearchLayout";
+import { useDapper } from "@thunderstore/dapper";
+import usePromise from "react-promise-suspense";
 
 export interface PackageListLayoutProps {
   isLoading?: boolean;
@@ -29,54 +30,61 @@ export interface PackageListLayoutProps {
 export function PackageListLayout(props: PackageListLayoutProps) {
   const { communityId } = props;
 
-  const communityData = getCommunityData(communityId);
+  const dapper = useDapper();
+  const communityData = usePromise(dapper.getCommunity, [communityId]);
 
   return (
     <BaseLayout
       backGroundImageSource={
-        communityData.backgroundImageSource
-          ? communityData.backgroundImageSource
-          : "/images/community_bg.png"
+        communityData.community.background_image_url ||
+        "/images/community_bg.png"
       }
       breadCrumb={
         <BreadCrumbs>
           <CommunitiesLink>Communities</CommunitiesLink>
-          <CommunityLink community={communityData.name}>
-            {communityData.name}
+          <CommunityLink community={communityData.community.name}>
+            {communityData.community.name}
           </CommunityLink>
         </BreadCrumbs>
       }
       header={
         <PageHeader
-          title={communityData.name}
-          description={communityData.description}
+          title={communityData.community.name}
+          description={communityData.community.description}
           image={
             <CommunityImage
               src={
-                communityData.imageSource
-                  ? communityData.imageSource
-                  : "/images/game.png"
+                communityData.community.portrait_image_url || "/images/game.png"
               }
             />
           }
           meta={[
             <MetaItem
               key="meta-packages"
-              label={formatInteger(communityData.packageCount) + " Packages"}
+              label={
+                formatInteger(communityData.community.total_package_count) +
+                " Packages"
+              }
               icon={<FontAwesomeIcon icon={faBoxOpen} fixedWidth />}
               colorScheme="accent"
               size="bold_large"
             />,
             <MetaItem
               key="meta-downloads"
-              label={formatInteger(communityData.downloadCount) + " Downloads"}
+              label={
+                formatInteger(communityData.community.total_download_count) +
+                " Downloads"
+              }
               icon={<FontAwesomeIcon icon={faDownload} fixedWidth />}
               colorScheme="accent"
               size="bold_large"
             />,
             <MetaItem
               key="meta-servers"
-              label={formatInteger(communityData.serverCount) + " Servers"}
+              label={
+                formatInteger(communityData.community.total_server_count) +
+                " Servers"
+              }
               icon={<FontAwesomeIcon icon={faServer} fixedWidth />}
               colorScheme="accent"
               size="bold_large"
@@ -97,7 +105,3 @@ export function PackageListLayout(props: PackageListLayoutProps) {
 }
 
 PackageListLayout.displayName = "PackageListLayout";
-
-function getCommunityData(communityId: string) {
-  return getCommunityDummyData(communityId);
-}

--- a/packages/dapper/src/cyberstormMethods/community.ts
+++ b/packages/dapper/src/cyberstormMethods/community.ts
@@ -23,7 +23,7 @@ interface CommunityData {
 }
 
 // Dapper method type, defining the parameters required to fetch the data.
-export type GetCommunity = (identifier: string) => CommunityData;
+export type GetCommunity = (identifier: string) => Promise<CommunityData>;
 
 // Method for transforming the received data to a format that will be
 // passed on.
@@ -33,22 +33,15 @@ const transform = (viewData: z.infer<typeof schema>): CommunityData => ({
 });
 
 // Method implementation for Dapper class.
-export const getCommunity: GetCommunity = function (this: Dapper, identifier) {
+export const getCommunity: GetCommunity = async function (
+  this: Dapper,
+  identifier
+) {
   // TODO: CHANGE THIS TO USE THE ACTUAL THUNDERSTORE API, ONCE THE API ENDPOINTS HAS BEEN IMPLEMENTED
   const dummyCommunity = getCommunityDummyData(identifier);
   const dummyServers = getListOfIds(20).map((packageId) => {
     return getServerPreviewDummyData(packageId);
   });
 
-  const dapperCommunity: Community = {
-    name: dummyCommunity.name,
-    identifier: dummyCommunity.namespace,
-    total_package_count: dummyCommunity.packageCount,
-    total_download_count: dummyCommunity.downloadCount,
-    background_image_url: dummyCommunity.backgroundImageSource,
-    description: dummyCommunity.description,
-    discord_url: dummyCommunity.discordLink,
-  };
-
-  return transform({ community: dapperCommunity, servers: dummyServers });
+  return transform({ community: dummyCommunity, servers: dummyServers });
 };

--- a/packages/dapper/src/cyberstormMethods/packageListings.ts
+++ b/packages/dapper/src/cyberstormMethods/packageListings.ts
@@ -187,5 +187,6 @@ export const getPackageListings: GetPackageListings = async function (
     { key: "page_size", value: undefined, impotent: 20 },
   ];
 
-  return await this.dummyAndProcess(dummyEndpoint, queryParams, transform);
+  const cleanedData = await dummyEndpoint(queryParams);
+  return transform(cleanedData);
 };

--- a/packages/dapper/src/cyberstormSchemas/community.ts
+++ b/packages/dapper/src/cyberstormSchemas/community.ts
@@ -24,7 +24,9 @@ export type Community = {
 
   total_download_count: number;
   total_package_count: number;
+  total_server_count: number;
   background_image_url?: string | null;
+  portrait_image_url?: string | null;
 
   description?: string | null;
   discord_url?: string | null;
@@ -38,7 +40,9 @@ export const communitySchema = z.object({
 
   total_download_count: z.number().int(),
   total_package_count: z.number().int(),
+  total_server_count: z.number().int(),
   background_image_url: z.string().nullish(),
+  portrait_image_url: z.string().nullish(),
 
   description: z.string().nullish(),
   discord_url: z.string().nullish(),

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -104,16 +104,6 @@ export class Dapper implements DapperInterface {
     return transform(cleanedData);
   }
 
-  protected async dummyAndProcess<Schema extends z.ZodTypeAny, ReturnType>(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dummyFunc: (props: any) => ReturnType,
-    queryParams: QsArray,
-    transform: (cleanedData: z.infer<Schema>) => z.infer<Schema>
-  ): Promise<ReturnType> {
-    const cleanedData = await dummyFunc(queryParams);
-    return transform(cleanedData);
-  }
-
   /**
    * Methods implementing the DapperInterface.
    */

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -1,16 +1,10 @@
 import { z } from "zod";
-import {
-  GetCommunities,
-  getCommunities,
-} from "./cyberstormMethods/communities";
-import { GetCommunity, getCommunity } from "./cyberstormMethods/community";
-import { GetPackage, getPackage } from "./cyberstormMethods/package";
-import {
-  getPackageListings,
-  GetPackageListings,
-} from "./cyberstormMethods/packageListings";
-import { getTeam, GetTeam } from "./cyberstormMethods/team";
-import { GetUser, getUser } from "./cyberstormMethods/user";
+import { GetCommunities } from "./cyberstormMethods/communities";
+import { GetCommunity } from "./cyberstormMethods/community";
+import { GetPackage } from "./cyberstormMethods/package";
+import { GetPackageListings } from "./cyberstormMethods/packageListings";
+import { GetTeam } from "./cyberstormMethods/team";
+import { GetUser } from "./cyberstormMethods/user";
 
 import { DapperError } from "./errors";
 import {
@@ -34,6 +28,10 @@ export interface DapperInterface {
   getFrontpage: GetFrontpage;
   getOldPackage: GetOldPackage;
 }
+
+const NotImplemented = () => {
+  throw new Error("Not implemented");
+};
 
 export class Dapper implements DapperInterface {
   readonly apiDomain: string;
@@ -104,16 +102,16 @@ export class Dapper implements DapperInterface {
     return transform(cleanedData);
   }
 
-  /**
-   * Methods implementing the DapperInterface.
-   */
-  getPackageListings = getPackageListings;
-  getCommunities = getCommunities;
-  getCommunity = getCommunity;
-  getPackage = getPackage;
-  getTeam = getTeam;
-  getUser = getUser;
+  // Legacy
   getOldCommunityPackageListing = getOldCommunityPackageListing;
   getFrontpage = getFrontpage;
   getOldPackage = getOldPackage;
+
+  // Cyberstorm
+  getPackageListings = NotImplemented;
+  getCommunities = NotImplemented;
+  getCommunity = NotImplemented;
+  getPackage = NotImplemented;
+  getTeam = NotImplemented;
+  getUser = NotImplemented;
 }

--- a/packages/dapper/src/implementations/dummy/DummyDapper.ts
+++ b/packages/dapper/src/implementations/dummy/DummyDapper.ts
@@ -1,0 +1,33 @@
+import { DapperInterface } from "../../dapper";
+import { getCommunityDummyData } from "./generate";
+import { getPackageListings } from "../../cyberstormMethods/packageListings";
+import { getPackage } from "../../cyberstormMethods/package";
+import { getTeam } from "../../cyberstormMethods/team";
+import { getUser } from "../../cyberstormMethods/user";
+
+const NotImplemented = () => {
+  throw new Error("Not implemented");
+};
+
+export class DummyDapper implements DapperInterface {
+  public getPackageListings = getPackageListings;
+
+  public getCommunities = NotImplemented;
+
+  public getCommunity = async (communityId: string) => {
+    return {
+      community: getCommunityDummyData(communityId),
+      servers: [],
+    };
+  };
+
+  public getPackage = getPackage;
+
+  public getTeam = getTeam;
+
+  public getUser = getUser;
+
+  public getFrontpage = NotImplemented;
+  public getOldPackage = NotImplemented;
+  public getOldCommunityPackageListing = NotImplemented;
+}

--- a/packages/dapper/src/implementations/dummy/generate.ts
+++ b/packages/dapper/src/implementations/dummy/generate.ts
@@ -21,7 +21,7 @@ import {
 } from "../../schema";
 import { Community } from "../../cyberstormSchemas/community";
 
-export const strToHashInt = function (inputString: string) {
+const strToHashInt = function (inputString: string) {
   return inputString
     ? inputString.split("").reduce(function (a, b) {
         a = (a << 5) - a + b.charCodeAt(0);
@@ -30,7 +30,7 @@ export const strToHashInt = function (inputString: string) {
     : 0;
 };
 
-export function getRandomCategories(returnAmount?: number): Category[] {
+function getRandomCategories(returnAmount?: number): Category[] {
   const categories = [
     { name: "Mods", slug: "mods" },
     { name: "Tools", slug: "tools" },

--- a/packages/dapper/src/implementations/dummy/generate.ts
+++ b/packages/dapper/src/implementations/dummy/generate.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import {
   Category,
-  Community,
   CommunityPreview,
   Connection,
   Package,
@@ -20,6 +19,7 @@ import {
   UserSettings,
   UserSubscription,
 } from "../../schema";
+import { Community } from "../../cyberstormSchemas/community";
 
 export const strToHashInt = function (inputString: string) {
   return inputString
@@ -81,17 +81,22 @@ export function getCommunityDummyData(seed?: string): Community {
   faker.seed(parsedSeed);
   return {
     name: faker.word.words(3),
-    namespace: "namespace",
-    downloadCount: faker.number.int({ min: 1000000, max: 10000000 }),
-    packageCount: faker.number.int({ min: 0, max: 100000 }),
-    serverCount: faker.number.int({ min: 0, max: 1000 }),
-    imageSource: faker.image.urlLoremFlickr({
+    identifier: faker.word.sample(),
+    total_download_count: faker.number.int({ min: 1000000, max: 10000000 }),
+    total_package_count: faker.number.int({ min: 0, max: 100000 }),
+    total_server_count: faker.number.int({ min: 0, max: 100000 }),
+    background_image_url: faker.image.urlLoremFlickr({
+      width: 1920,
+      height: 1080,
+      category: "abstract",
+    }),
+    portrait_image_url: faker.image.urlLoremFlickr({
       width: 142,
       height: 188,
       category: "abstract",
     }),
     description: faker.lorem.paragraphs(3),
-    discordLink: faker.internet.url(),
+    discord_url: faker.internet.url(),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13950,6 +13950,13 @@ react-markdown@^7.1.0:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
+react-promise-suspense@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz#05d19a75703d71374674840056cfef2fcd38809d"
+  integrity sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+
 react-query@^3.34.0:
   version "3.39.3"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"


### PR DESCRIPTION
Create a DummyDapper Dapper implementation and configure it for the cyberstorm-storybook and cyberstorm-nextjs. This is done to better separate the dummy code from the future production code, as opposed to mixing the two together.