### PR TITLE
@thunderstore/cyberstorm: fix SSR for CopyButton

### DIFF
--- a/packages/cyberstorm/src/components/CopyButton/CopyButton.tsx
+++ b/packages/cyberstorm/src/components/CopyButton/CopyButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClone, faCheck } from "@fortawesome/pro-regular-svg-icons";
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import styles from "./CopyButton.module.css";
 import { Tooltip } from "../Tooltip/Tooltip";
 import { Button } from "../Button/Button";
@@ -50,49 +50,45 @@ export function CopyButton(props: CopyButtonProps) {
     paddingSize = "none",
     colorScheme = "transparentDefault",
   } = props;
-  if (!navigator?.clipboard) {
-    console.warn("Clipboard not supported");
-    return null;
-  }
 
+  const [isSupported, setIsSupported] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
   const [wasRecentlyCopied, setWasRecentlyCopied] = useState(false);
-  const [tooltipOpen, setTooltipOpen] = useState(false);
 
-  const icon = wasRecentlyCopied ? (
-    <FontAwesomeIcon fixedWidth icon={faCheck} className={styles.checkmark} />
-  ) : (
-    <FontAwesomeIcon fixedWidth icon={faClone} className={styles.copy} />
-  );
+  useEffect(() => {
+    setIsSupported(
+      typeof window !== "undefined" &&
+        typeof navigator?.clipboard !== "undefined"
+    );
+  }, [setIsSupported]);
 
-  const button = (
-    <Button
-      paddingSize={paddingSize}
-      fontSize="small"
-      colorScheme={colorScheme}
-      onClick={() => {
-        useCopyToClipboard(text, setWasRecentlyCopied);
-      }}
-      onMouseOver={() => {
-        setTooltipOpen(true);
-      }}
-      onMouseOut={() => {
-        setTooltipOpen(false);
-      }}
-      leftIcon={icon}
-    />
-  );
-
-  return (
+  return isSupported ? (
     <TooltipProvider>
       <Tooltip
         content={wasRecentlyCopied ? "Copied!" : "Copy"}
-        open={tooltipOpen}
+        open={isTooltipOpen}
         side="bottom"
       >
-        <div className={styles.root}>{button}</div>
+        <div className={styles.root}>
+          <Button
+            paddingSize={paddingSize}
+            fontSize="small"
+            colorScheme={colorScheme}
+            onClick={() => useCopyToClipboard(text, setWasRecentlyCopied)}
+            onMouseOver={() => setIsTooltipOpen(true)}
+            onMouseOut={() => setIsTooltipOpen(false)}
+            leftIcon={
+              <FontAwesomeIcon
+                fixedWidth
+                icon={wasRecentlyCopied ? faCheck : faClone}
+                className={wasRecentlyCopied ? styles.checkmark : styles.copy}
+              />
+            }
+          />
+        </div>
       </Tooltip>
     </TooltipProvider>
-  );
+  ) : null;
 }
 
 CopyButton.displayName = "CopyButton";


### PR DESCRIPTION
Navigator is not defined on server side, so any checks on its existence needs to be done within a useEffect hook to trigger it only on client side.

Refs TS-1778