### PR TITLE
Disable unnecessary chromatic pushes

### DIFF
--- a/.github/workflows/storybook-chromatic.yml
+++ b/.github/workflows/storybook-chromatic.yml
@@ -1,6 +1,10 @@
 # Workflow for detecting visual changes in Storybook components.
 name: 'Chromatic'
-on: push
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
Disable chromatic snapshot builds for pushes that don't affect PRs