### PR TITLE
Add actual page count figuring to pkg list

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageListings/PackageListings.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageListings/PackageListings.tsx
@@ -79,6 +79,8 @@ export default function PackageListings(props: PackageListingsProps) {
     if (!isEqual(updatedAvailableCategories, filters.availableCategories)) {
       filters.setAvailableCategories(updatedAvailableCategories);
     }
+
+    filters.setPageObjectCount(datas.length);
   }, [
     datas,
     filters?.availableCategories,

--- a/packages/cyberstorm/src/components/Layout/PackageSearchLayout/PackageSearchLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageSearchLayout/PackageSearchLayout.tsx
@@ -47,11 +47,17 @@ export class Filters {
   setKeywords: React.Dispatch<React.SetStateAction<string[]>>;
   availableCategories: CategoriesProps;
   setAvailableCategories: React.Dispatch<React.SetStateAction<CategoriesProps>>;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  pageObjectCount: number;
+  setPageObjectCount: React.Dispatch<React.SetStateAction<number>>;
 
   constructor() {
     [this.keywords, this.setKeywords] = useState<string[]>([]);
     [this.availableCategories, this.setAvailableCategories] =
       useState<CategoriesProps>({});
+    [this.page, this.setPage] = useState<number>(1);
+    [this.pageObjectCount, this.setPageObjectCount] = useState<number>(1);
   }
 }
 
@@ -131,7 +137,6 @@ export default function PackageSearchLayout(props: PackageSearchLayoutProps) {
 
   const filters = new Filters();
   const [order, setOrder] = useState("1");
-  const [page, setPage] = useState(1);
   const [searchValue, setSearchValue] = useState("");
 
   const handleSearchFilterEdit = (e: string) =>
@@ -216,13 +221,12 @@ export default function PackageSearchLayout(props: PackageSearchLayoutProps) {
               />
             </Suspense>
           </FiltersProvider>
-          {/* TODO: use real totalCount */}
           <Pagination
-            currentPage={page}
-            onPageChange={setPage}
+            currentPage={filters.page}
+            onPageChange={filters.setPage}
             pageSize={20}
             siblingCount={2}
-            totalCount={327}
+            totalCount={filters.pageObjectCount}
           />
         </div>
       </div>


### PR DESCRIPTION
Add current page number and total object count to filters in PackageSearchLayout, so that they can be used to figure out how many pages there should be and what page is currently active PageSize and totalCount are still not configurable, but probably should. Implementation of all the configurable stuff needs to be unified

refs TS-1781