### PR TITLE
@thunderstore/dapper-ts: handle passing down the config

### DIFF
--- a/apps/cyberstorm-nextjs/dapper/client.tsx
+++ b/apps/cyberstorm-nextjs/dapper/client.tsx
@@ -4,10 +4,13 @@ import React from "react";
 import { DapperProvider } from "@thunderstore/dapper";
 import { DapperTs } from "@thunderstore/dapper-ts";
 
+import { API_DOMAIN } from "@/utils/constants";
+import { getCookie } from "@/utils/cookie";
+
 export function ClientDapper(props: React.PropsWithChildren) {
-  // import { API_DOMAIN } from "@/utils/constants";
-  // const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
-  const dapperConstructor = () => new DapperTs();
+  const config = { apiHost: API_DOMAIN, sessionId: getCookie("sessionid") };
+  const dapperConstructor = () => new DapperTs(config);
+
   return (
     <DapperProvider dapperConstructor={dapperConstructor}>
       {props.children}

--- a/apps/cyberstorm-nextjs/dapper/server.tsx
+++ b/apps/cyberstorm-nextjs/dapper/server.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import { DapperProvider } from "@thunderstore/dapper";
 import { DapperTs } from "@thunderstore/dapper-ts";
 
+import { API_DOMAIN } from "@/utils/constants";
+
 export function ServerDapper(props: React.PropsWithChildren) {
-  // const dapperConstructor = () => new Dapper(API_DOMAIN, undefined);
-  const dapperConstructor = () => new DapperTs();
+  const dapperConstructor = () => new DapperTs({ apiHost: API_DOMAIN });
+
   return (
     <DapperProvider dapperConstructor={dapperConstructor}>
       {props.children}

--- a/apps/cyberstorm-nextjs/utils/cookie.ts
+++ b/apps/cyberstorm-nextjs/utils/cookie.ts
@@ -1,0 +1,13 @@
+// This only works on client side components. For server side stuff
+// see https://nextjs.org/docs/app/api-reference/functions/cookies
+export const getCookie = (name: string) => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  const allCookies = new URLSearchParams(
+    window.document.cookie.replaceAll("&", "%26").replaceAll("; ", "&")
+  );
+  const cookie = allCookies.get(name);
+  return cookie === null ? undefined : cookie;
+};

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -1,4 +1,5 @@
 import { DapperInterface } from "@thunderstore/dapper";
+import { RequestConfig } from "@thunderstore/thunderstore-api";
 
 import { getCommunities } from "./methods/communities";
 
@@ -11,8 +12,20 @@ const NotImplemented: any = async () => {
   return [];
 };
 
-export class DapperTs implements DapperInterface {
+export interface DapperTsInterface extends DapperInterface {
+  config: RequestConfig;
+}
+
+export class DapperTs implements DapperTsInterface {
+  config: RequestConfig;
+
+  constructor(config: RequestConfig) {
+    this.config = config;
+    this.getCommunities = this.getCommunities.bind(this);
+  }
+
   public getCommunities = getCommunities;
+
   public getCommunity = NotImplemented;
   public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;

--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -1,12 +1,17 @@
+import { DapperTsInterface } from "../index";
+
 // TODO: this is a dummy implementation required to prevent cyberstorm
 // build from breaking.
-export const getCommunities = async (
+export async function getCommunities(
+  this: DapperTsInterface,
   page = 1,
   pageSize = 100,
   ordering = "name",
   search?: string
-) => ({
-  count: page * pageSize,
-  hasMore: ordering === search,
-  results: [],
-});
+) {
+  return {
+    count: page * pageSize,
+    hasMore: ordering === search,
+    results: [],
+  };
+}

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -1,8 +1,6 @@
 import * as methods from "./types/methods";
 
 export interface DapperInterface {
-  sessionId?: string;
-
   getCommunities: methods.GetCommunities;
   getCommunity: methods.GetCommunity;
   getPackage: methods.GetPackage;

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -7,6 +7,11 @@
  * - Handling errors
  */
 
+export interface RequestConfig {
+  apiHost: string;
+  sessionId?: string;
+}
+
 async function apiFetch(path: string) {
   const response = await fetch(path);
   return await response.json();


### PR DESCRIPTION
- RequestConfig defines information needed to request the content from the Thunderstore API. It's defined in the app and needs to be passed through the Dapper implementation all the way to to the package that handles the actual fetching
- @thunderstore/cyberstorm-nextjs uses DapperTs in the dapper providers
- @thunderstore/dapper remains unaware of the config being passed to DapperTs, so this doesn't affect e.g. DapperFake in any way
- @thunderstore/dapper-ts defines and implements an interface that augments the default Dapper interface by receiving the request config and storing it internally, to be eventually passed to thunderstore-api package
- @thunderstore/thunderstore-api defines the interface for the config so @thunderstore/dapper-ts depends on it but not the other way around

Refs TS-1815