### PR TITLE
@thunderstore/dapper: add getCommunityFilters

### DIFF
--- a/apps/cyberstorm-storybook/stories/layouts/PackageListLayout.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/layouts/PackageListLayout.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 } as Meta<typeof CommunityProfileLayout>;
 
 const Template: StoryFn<typeof CommunityProfileLayout> = () => (
-  <CommunityProfileLayout communityId="community" />
+  <CommunityProfileLayout communityId="riskofrain2" />
 );
 const CommunityProfile = Template.bind({});
 

--- a/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
@@ -89,10 +89,7 @@ export function CommunityProfileLayout(props: Props) {
         />
       }
       mainContent={
-        <PackageSearch
-          communityId={communityId}
-          packageCategories={community.package_categories}
-        />
+        <PackageSearch communityId={communityId} packageCategories={[]} />
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
@@ -27,6 +27,7 @@ export function CommunityProfileLayout(props: Props) {
 
   const dapper = useDapper();
   const community = usePromise(dapper.getCommunity, [communityId]);
+  const filters = usePromise(dapper.getCommunityFilters, [communityId]);
 
   return (
     <BaseLayout
@@ -89,7 +90,10 @@ export function CommunityProfileLayout(props: Props) {
         />
       }
       mainContent={
-        <PackageSearch communityId={communityId} packageCategories={[]} />
+        <PackageSearch
+          communityId={communityId}
+          packageCategories={filters.package_categories}
+        />
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -72,10 +72,7 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
         </div>
       }
       mainContent={
-        <PackageSearch
-          communityId={pkg.community}
-          packageCategories={community.package_categories}
-        />
+        <PackageSearch communityId={pkg.community} packageCategories={[]} />
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -31,6 +31,7 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
 
   const dapper = useDapper();
   const community = usePromise(dapper.getCommunity, [pkg.community]);
+  const filters = usePromise(dapper.getCommunityFilters, [pkg.community]);
 
   return (
     <BaseLayout
@@ -72,7 +73,10 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
         </div>
       }
       mainContent={
-        <PackageSearch communityId={pkg.community} packageCategories={[]} />
+        <PackageSearch
+          communityId={pkg.community}
+          packageCategories={filters.package_categories}
+        />
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
@@ -1,3 +1,6 @@
+import { useDapper } from "@thunderstore/dapper";
+import { usePromise } from "@thunderstore/use-promise";
+
 import styles from "./TeamProfileLayout.module.css";
 import { BaseLayout } from "../BaseLayout/BaseLayout";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
@@ -19,11 +22,13 @@ interface Props {
  * community. The naming should be rethinked when the actual profile
  * page is implemented.
  *
- * TODO: use Dapper to fetch package categories.
  * TODO: use Dapper to fetch community's name and use it in CommunityLink.
  */
 export function TeamProfileLayout(props: Props) {
   const { community, namespace } = props;
+
+  const dapper = useDapper();
+  const filters = usePromise(dapper.getCommunityFilters, [community]);
 
   return (
     <BaseLayout
@@ -43,7 +48,12 @@ export function TeamProfileLayout(props: Props) {
           </TeamLink>
         </div>
       }
-      mainContent={<PackageSearch teamId={namespace} packageCategories={[]} />}
+      mainContent={
+        <PackageSearch
+          teamId={namespace}
+          packageCategories={filters.package_categories}
+        />
+      }
     />
   );
 }

--- a/packages/dapper-fake/src/fakers/community.ts
+++ b/packages/dapper-fake/src/fakers/community.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { GetCommunities } from "@thunderstore/dapper/types";
 
-import { getFakeImg, getFakePackageCategories, getIds, setSeed } from "./utils";
+import { getFakeImg, getIds, setSeed } from "./utils";
 
-const getFakeCommunity = async (communityId: string) => {
+export const getFakeCommunity = async (communityId: string) => {
   setSeed(communityId);
 
   return {
@@ -20,16 +20,6 @@ const getFakeCommunity = async (communityId: string) => {
       null,
     total_download_count: faker.number.int({ min: 1000000, max: 10000000 }),
     total_package_count: faker.number.int({ min: 0, max: 100000 }),
-  };
-};
-
-export const getFakeCommunityDetails = async (communityId: string) => {
-  setSeed(communityId);
-  const community = await getFakeCommunity(communityId);
-
-  return {
-    ...community,
-    package_categories: getFakePackageCategories(11),
   };
 };
 

--- a/packages/dapper-fake/src/fakers/community.ts
+++ b/packages/dapper-fake/src/fakers/community.ts
@@ -1,7 +1,13 @@
 import { faker } from "@faker-js/faker";
 import { GetCommunities } from "@thunderstore/dapper/types";
 
-import { getFakeImg, getIds, setSeed } from "./utils";
+import {
+  getFakeImg,
+  getFakePackageCategories,
+  getFakeSections,
+  getIds,
+  setSeed,
+} from "./utils";
 
 export const getFakeCommunity = async (communityId: string) => {
   setSeed(communityId);
@@ -66,5 +72,14 @@ export const getFakeCommunities: GetCommunities = async (
     count,
     hasMore: page > fullPages + 1,
     results: pageCommunities,
+  };
+};
+
+export const getFakeCommunityFilters = async (communityId: string) => {
+  setSeed(communityId);
+
+  return {
+    package_categories: getFakePackageCategories(11),
+    sections: getFakeSections(6),
   };
 };

--- a/packages/dapper-fake/src/fakers/utils.ts
+++ b/packages/dapper-fake/src/fakers/utils.ts
@@ -29,6 +29,22 @@ export const getFakePackageCategories = (returnAmount?: number) => {
   });
 };
 
+export const getFakeSections = (returnAmount?: number) => {
+  const categories = [
+    { name: "Mods", slug: "mods", priority: 0 },
+    { name: "Modpacks", slug: "modpacks", priority: 1 },
+    { name: "Maps", slug: "maps", priority: 2 },
+    { name: "Custom cards", slug: "cards", priority: 3 },
+    { name: "Latest update", slug: "update", priority: 4 },
+    { name: "Paid DLC", slug: "dlc", priority: 5 },
+  ];
+
+  return faker.helpers.arrayElements(categories, {
+    min: faker.helpers.maybe(() => 2) ?? 0, // Don't return just 1 section.
+    max: returnAmount ?? 2,
+  });
+};
+
 export const getIds = (count: number, seed?: string) => {
   setSeed(seed);
 

--- a/packages/dapper-fake/src/index.ts
+++ b/packages/dapper-fake/src/index.ts
@@ -1,6 +1,10 @@
 import { DapperInterface } from "@thunderstore/dapper";
 
-import { getFakeCommunities, getFakeCommunity } from "./fakers/community";
+import {
+  getFakeCommunities,
+  getFakeCommunity,
+  getFakeCommunityFilters,
+} from "./fakers/community";
 import {
   getFakeDependencies,
   getFakePackage,
@@ -13,6 +17,7 @@ import { getFakeCurrentUser } from "./fakers/user";
 export class DapperFake implements DapperInterface {
   public getCommunities = getFakeCommunities;
   public getCommunity = getFakeCommunity;
+  public getCommunityFilters = getFakeCommunityFilters;
   public getCurrentUser = getFakeCurrentUser;
   public getPackage = getFakePackage;
   public getPackageDependencies = getFakeDependencies;

--- a/packages/dapper-fake/src/index.ts
+++ b/packages/dapper-fake/src/index.ts
@@ -1,9 +1,6 @@
 import { DapperInterface } from "@thunderstore/dapper";
 
-import {
-  getFakeCommunities,
-  getFakeCommunityDetails,
-} from "./fakers/community";
+import { getFakeCommunities, getFakeCommunity } from "./fakers/community";
 import {
   getFakeDependencies,
   getFakePackage,
@@ -15,7 +12,7 @@ import { getFakeCurrentUser } from "./fakers/user";
 
 export class DapperFake implements DapperInterface {
   public getCommunities = getFakeCommunities;
-  public getCommunity = getFakeCommunityDetails;
+  public getCommunity = getFakeCommunity;
   public getCurrentUser = getFakeCurrentUser;
   public getPackage = getFakePackage;
   public getPackageDependencies = getFakeDependencies;

--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -14,6 +14,12 @@ it("executes getCommunity without errors", async () => {
   await expect(dapper.getCommunity("riskofrain2")).resolves.not.toThrowError();
 });
 
+it("executes getCommunityFilters without errors", async () => {
+  await expect(
+    dapper.getCommunityFilters("riskofrain2")
+  ).resolves.not.toThrowError();
+});
+
 // TODO: this should be tested/mocked with sessionId too.
 it("executes getCurrentUser without errors", async () => {
   await expect(dapper.getCurrentUser()).resolves.not.toThrowError();

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -2,6 +2,7 @@ import { DapperInterface } from "@thunderstore/dapper";
 import { RequestConfig } from "@thunderstore/thunderstore-api";
 
 import { getCommunities, getCommunity } from "./methods/communities";
+import { getCommunityFilters } from "./methods/communityFilters";
 import { getCurrentUser } from "./methods/currentUser";
 import {
   getTeamDetails,
@@ -29,6 +30,7 @@ export class DapperTs implements DapperTsInterface {
     this.config = config;
     this.getCommunities = this.getCommunities.bind(this);
     this.getCommunity = this.getCommunity.bind(this);
+    this.getCommunityFilters = this.getCommunityFilters.bind(this);
     this.getCurrentUser = this.getCurrentUser.bind(this);
     this.getTeamDetails = this.getTeamDetails.bind(this);
     this.getTeamMembers = this.getTeamMembers.bind(this);
@@ -37,12 +39,12 @@ export class DapperTs implements DapperTsInterface {
 
   public getCommunities = getCommunities;
   public getCommunity = getCommunity;
+  public getCommunityFilters = getCommunityFilters;
   public getCurrentUser = getCurrentUser;
   public getTeamDetails = getTeamDetails;
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
 
-  public getCommunityFilters = NotImplemented;
   public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;
   public getPackageListings = NotImplemented;

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -42,6 +42,7 @@ export class DapperTs implements DapperTsInterface {
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
 
+  public getCommunityFilters = NotImplemented;
   public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;
   public getPackageListings = NotImplemented;

--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -5,7 +5,7 @@ import {
 } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
-import { PackageCategory, paginatedResults } from "../sharedSchemas";
+import { paginatedResults } from "../sharedSchemas";
 
 const communitySchema = z.object({
   name: z.string().nonempty(),
@@ -42,16 +42,12 @@ export async function getCommunities(
   };
 }
 
-const communityDetailsSchema = communitySchema.extend({
-  package_categories: PackageCategory.array(),
-});
-
 export async function getCommunity(
   this: DapperTsInterface,
   communityId: string
 ) {
   const data = await fetchCommunity(this.config, communityId);
-  const parsed = communityDetailsSchema.safeParse(data);
+  const parsed = communitySchema.safeParse(data);
 
   if (!parsed.success) {
     // TODO: add Sentry support and log parsed.error.

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { fetchCommunityFilters } from "@thunderstore/thunderstore-api";
+
+import { DapperTsInterface } from "../index";
+
+const PackageCategory = z.object({
+  name: z.string().nonempty(),
+  slug: z.string().nonempty(),
+});
+
+const Section = z.object({
+  name: z.string().nonempty(),
+  slug: z.string().nonempty(),
+  priority: z.number().int(),
+});
+
+const schema = z.object({
+  package_categories: PackageCategory.array(),
+  sections: Section.array(),
+});
+
+export async function getCommunityFilters(
+  this: DapperTsInterface,
+  communityId: string
+) {
+  const data = await fetchCommunityFilters(this.config, communityId);
+  const parsed = schema.safeParse(data);
+
+  if (!parsed.success) {
+    // TODO: add Sentry support and log parsed.error.
+    throw new Error("Invalid data received from backend");
+  }
+
+  return parsed.data;
+}

--- a/packages/dapper-ts/src/sharedSchemas.ts
+++ b/packages/dapper-ts/src/sharedSchemas.ts
@@ -7,8 +7,3 @@ export const paginatedResults = <T extends z.ZodTypeAny>(resultType: T) =>
     previous: z.string().url().nullable(),
     results: z.array(resultType),
   });
-
-export const PackageCategory = z.object({
-  name: z.string().nonempty(),
-  slug: z.string().nonempty(),
-});

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -3,6 +3,7 @@ import * as methods from "./types/methods";
 export interface DapperInterface {
   getCommunities: methods.GetCommunities;
   getCommunity: methods.GetCommunity;
+  getCommunityFilters: methods.GetCommunityFilters;
   getCurrentUser: methods.GetCurrentUser;
   getPackage: methods.GetPackage;
   getPackageDependencies: methods.GetPackageDependencies;

--- a/packages/dapper/src/types/community.ts
+++ b/packages/dapper/src/types/community.ts
@@ -1,6 +1,6 @@
-import { PaginatedList } from "./shared";
+import { PackageCategory, PaginatedList } from "./shared";
 
-export type Community = {
+export interface Community {
   name: string;
   identifier: string;
   description: string | null;
@@ -10,6 +10,17 @@ export type Community = {
   icon_url: string | null;
   total_download_count: number;
   total_package_count: number;
-};
+}
 
 export type Communities = PaginatedList<Community>;
+
+export interface Section {
+  name: string;
+  slug: string;
+  priority: number;
+}
+
+export interface CommunityFilters {
+  package_categories: PackageCategory[];
+  sections: Section[];
+}

--- a/packages/dapper/src/types/community.ts
+++ b/packages/dapper/src/types/community.ts
@@ -1,4 +1,4 @@
-import { PackageCategory, PaginatedList } from "./shared";
+import { PaginatedList } from "./shared";
 
 export type Community = {
   name: string;
@@ -10,10 +10,6 @@ export type Community = {
   icon_url: string | null;
   total_download_count: number;
   total_package_count: number;
-};
-
-export type CommunityDetails = Community & {
-  package_categories: PackageCategory[];
 };
 
 export type Communities = PaginatedList<Community>;

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,4 +1,4 @@
-import { Communities, Community } from "./community";
+import { Communities, Community, CommunityFilters } from "./community";
 import { Package, PackageDependency, PackagePreview } from "./package";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
@@ -10,6 +10,10 @@ export type GetCommunities = (
 ) => Promise<Communities>;
 
 export type GetCommunity = (communityId: string) => Promise<Community>;
+
+export type GetCommunityFilters = (
+  communityId: string
+) => Promise<CommunityFilters>;
 
 export type GetCurrentUser = () => Promise<CurrentUser>;
 

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,4 +1,4 @@
-import { Communities, CommunityDetails } from "./community";
+import { Communities, Community } from "./community";
 import { Package, PackageDependency, PackagePreview } from "./package";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
@@ -9,7 +9,7 @@ export type GetCommunities = (
   search?: string
 ) => Promise<Communities>;
 
-export type GetCommunity = (communityId: string) => Promise<CommunityDetails>;
+export type GetCommunity = (communityId: string) => Promise<Community>;
 
 export type GetCurrentUser = () => Promise<CurrentUser>;
 

--- a/packages/thunderstore-api/src/fetch/__tests__/communityFilters.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/communityFilters.ts
@@ -1,0 +1,9 @@
+import { config } from "./defaultConfig";
+import { fetchCommunityFilters } from "../communityFilters";
+
+it("ensures filters contain categories and sections", async () => {
+  const response = await fetchCommunityFilters(config, "riskofrain2");
+
+  expect(Array.isArray(response.package_categories)).toBeTruthy();
+  expect(Array.isArray(response.sections)).toBeTruthy();
+});

--- a/packages/thunderstore-api/src/fetch/communityFilters.ts
+++ b/packages/thunderstore-api/src/fetch/communityFilters.ts
@@ -1,0 +1,11 @@
+import { RequestConfig } from "../index";
+import { apiFetch } from "../apiFetch";
+
+export async function fetchCommunityFilters(
+  config: RequestConfig,
+  communityId: string
+) {
+  const path = `api/cyberstorm/community/${communityId}/filters/`;
+
+  return await apiFetch(config, path);
+}

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -4,6 +4,7 @@ export interface RequestConfig {
 }
 
 export * from "./fetch/community";
+export * from "./fetch/communityFilters";
 export * from "./fetch/communityList";
 export * from "./fetch/currentUser";
 export * from "./fetch/teamDetails";


### PR DESCRIPTION
@thunderstore/dapper: remove package categories from community details

Package categories, as well as package listing sections, which both
will be used for filtering packages, will be queried from a separate
endpoint in the future.

Refs TS-1885

@thunderstore/dapper: add getCommunityFilters method

Returns values that can be used to filter packages based on categories
and sections. Both categories and sections are always bound to a
specific community.

Refs TS-1885

@thunderstore/thunderstore-api: add fetchCommunityFilters

Refs TS-1885

@thunderstore/dapper-ts: add getCommunityFilters

Refs TS-1885