### PR TITLE
@thunderstore/cyberstorm: add SectionMenu for PackageSearch

### DIFF
--- a/apps/cyberstorm-storybook/stories/layouts/PackageListLayout.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/layouts/PackageListLayout.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
 } as Meta<typeof CommunityProfileLayout>;
 
 const Template: StoryFn<typeof CommunityProfileLayout> = () => (
-  <CommunityProfileLayout communityId="riskofrain2" />
+  <CommunityProfileLayout communityId="foobar" />
 );
 const CommunityProfile = Template.bind({});
 

--- a/packages/cyberstorm/package.json
+++ b/packages/cyberstorm/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-checkbox": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.2",
     "@radix-ui/react-dropdown-menu": "^2.0.1",
+    "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-select": "^1.2.0",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tooltip": "^1.0.2",

--- a/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
@@ -93,6 +93,7 @@ export function CommunityProfileLayout(props: Props) {
         <PackageSearch
           communityId={communityId}
           packageCategories={filters.package_categories}
+          sections={filters.sections}
         />
       }
     />

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -76,6 +76,7 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
         <PackageSearch
           communityId={pkg.community}
           packageCategories={filters.package_categories}
+          sections={filters.sections}
         />
       }
     />

--- a/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
@@ -52,6 +52,7 @@ export function TeamProfileLayout(props: Props) {
         <PackageSearch
           teamId={namespace}
           packageCategories={filters.package_categories}
+          sections={filters.sections}
         />
       }
     />

--- a/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
@@ -28,7 +28,9 @@ export function UserProfileLayout(props: Props) {
           Mods uploaded by <UserLink user={userId}>{userId}</UserLink>
         </div>
       }
-      mainContent={<PackageSearch userId={userId} packageCategories={[]} />}
+      mainContent={
+        <PackageSearch userId={userId} packageCategories={[]} sections={[]} />
+      }
     />
   );
 }

--- a/packages/cyberstorm/src/components/PackageList/PackageList.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageList.tsx
@@ -17,6 +17,7 @@ interface Props {
   teamId?: string;
   searchQuery: string;
   categories: CategorySelection[];
+  section: string;
   deprecated: boolean;
   nsfw: boolean;
 }
@@ -33,7 +34,8 @@ const PER_PAGE = 20;
  * TODO: we also support only one searchQuery, so the Dapper method
  *       shouldn't expect an array of them.
  *
- * TODO: Add support for order, deprecated, and NSFW in the Dapper method.
+ * TODO: Add support for order, deprecated, NSFW, and section in the
+ *       Dapper method.
  */
 export function PackageList(props: Props) {
   const { communityId, namespaceId, searchQuery, teamId, userId } = props;

--- a/packages/cyberstorm/src/components/PackageSearch/FilterMenus/FilterMenu.module.css
+++ b/packages/cyberstorm/src/components/PackageSearch/FilterMenus/FilterMenu.module.css
@@ -63,3 +63,27 @@
   height: var(--space--16);
   color: var(--color-surface--0);
 }
+
+.radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space--16);
+  height: var(--space--16);
+  border: var(--space--2) solid var(--color-surface--7);
+  border-radius: var(--border-radius--8);
+  background-color: transparent;
+  transition: ease-out 60ms;
+}
+
+.radio.radioSelected {
+  border-color: var(--mark-color);
+}
+
+.radioIndicator {
+  display: block;
+  width: var(--space--6);
+  height: var(--space--6);
+  border-radius: 50%;
+  background-color: var(--mark-color);
+}

--- a/packages/cyberstorm/src/components/PackageSearch/FilterMenus/SectionMenu.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/FilterMenus/SectionMenu.tsx
@@ -1,0 +1,51 @@
+import * as RadioGroup from "@radix-ui/react-radio-group";
+import { Section } from "@thunderstore/dapper/types";
+import { Dispatch, SetStateAction } from "react";
+
+import styles from "./FilterMenu.module.css";
+
+interface Props {
+  allSections: Section[];
+  selected: string;
+  setSelected: Dispatch<SetStateAction<string>>;
+}
+
+/**
+ * Allow filtering packages by sections on PackageSearch.
+ */
+export const SectionMenu = (props: Props) => {
+  const { allSections, selected, setSelected } = props;
+
+  if (!allSections.length) {
+    return null;
+  }
+
+  return (
+    <div className={styles.root}>
+      <h2 className={styles.header}>Sections</h2>
+
+      <RadioGroup.Root value={selected} onValueChange={setSelected}>
+        {allSections.map((s) => (
+          <label
+            key={s.slug}
+            className={`${styles.label} ${
+              s.slug === selected ? styles.include : ""
+            }`}
+          >
+            <RadioGroup.Item
+              value={s.slug}
+              className={`${styles.radio} ${
+                s.slug === selected ? styles.radioSelected : ""
+              }`}
+            >
+              <RadioGroup.Indicator className={styles.radioIndicator} />
+            </RadioGroup.Item>
+            {s.name}
+          </label>
+        ))}
+      </RadioGroup.Root>
+    </div>
+  );
+};
+
+SectionMenu.displayName = "SectionMenu";

--- a/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
@@ -1,13 +1,14 @@
 "use client";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { PackageCategory } from "@thunderstore/dapper/types";
+import { PackageCategory, Section } from "@thunderstore/dapper/types";
 import { useState } from "react";
 import { useDebounce } from "use-debounce";
 
 import { CategoryTagCloud } from "./CategoryTagCloud/CategoryTagCloud";
 import { CategoryMenu } from "./FilterMenus/CategoryMenu";
 import { OthersMenu } from "./FilterMenus/OthersMenu";
+import { SectionMenu } from "./FilterMenus/SectionMenu";
 import styles from "./PackageSearch.module.css";
 import { CategorySelection } from "./types";
 import { Icon } from "../Icon/Icon";
@@ -17,6 +18,7 @@ import { TextInput } from "../TextInput/TextInput";
 interface Props {
   communityId?: string;
   packageCategories: PackageCategory[];
+  sections: Section[];
   teamId?: string;
   userId?: string;
 }
@@ -28,9 +30,12 @@ export function PackageSearch(props: Props) {
   const {
     communityId,
     packageCategories: allCategories,
+    sections,
     teamId,
     userId,
   } = props;
+
+  const allSections = sections.sort((a, b) => a.priority - b.priority);
 
   const [searchValue, setSearchValue] = useState("");
   const [debouncedSearchValue] = useDebounce(searchValue, 300);
@@ -39,6 +44,7 @@ export function PackageSearch(props: Props) {
       .sort((a, b) => a.slug.localeCompare(b.slug))
       .map((c) => ({ ...c, selection: "off" }))
   );
+  const [section, setSection] = useState(allSections[0]?.slug ?? "");
   const [deprecated, setDeprecated] = useState(false);
   const [nsfw, setNsfw] = useState(false);
 
@@ -57,6 +63,12 @@ export function PackageSearch(props: Props) {
 
       <div className={styles.contentWrapper}>
         <div className={styles.sidebar}>
+          <SectionMenu
+            allSections={allSections}
+            selected={section}
+            setSelected={setSection}
+          />
+
           <CategoryMenu categories={categories} setCategories={setCategories} />
 
           <OthersMenu
@@ -79,6 +91,7 @@ export function PackageSearch(props: Props) {
             teamId={teamId}
             searchQuery={debouncedSearchValue}
             categories={categories}
+            section={section}
             deprecated={deprecated}
             nsfw={nsfw}
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,6 +3578,15 @@
     "@radix-ui/react-compose-refs" "1.0.0"
     "@radix-ui/react-use-layout-effect" "1.0.0"
 
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
 "@radix-ui/react-primitive@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz#54e22f49ca59ba88d8143090276d50b93f8a7053"
@@ -3593,6 +3602,23 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-radio-group@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.1.3.tgz#3197f5dcce143bcbf961471bf89320735c0212d3"
+  integrity sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
 
 "@radix-ui/react-roving-focus@1.0.3":
   version "1.0.3"


### PR DESCRIPTION
SectioMenu allows filtering packages by section they belong to.
Sections are community specific. Common sections are "mods" and
"modpacks", but some communities don't use sections while others have
more than two.

Only one sections can be selected at a time, and if community has
sections, the first one is selected by default. This matches the
functionality of the old website while improving cacheability in
situations where e.g. "no section" and "mods" would mean the same
thing.

Refs TS-1860