### PR TITLE
@thunderstore/dapper: make PackagePreview match the data from backend

### DIFF
--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
@@ -9,7 +9,7 @@ export default function Page({
   // TODO: dummy data for now, the component shouldn't consume Package
   // object anyway.
   const packageData = {
-    community: params.community,
+    community_identifier: params.community,
     namespace: params.namespace,
     name: params.package,
   } as Package;

--- a/apps/cyberstorm-storybook/stories/components/PackageCard.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/components/PackageCard.stories.tsx
@@ -38,18 +38,17 @@ ReferencePackageCard.args = {
   package: {
     name: "WaveTimer",
     namespace: "otDan",
-    community: "brotato",
+    community_identifier: "brotato",
     description: "Modifies the in game timer to have a new look ",
-    imageSource:
+    icon_url:
       "https://gcdn.thunderstore.io/live/repository/icons/otDan-WaveTimer-1.1.0.png.256x256_q95_crop.jpg",
-    downloadCount: 2707,
-    likes: 1,
+    download_count: 2707,
+    rating_count: 1,
     size: 106299,
-    author: "otDan",
-    lastUpdated: "Tue Feb 28 2023",
-    isPinned: false,
-    isNsfw: false,
-    isDeprecated: false,
+    last_updated: "2023-02-28T11:23:42.000000Z",
+    is_pinned: false,
+    is_nsfw: false,
+    is_deprecated: false,
     categories: [
       { id: 1, name: "Misc", slug: "misc" },
       { id: 2, name: "Mods", slug: "mods" },

--- a/apps/cyberstorm-storybook/stories/layouts/PackageDependantsLayout.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/layouts/PackageDependantsLayout.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
 } as Meta<typeof PackageDependantsLayout>;
 
 const packageData = {
-  community: "brotato",
+  community_identifier: "brotato",
   namespace: "otDan",
   name: "WaveTimer",
 } as Package;

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -27,8 +27,10 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
   const { package: pkg } = props;
 
   const dapper = useDapper();
-  const community = usePromise(dapper.getCommunity, [pkg.community]);
-  const filters = usePromise(dapper.getCommunityFilters, [pkg.community]);
+  const community = usePromise(dapper.getCommunity, [pkg.community_identifier]);
+  const filters = usePromise(dapper.getCommunityFilters, [
+    pkg.community_identifier,
+  ]);
 
   return (
     <BaseLayout
@@ -42,11 +44,11 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
             {community.name}
           </CommunityLink>
           Packages
-          <TeamLink community={pkg.community} team={pkg.namespace}>
+          <TeamLink community={pkg.community_identifier} team={pkg.namespace}>
             {pkg.namespace}
           </TeamLink>
           <PackageLink
-            community={pkg.community}
+            community={pkg.community_identifier}
             namespace={pkg.namespace}
             package={pkg.name}
           >
@@ -59,21 +61,21 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
         <div className={styles.header}>
           Mods that depend on{" "}
           <PackageLink
-            community={pkg.community}
+            community={pkg.community_identifier}
             namespace={pkg.namespace}
             package={pkg.name}
           >
             {pkg.name}
           </PackageLink>
           {" by "}
-          <TeamLink community={pkg.community} team={pkg.namespace}>
+          <TeamLink community={pkg.community_identifier} team={pkg.namespace}>
             {pkg.namespace}
           </TeamLink>
         </div>
       }
       mainContent={
         <PackageSearch
-          communityId={pkg.community}
+          communityId={pkg.community_identifier}
           packageCategories={filters.package_categories}
           sections={filters.sections}
         />

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -56,6 +56,11 @@ export interface PackageDetailLayoutProps {
 
 /**
  * Cyberstorm PackageDetail Layout
+ *
+ * TODO: Use community.background_image_url as the background
+ * TODO: Change BaseLayout.backGroundImageSource to accept null rather
+ *       than undefined if image URLs are not available, as this is what
+ *       backend returns. (Unless we have a default image.)
  */
 export function PackageDetailLayout(props: PackageDetailLayoutProps) {
   const {
@@ -88,7 +93,7 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
   const packageDetailsMeta = [
     <TeamLink
       key="team"
-      community={packageData.community}
+      community={packageData.community_identifier}
       team={packageData.namespace}
     >
       <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
@@ -133,16 +138,16 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
 
   return (
     <BaseLayout
-      backGroundImageSource={packageData.imageSource}
+      backGroundImageSource={packageData.icon_url || undefined}
       breadCrumb={
         <BreadCrumbs>
           <CommunitiesLink>Communities</CommunitiesLink>
-          <CommunityLink community={packageData.community}>
-            {packageData.community}
+          <CommunityLink community={packageData.community_identifier}>
+            {packageData.community_name}
           </CommunityLink>
           Packages
           <TeamLink
-            community={packageData.community}
+            community={packageData.community_identifier}
             team={packageData.namespace}
           >
             {packageData.namespace}
@@ -155,11 +160,13 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
           <PageHeader
             title={packageData.name}
             image={
-              <img
-                className={styles.modImage}
-                alt={packageData.name}
-                src={packageData.imageSource}
-              />
+              packageData.icon_url ? (
+                <img
+                  className={styles.modImage}
+                  alt=""
+                  src={packageData.icon_url}
+                />
+              ) : undefined
             }
             description={packageData.shortDescription}
             meta={packageDetailsMeta}
@@ -176,7 +183,7 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
                 </Button.Root>
               }
               additionalFooterContent={
-                packageData.isDeprecated ? (
+                packageData.is_deprecated ? (
                   <Button.Root paddingSize="large" colorScheme="default">
                     <Button.ButtonLabel>Undeprecate</Button.ButtonLabel>
                   </Button.Root>
@@ -268,7 +275,7 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
           <PackageTagList packageData={packageData} />
           <PackageDependencyList namespace={namespace} community={community} />
           <PackageTeamMemberList
-            community={packageData.community}
+            community={packageData.community_identifier}
             teamName={packageData.namespace}
             teamMembers={packageData.team.members}
           />
@@ -285,7 +292,7 @@ function getMetaInfoData(packageData: Package) {
     {
       key: "1",
       label: "Last Updated",
-      content: <>{packageData.lastUpdated}</>,
+      content: <>{packageData.last_updated}</>,
     },
     {
       key: "2",
@@ -295,12 +302,12 @@ function getMetaInfoData(packageData: Package) {
     {
       key: "3",
       label: "Downloads",
-      content: <>{formatInteger(packageData.downloadCount)}</>,
+      content: <>{formatInteger(packageData.download_count)}</>,
     },
     {
       key: "4",
       label: "Likes",
-      content: <>{formatInteger(packageData.likes)}</>,
+      content: <>{formatInteger(packageData.rating_count)}</>,
     },
     {
       key: "5",
@@ -327,7 +334,7 @@ function getMetaInfoData(packageData: Package) {
       label: "Dependants",
       content: (
         <PackageDependantsLink
-          community={packageData.community}
+          community={packageData.community_identifier}
           namespace={packageData.namespace}
           package={packageData.name}
         >

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageTagList/PackageTagList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageTagList/PackageTagList.tsx
@@ -36,19 +36,19 @@ PackageTagList.displayName = "PackageTagList";
 
 function getPackageFlags(packageData: Package) {
   const updateTimeDelta = Math.round(
-    (Date.now() - Date.parse(packageData.lastUpdated)) / 86400000
+    (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );
   const isNew = updateTimeDelta < 3;
   if (
-    !packageData.isPinned &&
-    !packageData.isNsfw &&
-    !packageData.isDeprecated &&
+    !packageData.is_pinned &&
+    !packageData.is_nsfw &&
+    !packageData.is_deprecated &&
     !isNew
   ) {
     return null;
   }
   const flagList: ReactNode[] = [];
-  if (packageData.isPinned) {
+  if (packageData.is_pinned) {
     flagList.push(
       <Tag
         key="flag_pinned"
@@ -59,7 +59,7 @@ function getPackageFlags(packageData: Package) {
       />
     );
   }
-  if (packageData.isDeprecated) {
+  if (packageData.is_deprecated) {
     flagList.push(
       <Tag
         key="flag_deprecated"
@@ -70,7 +70,7 @@ function getPackageFlags(packageData: Package) {
       />
     );
   }
-  if (packageData.isNsfw) {
+  if (packageData.is_nsfw) {
     flagList.push(
       <Tag
         key="flag_nsfw"

--- a/packages/cyberstorm/src/components/PackageCard/PackageCard.tsx
+++ b/packages/cyberstorm/src/components/PackageCard/PackageCard.tsx
@@ -29,12 +29,12 @@ export function PackageCard(props: Props) {
     <div className={classnames(styles.root, styles.packageCard__default)}>
       <div className={styles.imageWrapper}>
         <PackageLink
-          community={p.community}
+          community={p.community_identifier}
           namespace={p.namespace}
           package={p.name}
         >
-          {p.imageSource ? (
-            <img className={styles.image} src={p.imageSource} alt={p.name} />
+          {p.icon_url ? (
+            <img className={styles.image} src={p.icon_url} alt={p.name} />
           ) : null}
           {getPackageFlags(p)}
         </PackageLink>
@@ -42,7 +42,7 @@ export function PackageCard(props: Props) {
 
       <div className={styles.content}>
         <PackageLink
-          community={p.community}
+          community={p.community_identifier}
           namespace={p.namespace}
           package={p.name}
         >
@@ -51,7 +51,7 @@ export function PackageCard(props: Props) {
 
         <div className={styles.author}>
           <span className={styles.author_prefix}>by</span>
-          <TeamLink community={p.community} team={p.namespace}>
+          <TeamLink community={p.community_identifier} team={p.namespace}>
             <div className={styles.author_label}>{p.namespace}</div>
           </TeamLink>
         </div>
@@ -80,19 +80,19 @@ PackageCard.displayName = "PackageCard";
 
 function getPackageFlags(packageData: PackagePreview) {
   const updateTimeDelta = Math.round(
-    (Date.now() - Date.parse(packageData.lastUpdated)) / 86400000
+    (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );
   const isNew = updateTimeDelta < 3;
   if (
-    !packageData.isPinned &&
-    !packageData.isNsfw &&
-    !packageData.isDeprecated &&
+    !packageData.is_pinned &&
+    !packageData.is_nsfw &&
+    !packageData.is_deprecated &&
     !isNew
   ) {
     return null;
   }
   const flagList: ReactNode[] = [];
-  if (packageData.isPinned) {
+  if (packageData.is_pinned) {
     flagList.push(
       <Tag
         key="flag_pinned"
@@ -102,7 +102,7 @@ function getPackageFlags(packageData: PackagePreview) {
       />
     );
   }
-  if (packageData.isDeprecated) {
+  if (packageData.is_deprecated) {
     flagList.push(
       <Tag
         key="flag_deprecated"
@@ -112,7 +112,7 @@ function getPackageFlags(packageData: PackagePreview) {
       />
     );
   }
-  if (packageData.isNsfw) {
+  if (packageData.is_nsfw) {
     flagList.push(
       <Tag
         key="flag_nsfw"
@@ -137,7 +137,7 @@ function getPackageFlags(packageData: PackagePreview) {
 
 function getMetaItemList(packageData: PackagePreview) {
   const updateTimeDelta = Math.round(
-    (Date.now() - Date.parse(packageData.lastUpdated)) / 86400000
+    (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );
   return (
     <div className={styles.metaItemWrapper}>
@@ -148,12 +148,12 @@ function getMetaItemList(packageData: PackagePreview) {
       />
       <MetaItem
         icon={<FontAwesomeIcon icon={faDownload} />}
-        label={formatInteger(packageData.downloadCount)}
+        label={formatInteger(packageData.download_count)}
         colorScheme="tertiary"
       />
       <MetaItem
         icon={<FontAwesomeIcon icon={faThumbsUp} />}
-        label={formatInteger(packageData.likes)}
+        label={formatInteger(packageData.rating_count)}
         colorScheme="tertiary"
       />
     </div>

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -1,13 +1,46 @@
 import { faker } from "@faker-js/faker";
 
-import {
-  getFakeImg,
-  getFakeLink,
-  getFakePackageCategories,
-  range,
-  setSeed,
-} from "./utils";
+import { getFakeImg, getFakePackageCategories, range, setSeed } from "./utils";
 import { getFakeTeamMembers } from "./team";
+
+// Content used to render one PackageCard in a list view.
+const getFakePackagePreview = (community?: string, namespace?: string) => {
+  const seed = `${community}-${namespace}`;
+  setSeed(seed);
+
+  return {
+    categories: getFakePackageCategories(),
+    community_identifier: community ?? faker.word.sample(),
+    description: faker.company.buzzPhrase(),
+    download_count: faker.number.int({ min: 100, max: 10000000 }),
+    icon_url: faker.helpers.maybe(getFakeImg, { probability: 0.9 }) ?? null,
+    is_deprecated: faker.datatype.boolean(0.1),
+    is_nsfw: faker.datatype.boolean(0.1),
+    is_pinned: faker.datatype.boolean(0.1),
+    last_updated: faker.date.recent({ days: 700 }).toDateString(),
+    name: faker.word.words(3).split(" ").join("_"),
+    namespace: namespace ?? faker.word.sample(),
+    rating_count: faker.number.int({ min: 0, max: 100000 }),
+    size: faker.number.int({ min: 20000, max: 4000000000 }),
+  };
+};
+
+export const getFakePackageListings = async (
+  communityId?: string,
+  namespaceId?: string,
+  // Temporary, will be refactored away when the actual implementation is done.
+  _teamId?: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+  _userId?: string // eslint-disable-line @typescript-eslint/no-unused-vars
+) =>
+  range(20).map(() =>
+    getFakePackagePreview(
+      communityId ?? faker.word.sample(),
+      namespaceId ?? faker.word.sample()
+    )
+  );
+
+// TODO: the methods below this point don't yet match what the backend
+// will be actually returning.
 
 export const getFakeDependencies = async (
   community: string,
@@ -32,55 +65,23 @@ export const getFakePackage = async (
   setSeed(seed);
 
   return {
-    ...getPackageBase(community, namespace, name),
-    ...getPackageExtras(),
+    ...getFakePackagePreview(community, namespace),
 
+    community_identifier: community,
+    community_name: faker.word.sample(),
+    discordLink: faker.internet.url(),
     author: faker.person.fullName(),
     dependantCount: faker.number.int({ min: 0, max: 2000 }),
     dependencies: await getFakeDependencies(community, namespace, name),
     dependencyString: faker.string.uuid(),
-    description: faker.lorem.paragraphs(12),
     firstUploaded: faker.date.past({ years: 2 }).toDateString(),
-    team: await getPackageTeam(seed),
+    gitHubLink: faker.internet.url(),
+    shortDescription: faker.company.buzzPhrase(),
+    team: {
+      name: faker.word.words(3),
+      members: await getFakeTeamMembers(seed),
+    },
     versions: range(20).map(getPackageVersion),
-  };
-};
-
-// TODO: the DummyDapper implementation in the dapper package at the
-// time of this writing has so many shortcomings and bugs that rather
-// than try to duplicate that implementation, I'll save time and just
-// return some packages. The whole Dapper method interface needs to be
-// changed in order to be able to implement all the features we want, so
-// this method can be updated once we get there.
-export const getFakePackageListings = async (
-  communityId?: string,
-  namespaceId?: string,
-  teamId?: string,
-  userId?: string
-) =>
-  range(20).map(() =>
-    getFakePackagePreview(
-      communityId ?? faker.word.sample(),
-      namespaceId ?? faker.word.sample(),
-      teamId ?? faker.word.words(3),
-      userId ?? faker.internet.userName()
-    )
-  );
-
-const getFakePackagePreview = (
-  community?: string,
-  namespace?: string,
-  team?: string,
-  user?: string
-) => {
-  const seed = `${community}-${namespace}-${team}-${user}`;
-  setSeed(seed);
-
-  return {
-    ...getPackageBase(community, namespace),
-    ...getPackageExtras(),
-    author: user ?? faker.person.fullName(),
-    description: faker.company.buzzPhrase(),
   };
 };
 
@@ -95,33 +96,6 @@ const getPackageBase = (
   shortDescription: faker.company.buzzPhrase(),
   imageSource: getFakeImg(),
 });
-
-const getPackageExtras = () => ({
-  categories: getFakePackageCategories(),
-  downloadCount: faker.number.int({ min: 1000000, max: 10000000 }),
-  isDeprecated: faker.datatype.boolean(),
-  isNsfw: faker.datatype.boolean(),
-  isPinned: faker.datatype.boolean(),
-  lastUpdated: faker.date.recent({ days: 700 }).toDateString(),
-  likes: faker.number.int({ min: 0, max: 100000 }),
-  size: faker.number.int({ min: 20000, max: 10000000 }),
-  gitHubLink: faker.internet.url(),
-  discordLink: faker.internet.url(),
-});
-
-const getPackageTeam = async (teamId: string) => {
-  setSeed(teamId);
-
-  return {
-    name: faker.word.words(3),
-    imageSource: getFakeImg(),
-    description: faker.lorem.paragraphs(12),
-    about: faker.lorem.words(16),
-    members: await getFakeTeamMembers(teamId),
-    dynamicLinks: [getFakeLink(), getFakeLink(), getFakeLink()],
-    donationLink: faker.internet.url(),
-  };
-};
 
 const getPackageVersion = () => ({
   version: getVersionNumber(),

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -2,23 +2,23 @@ import { PackageCategory } from "./shared";
 import { TeamMember } from "./team";
 
 export interface PackagePreview {
+  categories: PackageCategory[];
+  community_identifier: string;
+  description: string;
+  download_count: number;
+  icon_url: string | null;
+  is_deprecated: boolean;
+  is_nsfw: boolean;
+  is_pinned: boolean;
+  last_updated: string;
   name: string;
   namespace: string;
-  community: string;
-  description?: string;
-  imageSource?: string;
-  downloadCount: number;
-  likes: number;
+  rating_count: number;
   size: number;
-  author?: string;
-  lastUpdated: string;
-  isPinned?: boolean;
-  isNsfw?: boolean;
-  isDeprecated?: boolean;
-  categories: PackageCategory[];
 }
 
 export interface Package extends PackagePreview {
+  community_name: string;
   shortDescription?: string;
   additionalImages?: string[];
   gitHubLink?: string;


### PR DESCRIPTION
PackagePreview, used to render package cards, should use the actual
values the backend will eventually return. By a decided convetion, the
naming should use backend terms to make it easier for developers to
work on both repositories.

Refs TS-1875