### PR TITLE
@thunderstore/dapper: augment GetPackageListings function signature

### DIFF
--- a/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
@@ -29,6 +29,8 @@ export function CommunityProfileLayout(props: Props) {
   const community = usePromise(dapper.getCommunity, [communityId]);
   const filters = usePromise(dapper.getCommunityFilters, [communityId]);
 
+  const listingType = { kind: "community" as const, communityId };
+
   return (
     <BaseLayout
       backGroundImageSource={
@@ -84,7 +86,7 @@ export function CommunityProfileLayout(props: Props) {
       }
       mainContent={
         <PackageSearch
-          communityId={communityId}
+          listingType={listingType}
           packageCategories={filters.package_categories}
           sections={filters.sections}
         />

--- a/packages/cyberstorm/src/components/Layout/HomeLayout/HomeLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/HomeLayout/HomeLayout.tsx
@@ -12,8 +12,12 @@ export function HomeLayout() {
   const dapper = useDapper();
   const featuredCommunities = usePromise(dapper.getCommunities, []);
   // TODO: "featured" or "hot" packages are not supported.
-  const featuredPackages = usePromise(dapper.getPackageListings, ["featured"]);
-  const hotPackages = usePromise(dapper.getPackageListings, ["hot"]);
+  const featuredPackages = usePromise(dapper.getPackageListings, [
+    { kind: "community" as const, communityId: "featured" },
+  ]);
+  const hotPackages = usePromise(dapper.getPackageListings, [
+    { kind: "community" as const, communityId: "hot" },
+  ]);
 
   return (
     <BaseLayout

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -32,6 +32,11 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
     pkg.community_identifier,
   ]);
 
+  const listingType = {
+    kind: "community" as const,
+    communityId: pkg.community_identifier,
+  };
+
   return (
     <BaseLayout
       backGroundImageSource={
@@ -75,7 +80,7 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
       }
       mainContent={
         <PackageSearch
-          communityId={pkg.community_identifier}
+          listingType={listingType}
           packageCategories={filters.package_categories}
           sections={filters.sections}
         />

--- a/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
@@ -50,7 +50,8 @@ export function TeamProfileLayout(props: Props) {
       }
       mainContent={
         <PackageSearch
-          teamId={namespace}
+          communityId={community}
+          namespaceId={namespace}
           packageCategories={filters.package_categories}
           sections={filters.sections}
         />

--- a/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
@@ -30,6 +30,12 @@ export function TeamProfileLayout(props: Props) {
   const dapper = useDapper();
   const filters = usePromise(dapper.getCommunityFilters, [community]);
 
+  const listingType = {
+    kind: "namespace" as const,
+    communityId: community,
+    namespaceId: namespace,
+  };
+
   return (
     <BaseLayout
       breadCrumb={
@@ -50,8 +56,7 @@ export function TeamProfileLayout(props: Props) {
       }
       mainContent={
         <PackageSearch
-          communityId={community}
-          namespaceId={namespace}
+          listingType={listingType}
           packageCategories={filters.package_categories}
           sections={filters.sections}
         />

--- a/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
@@ -11,7 +11,8 @@ interface Props {
 /**
  * Cyberstorm user's profile Layout
  *
- * TODO: use Dapper to fetch package categories.
+ * TODO: use Dapper to fetch package categories and sections.
+ * TODO: add support for user-scoped package listings to Dapper
  */
 export function UserProfileLayout(props: Props) {
   const { userId } = props;
@@ -29,7 +30,11 @@ export function UserProfileLayout(props: Props) {
         </div>
       }
       mainContent={
-        <PackageSearch userId={userId} packageCategories={[]} sections={[]} />
+        <PackageSearch
+          communityId={"TODO"}
+          packageCategories={[]}
+          sections={[]}
+        />
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/UserProfileLayout/UserProfileLayout.tsx
@@ -16,6 +16,7 @@ interface Props {
  */
 export function UserProfileLayout(props: Props) {
   const { userId } = props;
+  const listingType = { kind: "community" as const, communityId: "TODO" };
 
   return (
     <BaseLayout
@@ -31,7 +32,7 @@ export function UserProfileLayout(props: Props) {
       }
       mainContent={
         <PackageSearch
-          communityId={"TODO"}
+          listingType={listingType}
           packageCategories={[]}
           sections={[]}
         />

--- a/packages/cyberstorm/src/components/PackageList/PackageList.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageList.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useDapper } from "@thunderstore/dapper";
+import { PackageListingType } from "@thunderstore/dapper/types";
 import { usePromise } from "@thunderstore/use-promise";
 import { useState } from "react";
 
@@ -11,8 +12,7 @@ import { PackageCard } from "../PackageCard/PackageCard";
 import { Pagination } from "../Pagination/Pagination";
 
 interface Props {
-  communityId?: string;
-  namespaceId?: string;
+  listingType: PackageListingType;
   categories: CategorySelection[];
   deprecated: boolean;
   nsfw: boolean;
@@ -36,17 +36,14 @@ const PER_PAGE = 20;
  *       Dapper method.
  */
 export function PackageList(props: Props) {
-  const { communityId, namespaceId, searchQuery } = props;
+  const { listingType, searchQuery } = props;
 
   const [order, setOrder] = useState(PackageOrderOptions.Updated);
   const [page, setPage] = useState(1);
   const dapper = useDapper();
 
   const packages = usePromise(dapper.getPackageListings, [
-    communityId,
-    undefined,
-    namespaceId,
-    undefined,
+    listingType,
     [searchQuery],
   ]);
 

--- a/packages/cyberstorm/src/components/PackageList/PackageList.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageList.tsx
@@ -12,14 +12,12 @@ import { Pagination } from "../Pagination/Pagination";
 
 interface Props {
   communityId?: string;
-  userId?: string;
   namespaceId?: string;
-  teamId?: string;
-  searchQuery: string;
   categories: CategorySelection[];
-  section: string;
   deprecated: boolean;
   nsfw: boolean;
+  searchQuery: string;
+  section: string;
 }
 
 const PER_PAGE = 20;
@@ -38,7 +36,7 @@ const PER_PAGE = 20;
  *       Dapper method.
  */
 export function PackageList(props: Props) {
-  const { communityId, namespaceId, searchQuery, teamId, userId } = props;
+  const { communityId, namespaceId, searchQuery } = props;
 
   const [order, setOrder] = useState(PackageOrderOptions.Updated);
   const [page, setPage] = useState(1);
@@ -46,9 +44,9 @@ export function PackageList(props: Props) {
 
   const packages = usePromise(dapper.getPackageListings, [
     communityId,
-    userId,
+    undefined,
     namespaceId,
-    teamId,
+    undefined,
     [searchQuery],
   ]);
 

--- a/packages/cyberstorm/src/components/PackageList/PackageList.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageList.tsx
@@ -2,7 +2,7 @@
 import { useDapper } from "@thunderstore/dapper";
 import { PackageListingType } from "@thunderstore/dapper/types";
 import { usePromise } from "@thunderstore/use-promise";
-import { useDeferredValue, useState } from "react";
+import { useDeferredValue, useEffect, useState } from "react";
 
 import { PackageCount } from "./PackageCount";
 import { PackageOrder, PackageOrderOptions } from "./PackageOrder";
@@ -52,6 +52,10 @@ export function PackageList(props: Props) {
     .filter((c) => c.selection === "exclude")
     .map((c) => c.id);
 
+  useEffect(() => {
+    setPage(1);
+  }, [categories, deprecated, listingType, nsfw, order, searchQuery, section]);
+
   const dapper = useDapper();
   const packages = usePromise(dapper.getPackageListings, [
     listingType,
@@ -69,7 +73,7 @@ export function PackageList(props: Props) {
     <div className={styles.root}>
       <div className={styles.top}>
         <PackageCount
-          page={1}
+          page={page}
           pageSize={PER_PAGE}
           searchQuery={searchQuery}
           totalCount={packages.count}

--- a/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { PackageCategory, Section } from "@thunderstore/dapper/types";
+import {
+  PackageCategory,
+  PackageListingType,
+  Section,
+} from "@thunderstore/dapper/types";
 import { useState } from "react";
 import { useDebounce } from "use-debounce";
 
@@ -15,8 +19,7 @@ import { PackageList } from "../PackageList/PackageList";
 import { TextInput } from "../TextInput/TextInput";
 
 interface Props {
-  communityId?: string;
-  namespaceId?: string;
+  listingType: PackageListingType;
   packageCategories: PackageCategory[];
   sections: Section[];
 }
@@ -25,13 +28,7 @@ interface Props {
  * Component for filtering and rendering a PackageList
  */
 export function PackageSearch(props: Props) {
-  const {
-    communityId,
-    namespaceId,
-    packageCategories: allCategories,
-    sections,
-  } = props;
-
+  const { listingType, packageCategories: allCategories, sections } = props;
   const allSections = sections.sort((a, b) => a.priority - b.priority);
 
   const [searchValue, setSearchValue] = useState("");
@@ -79,8 +76,7 @@ export function PackageSearch(props: Props) {
           />
 
           <PackageList
-            communityId={communityId}
-            namespaceId={namespaceId}
+            listingType={listingType}
             searchQuery={debouncedSearchValue}
             categories={categories}
             section={section}

--- a/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/PackageSearch.tsx
@@ -16,10 +16,9 @@ import { TextInput } from "../TextInput/TextInput";
 
 interface Props {
   communityId?: string;
+  namespaceId?: string;
   packageCategories: PackageCategory[];
   sections: Section[];
-  teamId?: string;
-  userId?: string;
 }
 
 /**
@@ -28,10 +27,9 @@ interface Props {
 export function PackageSearch(props: Props) {
   const {
     communityId,
+    namespaceId,
     packageCategories: allCategories,
     sections,
-    teamId,
-    userId,
   } = props;
 
   const allSections = sections.sort((a, b) => a.priority - b.priority);
@@ -82,8 +80,7 @@ export function PackageSearch(props: Props) {
 
           <PackageList
             communityId={communityId}
-            userId={userId}
-            teamId={teamId}
+            namespaceId={namespaceId}
             searchQuery={debouncedSearchValue}
             categories={categories}
             section={section}

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { PackageListingType } from "@thunderstore/dapper/types";
 
 import { getFakeImg, getFakePackageCategories, range, setSeed } from "./utils";
 import { getFakeTeamMembers } from "./team";
@@ -29,19 +30,13 @@ const getFakePackagePreview = (community?: string, namespace?: string) => {
 // interacts with filters or pagination. Something similar could be done
 // here that's done for community listing, but getting all the filters
 // to work properly might not be worth the effort.
-export const getFakePackageListings = async (
-  communityId?: string,
-  namespaceId?: string,
-  // Temporary, will be refactored away when the actual implementation is done.
-  _teamId?: string, // eslint-disable-line @typescript-eslint/no-unused-vars
-  _userId?: string // eslint-disable-line @typescript-eslint/no-unused-vars
-) => ({
+export const getFakePackageListings = async (type: PackageListingType) => ({
   count: 200,
   hasMore: true,
   results: range(20).map(() =>
     getFakePackagePreview(
-      communityId ?? faker.word.sample(),
-      namespaceId ?? faker.word.sample()
+      type.communityId,
+      type.kind === "namespace" ? type.namespaceId : faker.word.sample()
     )
   ),
 });

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -30,7 +30,17 @@ const getFakePackagePreview = (community?: string, namespace?: string) => {
 // interacts with filters or pagination. Something similar could be done
 // here that's done for community listing, but getting all the filters
 // to work properly might not be worth the effort.
-export const getFakePackageListings = async (type: PackageListingType) => ({
+export const getFakePackageListings = async (
+  type: PackageListingType
+  // order = "-datetime_updated",
+  // page = 1,
+  // query = "",
+  // includedCategories = [],
+  // excludedCategories = [],
+  // section = "",
+  // nsfw = false,
+  // deprecated = false
+) => ({
   count: 200,
   hasMore: true,
   results: range(20).map(() =>

--- a/packages/dapper/src/types/index.ts
+++ b/packages/dapper/src/types/index.ts
@@ -3,4 +3,5 @@ export * from "./methods";
 export * from "./package";
 export * from "./team";
 export * from "./user";
+export { type PackageListingType } from "./props";
 export { type PackageCategory } from "./shared";

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -33,12 +33,14 @@ export type GetPackageDependencies = (
 
 export type GetPackageListings = (
   type: PackageListingType,
-  keywords?: string[],
-  categories?: {
-    [key: string]: {
-      value: boolean | undefined;
-    };
-  }
+  order?: string,
+  page?: number,
+  query?: string,
+  includedCategories?: number[],
+  excludedCategories?: number[],
+  section?: string,
+  nsfw?: boolean,
+  deprecated?: boolean
 ) => Promise<PackagePreviews>;
 
 export type GetTeamDetails = (teamName: string) => Promise<TeamDetails>;

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,5 +1,6 @@
 import { Communities, Community, CommunityFilters } from "./community";
 import { Package, PackageDependency, PackagePreviews } from "./package";
+import { PackageListingType } from "./props";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
 
@@ -31,10 +32,7 @@ export type GetPackageDependencies = (
 ) => Promise<PackageDependency[]>;
 
 export type GetPackageListings = (
-  communityId?: string,
-  userId?: string,
-  namespaceId?: string,
-  teamId?: string,
+  type: PackageListingType,
   keywords?: string[],
   categories?: {
     [key: string]: {

--- a/packages/dapper/src/types/props.ts
+++ b/packages/dapper/src/types/props.ts
@@ -1,0 +1,16 @@
+/**
+ * Explicitly define the scope of results expected from GetPackageListings.
+ *
+ * Each discriminating union part should also include all the arguments
+ * required to query the first page of results using default filters etc.
+ */
+export type PackageListingType =
+  | {
+      kind: "community";
+      communityId: string;
+    }
+  | {
+      kind: "namespace";
+      communityId: string;
+      namespaceId: string;
+    };


### PR DESCRIPTION
@thunderstore/cyberstorm: remove unsupported props from PackageList

For the time being PackageList, and thus also PackageSearch, will
support only showing community or community+namespace scoped results.
Remove props that are meant for non-supported listings since they're
just adding noice currently. They can be readded if/when we add
related support to @thunderstore/dapper.

Refs TS-1875

@thunderstore/dapper: strongly type the scope of GetPackageListings

THe scope refers to the factors limiting the base result set when no
filters etc. are in play. E.g. the listing can be scoped to packages
listed in a specific community.

In attempt to be reusable, the earlier interface included a bunch of id
strings, e.g. community identifier and namespace name. All of these
were optional and there was no plan for which part of the code base
should be responsible to parsing the combination of these values to the
actual scope.

My initial idea was to do that parsing on the PackageList component,
but in the end I chose to do this at the top the chain in Layout
components. The rationale being that doing the parsing in middle of the
chain in unnecessary and a possible source of errors. It's better to
bypass it by requiring the Layouts to be explicit about the listing
from the get go.

It might seem that this couples Cyberstorm components and Dapper more
tightly together, but I'd argue the coupling was there already with the
old implementation. The changes in this commit only make that coupling
explicit.

Refs TS-1875

@thunderstore/dapper: add filter support for GetPackageListings

The method now accepts parameters used for filtering, ordering and
paginating the results.

PackageList needs to use deferred values to separate the light "update
UI" operation from the heavy "fetch results" operation. In practice
searchQuery is already debounced and wouldn't require deferring, but
for clarity's sake it's also deferred.

Refs TS-1875

@thunderstore/cyberstorm: reset page when PackageList filters change

Also fix the hard coded page number on PackageCount display.

Refs TS-1875