### PR TITLE
add missing text

### DIFF
--- a/packages/cyberstorm/src/components/Layout/Developers/PackageFormatDocs/PackageFormatDocsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/Developers/PackageFormatDocs/PackageFormatDocsLayout.tsx
@@ -42,6 +42,9 @@ export function PackageFormatDocsLayout() {
       header={<PageHeader title="Package Format Docs" />}
       mainContent={
         <div className={styles.root}>
+          <p>
+            A valid package is a zip file that contains the following files:
+          </p>
           <Table
             headers={firstTableDataColumns}
             rows={firstTableData}


### PR DESCRIPTION
[Refs TS-1874 - Package Format Docs - Missing the text "A valid package is a zip file that contains the following files"](https://app.clickup.com/t/20413243/TS-1874)