### PR TITLE
Small fixes to Cyberstorm and Dapper

### DIFF
--- a/packages/cyberstorm/src/components/PackageList/PackageCount.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageCount.tsx
@@ -19,15 +19,23 @@ export const PackageCount = (props: Props) => {
   const { page, pageSize, searchQuery, totalCount } = props;
   const first = (page - 1) * pageSize + 1;
   const last = first + pageSize - 1;
+  const query = searchQuery !== "" ? ` for "${searchQuery}"` : "";
+
+  if (totalCount === 0) {
+    return <p className={styles.packageCount}>No results{query}</p>;
+  }
 
   return (
     <p className={styles.packageCount}>
-      Showing{" "}
+      {"Showing "}
       <strong>
-        {first}-{last}
-      </strong>{" "}
-      of <strong>{totalCount}</strong> results
-      {searchQuery !== "" ? ` for "${searchQuery}"` : ""}
+        {first}
+        {first !== totalCount ? `-${Math.min(last, totalCount)}` : ""}
+      </strong>
+      {" of "}
+      <strong>{totalCount}</strong>
+      {" results"}
+      {query}
     </p>
   );
 };

--- a/packages/cyberstorm/src/components/PackageList/PackageList.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageList.tsx
@@ -84,7 +84,7 @@ export function PackageList(props: Props) {
 
       <div className={styles.packages}>
         {packages.results.map((p) => (
-          <PackageCard key={p.name} package={p} />
+          <PackageCard key={`${p.namespace}-${p.name}`} package={p} />
         ))}
       </div>
 

--- a/packages/cyberstorm/src/components/PackageList/PackageOrder.tsx
+++ b/packages/cyberstorm/src/components/PackageList/PackageOrder.tsx
@@ -27,10 +27,10 @@ export const PackageOrder = (props: Props) => (
 );
 
 export enum PackageOrderOptions {
-  Created = "-datetime_created",
-  Downloaded = "-downloads",
-  Rated = "-rating_score",
-  Updated = "-datetime_updated",
+  Created = "newest",
+  Downloaded = "most-downloaded",
+  Rated = "top-rated",
+  Updated = "last-updated",
 }
 
 const selectOptions = [

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -32,9 +32,9 @@ const getFakePackagePreview = (community?: string, namespace?: string) => {
 // to work properly might not be worth the effort.
 export const getFakePackageListings = async (
   type: PackageListingType
-  // order = "-datetime_updated",
+  // ordering = "last-updated",
   // page = 1,
-  // query = "",
+  // q = "",
   // includedCategories = [],
   // excludedCategories = [],
   // section = "",

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -33,9 +33,9 @@ export type GetPackageDependencies = (
 
 export type GetPackageListings = (
   type: PackageListingType,
-  order?: string,
+  ordering?: string,
   page?: number,
-  query?: string,
+  q?: string,
   includedCategories?: number[],
   excludedCategories?: number[],
   section?: string,


### PR DESCRIPTION
@thunderstore/cyberstorm: change values used by PackageOrder component

The old values reflected backend implementation, which is none of the
UI's business. Use generic strings instead, so we don't have to change
the component if backend implementation changes.

Refs TS-1875

@thunderstore/dapper: rename GetPackageListings arguments

Use the names the backend expects for query parameters to avoid
renaming and confusion. Didn't want to force the UI to use the same
terms at this point, so the change only affects Dapper.

Refs TS-1875

@thunderstore/cyberstorm: fix edge cases on PackageCount display

- Show "No results" if no packages match filters
- Show "Showing X of X results" if the current page contains only one
  package
- Show "Showing X-Y of Y results" if the current page doesn't contain
  full page of results

Refs no ticket