### PR TITLE
@thunderstore-dapper-ts: add getPackageListings

### DIFF
--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -1,5 +1,7 @@
 import { DapperTs } from "../index";
 
+const communityId = "riskofrain2";
+const namespaceId = "TestTeam";
 let dapper: DapperTs;
 
 beforeAll(() => {
@@ -11,12 +13,12 @@ it("executes getCommunities without errors", async () => {
 });
 
 it("executes getCommunity without errors", async () => {
-  await expect(dapper.getCommunity("riskofrain2")).resolves.not.toThrowError();
+  await expect(dapper.getCommunity(communityId)).resolves.not.toThrowError();
 });
 
 it("executes getCommunityFilters without errors", async () => {
   await expect(
-    dapper.getCommunityFilters("riskofrain2")
+    dapper.getCommunityFilters(communityId)
   ).resolves.not.toThrowError();
 });
 
@@ -33,24 +35,36 @@ it("executes getPackageDependencies without errors", async () => {
   await expect(dapper.getPackageDependencies()).resolves.not.toThrowError();
 });
 
-it("executes getPackageListings without errors", async () => {
-  await expect(dapper.getPackageListings()).resolves.not.toThrowError();
+it("executes getPackageListings for community without errors", async () => {
+  await expect(
+    dapper.getPackageListings({ kind: "community", communityId })
+  ).resolves.not.toThrowError();
+});
+
+it("executes getPackageListings for namespace without errors", async () => {
+  await expect(
+    dapper.getPackageListings({
+      kind: "namespace",
+      communityId,
+      namespaceId,
+    })
+  ).resolves.not.toThrowError();
 });
 
 it("executes getTeamDetails without errors", async () => {
-  await expect(dapper.getTeamDetails("TestTeam")).resolves.not.toThrowError();
+  await expect(dapper.getTeamDetails(namespaceId)).resolves.not.toThrowError();
 });
 
 // TODO: this should be tested/mocked with sessionId too.
 it("executes getTeamMembers with 401 error", async () => {
-  await expect(dapper.getTeamMembers("TestTeam")).rejects.toThrowError(
+  await expect(dapper.getTeamMembers(namespaceId)).rejects.toThrowError(
     "401: Unauthorized"
   );
 });
 
 // TODO: this should be tested/mocked with sessionId too.
 it("executes getTeamServiceAccounts with 401 error", async () => {
-  await expect(dapper.getTeamServiceAccounts("TestTeam")).rejects.toThrowError(
+  await expect(dapper.getTeamServiceAccounts(namespaceId)).rejects.toThrowError(
     "401: Unauthorized"
   );
 });

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -4,6 +4,7 @@ import { RequestConfig } from "@thunderstore/thunderstore-api";
 import { getCommunities, getCommunity } from "./methods/communities";
 import { getCommunityFilters } from "./methods/communityFilters";
 import { getCurrentUser } from "./methods/currentUser";
+import { getPackageListings } from "./methods/packageListings";
 import {
   getTeamDetails,
   getTeamMembers,
@@ -32,6 +33,7 @@ export class DapperTs implements DapperTsInterface {
     this.getCommunity = this.getCommunity.bind(this);
     this.getCommunityFilters = this.getCommunityFilters.bind(this);
     this.getCurrentUser = this.getCurrentUser.bind(this);
+    this.getPackageListings = this.getPackageListings.bind(this);
     this.getTeamDetails = this.getTeamDetails.bind(this);
     this.getTeamMembers = this.getTeamMembers.bind(this);
     this.getTeamServiceAccounts = this.getTeamServiceAccounts.bind(this);
@@ -41,11 +43,11 @@ export class DapperTs implements DapperTsInterface {
   public getCommunity = getCommunity;
   public getCommunityFilters = getCommunityFilters;
   public getCurrentUser = getCurrentUser;
+  public getPackageListings = getPackageListings;
   public getTeamDetails = getTeamDetails;
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
 
   public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;
-  public getPackageListings = NotImplemented;
 }

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -2,12 +2,7 @@ import { z } from "zod";
 import { fetchCommunityFilters } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
-
-const PackageCategory = z.object({
-  id: z.number().nonnegative(),
-  name: z.string().nonempty(),
-  slug: z.string().nonempty(),
-});
+import { PackageCategory } from "../sharedSchemas";
 
 const Section = z.object({
   uuid: z.string().uuid(),

--- a/packages/dapper-ts/src/sharedSchemas.ts
+++ b/packages/dapper-ts/src/sharedSchemas.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+export const PackageCategory = z.object({
+  id: z.number().nonnegative(),
+  name: z.string().nonempty(),
+  slug: z.string().nonempty(),
+});
+
 export const paginatedResults = <T extends z.ZodTypeAny>(resultType: T) =>
   z.object({
     count: z.number().int().min(0),


### PR DESCRIPTION
The method currently supports getting community-scoped or community-
and namespace-scoped package listings. More will be added in the
future.

I would have preferred these to be separate methods. The way Cyberstorm
currently uses PackageList for all our package listing needs would have
made getting the hooks (called unconditionally) and TypeScript play
nicely would have required changes outside the scope of this commit. I
might get back to that issue though.

Refs TS-1875