### PR TITLE
@thunderstore/thunderstore-api: improve error handling

### DIFF
--- a/packages/thunderstore-api/src/fetch/__tests__/teamMembers.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/teamMembers.ts
@@ -3,6 +3,6 @@ import { fetchTeamMembers } from "../teamMembers";
 
 it("ensures accessing team members requires authentication", async () => {
   await expect(fetchTeamMembers(config, "TestTeam")).rejects.toThrowError(
-    "401: Unauthorized"
+    "(401) Unauthorized"
   );
 });

--- a/packages/thunderstore-api/src/fetch/__tests__/teamServiceAccounts.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/teamServiceAccounts.ts
@@ -4,5 +4,5 @@ import { fetchTeamServiceAccounts } from "../teamServiceAccounts";
 it("ensures accessing team members requires authentication", async () => {
   await expect(
     fetchTeamServiceAccounts(config, "TestTeam")
-  ).rejects.toThrowError("401: Unauthorized");
+  ).rejects.toThrowError("(401) Unauthorized");
 });


### PR DESCRIPTION
Sentry handling doesn't need to be done on package level since we're
doing it on app level. Try to throw useful error messages, taking into
account I don't how much of the error stack is available on Sentry or
NextJs logs this way.

Refs no ticket