### PR TITLE
@thunderstore/dapper-ts: improve error handling

### DIFF
--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -6,6 +6,7 @@ import {
 
 import { DapperTsInterface } from "../index";
 import { paginatedResults } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const communitySchema = z.object({
   name: z.string().nonempty(),
@@ -31,8 +32,7 @@ export async function getCommunities(
   const parsed = communitiesSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return {
@@ -50,8 +50,7 @@ export async function getCommunity(
   const parsed = communitySchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -3,6 +3,7 @@ import { fetchCommunityFilters } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
 import { PackageCategory } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const Section = z.object({
   uuid: z.string().uuid(),
@@ -24,8 +25,7 @@ export async function getCommunityFilters(
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/methods/currentUser.ts
+++ b/packages/dapper-ts/src/methods/currentUser.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { fetchCurrentUser } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
+import { formatErrorMessage } from "../utils";
 
 const oAuthConnectionSchema = z.object({
   provider: z.string().nonempty(),
@@ -42,8 +43,7 @@ export async function getCurrentUser(this: DapperTsInterface) {
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   // For legacy support, the backend returns teams in two formats.

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -8,6 +8,7 @@ import { PackageListingQueryParams } from "@thunderstore/thunderstore-api/types"
 
 import { DapperTsInterface } from "../index";
 import { PackageCategory, paginatedResults } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const packageListingSchema = z.object({
   categories: PackageCategory.array(),
@@ -73,8 +74,7 @@ export async function getPackageListings(
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return {

--- a/packages/dapper-ts/src/methods/team.ts
+++ b/packages/dapper-ts/src/methods/team.ts
@@ -6,6 +6,7 @@ import {
 } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
+import { formatErrorMessage } from "../utils";
 
 const detailsSchema = z.object({
   identifier: z.number().int().gt(0),
@@ -45,8 +46,7 @@ export async function getTeamMembers(
   const parsed = membersSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;
@@ -68,8 +68,7 @@ export async function getTeamServiceAccounts(
   const parsed = serviceAccountSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/utils.ts
+++ b/packages/dapper-ts/src/utils.ts
@@ -1,0 +1,13 @@
+import { ZodError } from "zod";
+
+export const formatErrorMessage = (errors: ZodError) => {
+  const issues = errors.issues.map(
+    (issue) => `  ${issue.path.join(".")}: ${issue.message}`
+  );
+
+  issues.unshift(
+    `Invalid data received from backend (${errors.issues.length}):`
+  );
+
+  return issues.join("\n");
+};


### PR DESCRIPTION
Sentry handling doesn't need to be done on package level since we're
doing it on app level. Try to throw useful error messages, taking into
account I don't how much of the error stack is available on Sentry or
NextJs logs this way.

Refs no ticket