### PR TITLE
Use Dapper to fetch package dependants

### DIFF
--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/dependants/page.tsx
@@ -1,18 +1,15 @@
 import { PackageDependantsLayout } from "@thunderstore/cyberstorm";
-import { Package } from "@thunderstore/dapper/types";
 
 export default function Page({
   params,
 }: {
   params: { community: string; namespace: string; package: string };
 }) {
-  // TODO: dummy data for now, the component shouldn't consume Package
-  // object anyway.
-  const packageData = {
-    community_identifier: params.community,
-    namespace: params.namespace,
-    name: params.package,
-  } as Package;
-
-  return <PackageDependantsLayout package={packageData} />;
+  return (
+    <PackageDependantsLayout
+      communityId={params.community}
+      namespaceId={params.namespace}
+      packageName={params.package}
+    />
+  );
 }

--- a/apps/cyberstorm-storybook/stories/components/PackageCard.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/components/PackageCard.stories.tsx
@@ -50,8 +50,8 @@ ReferencePackageCard.args = {
     is_nsfw: false,
     is_deprecated: false,
     categories: [
-      { id: 1, name: "Misc", slug: "misc" },
-      { id: 2, name: "Mods", slug: "mods" },
+      { id: "1", name: "Misc", slug: "misc" },
+      { id: "2", name: "Mods", slug: "mods" },
     ],
   },
 };

--- a/apps/cyberstorm-storybook/stories/layouts/PackageDependantsLayout.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/layouts/PackageDependantsLayout.stories.tsx
@@ -1,6 +1,5 @@
 import { StoryFn, Meta } from "@storybook/react";
 import { PackageDependantsLayout } from "@thunderstore/cyberstorm";
-import { Package } from "@thunderstore/dapper/types";
 import React from "react";
 
 const meta = {
@@ -8,14 +7,12 @@ const meta = {
   component: PackageDependantsLayout,
 } as Meta<typeof PackageDependantsLayout>;
 
-const packageData = {
-  community_identifier: "brotato",
-  namespace: "otDan",
-  name: "WaveTimer",
-} as Package;
-
 const Template: StoryFn<typeof PackageDependantsLayout> = () => (
-  <PackageDependantsLayout package={packageData} />
+  <PackageDependantsLayout
+    communityId="brotato"
+    namespaceId="otDan"
+    packageName="WaveTimer"
+  />
 );
 const PackageDependants = Template.bind({});
 

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -1,5 +1,4 @@
 import { useDapper } from "@thunderstore/dapper";
-import { Package } from "@thunderstore/dapper/types";
 import { usePromise } from "@thunderstore/use-promise";
 
 import styles from "./PackageDependantsLayout.module.css";
@@ -13,28 +12,27 @@ import {
 } from "../../Links/Links";
 import { PackageSearch } from "../../PackageSearch/PackageSearch";
 
-interface PackageDependantsLayoutProps {
-  package: Package;
+interface Props {
+  communityId: string;
+  namespaceId: string;
+  packageName: string;
 }
 
 /**
  * View for listing the packages depending on a given package.
- *
- * TODO: Currently this lists Community's packages as the
- * PackageSearch doesn't support showing dependants.
  */
-export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
-  const { package: pkg } = props;
+export function PackageDependantsLayout(props: Props) {
+  const { communityId, namespaceId, packageName } = props;
 
   const dapper = useDapper();
-  const community = usePromise(dapper.getCommunity, [pkg.community_identifier]);
-  const filters = usePromise(dapper.getCommunityFilters, [
-    pkg.community_identifier,
-  ]);
+  const community = usePromise(dapper.getCommunity, [communityId]);
+  const filters = usePromise(dapper.getCommunityFilters, [communityId]);
 
   const listingType = {
-    kind: "community" as const,
-    communityId: pkg.community_identifier,
+    kind: "package-dependants" as const,
+    communityId,
+    namespaceId,
+    packageName,
   };
 
   return (
@@ -45,19 +43,19 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
       breadCrumb={
         <BreadCrumbs>
           <CommunitiesLink>Communities</CommunitiesLink>
-          <CommunityLink community={community.identifier}>
+          <CommunityLink community={communityId}>
             {community.name}
           </CommunityLink>
           Packages
-          <TeamLink community={pkg.community_identifier} team={pkg.namespace}>
-            {pkg.namespace}
+          <TeamLink community={communityId} team={namespaceId}>
+            {namespaceId}
           </TeamLink>
           <PackageLink
-            community={pkg.community_identifier}
-            namespace={pkg.namespace}
-            package={pkg.name}
+            community={communityId}
+            namespace={namespaceId}
+            package={packageName}
           >
-            {pkg.name}
+            {packageName}
           </PackageLink>
           Dependants
         </BreadCrumbs>
@@ -66,15 +64,15 @@ export function PackageDependantsLayout(props: PackageDependantsLayoutProps) {
         <div className={styles.header}>
           Mods that depend on{" "}
           <PackageLink
-            community={pkg.community_identifier}
-            namespace={pkg.namespace}
-            package={pkg.name}
+            community={communityId}
+            namespace={namespaceId}
+            package={packageName}
           >
-            {pkg.name}
+            {packageName}
           </PackageLink>
           {" by "}
-          <TeamLink community={pkg.community_identifier} team={pkg.namespace}>
-            {pkg.namespace}
+          <TeamLink community={communityId} team={namespaceId}>
+            {namespaceId}
           </TeamLink>
         </div>
       }

--- a/packages/cyberstorm/src/components/PackageSearch/CategoryTagCloud/CategoryTagCloud.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/CategoryTagCloud/CategoryTagCloud.tsx
@@ -24,7 +24,7 @@ export const CategoryTagCloud = (props: Props) => {
     return null;
   }
 
-  const clearCategory = (id: number) =>
+  const clearCategory = (id: string) =>
     setCategories(
       categories.map((c) => (c.id === id ? { ...c, selection: OFF } : c))
     );

--- a/packages/cyberstorm/src/components/PackageSearch/FilterMenus/CategoryMenu.tsx
+++ b/packages/cyberstorm/src/components/PackageSearch/FilterMenus/CategoryMenu.tsx
@@ -21,7 +21,7 @@ interface Props {
 export const CategoryMenu = (props: Props) => {
   const { categories, setCategories } = props;
 
-  const toggleCategory = (id: number) => setCategories(toggle(categories, id));
+  const toggleCategory = (id: string) => setCategories(toggle(categories, id));
 
   return (
     <div className={styles.root}>
@@ -65,7 +65,7 @@ CategoryMenu.displayName = "CategoryMenu";
  *
  * Toggling "off" -> "include" -> "exclude" -> "off"
  */
-const toggle = (categories: CategorySelection[], targetId: number) =>
+const toggle = (categories: CategorySelection[], targetId: string) =>
   categories.map((c) => {
     if (c.id === targetId) {
       const nextIndex = (STATES.indexOf(c.selection) + 1) % STATES.length;

--- a/packages/dapper-fake/src/fakers/utils.ts
+++ b/packages/dapper-fake/src/fakers/utils.ts
@@ -10,17 +10,17 @@ export const getFakeLink = () => ({
 
 export const getFakePackageCategories = (returnAmount?: number) => {
   const categories = [
-    { id: 1, name: "Mods", slug: "mods" },
-    { id: 2, name: "Tools", slug: "tools" },
-    { id: 3, name: "Libraries", slug: "libraries" },
-    { id: 4, name: "Modpacks", slug: "modpacks" },
-    { id: 5, name: "Skins", slug: "skins" },
-    { id: 6, name: "Maps", slug: "maps" },
-    { id: 7, name: "Tweaks", slug: "tweaks" },
-    { id: 8, name: "Items", slug: "items" },
-    { id: 9, name: "Language", slug: "language" },
-    { id: 10, name: "Audio", slug: "audio" },
-    { id: 11, name: "Enemies", slug: "enemies" },
+    { id: "1", name: "Mods", slug: "mods" },
+    { id: "2", name: "Tools", slug: "tools" },
+    { id: "3", name: "Libraries", slug: "libraries" },
+    { id: "4", name: "Modpacks", slug: "modpacks" },
+    { id: "5", name: "Skins", slug: "skins" },
+    { id: "6", name: "Maps", slug: "maps" },
+    { id: "7", name: "Tweaks", slug: "tweaks" },
+    { id: "potato", name: "Items", slug: "items" },
+    { id: "9", name: "Language", slug: "language" },
+    { id: "10", name: "Audio", slug: "audio" },
+    { id: "11", name: "Enemies", slug: "enemies" },
   ];
 
   return faker.helpers.arrayElements(categories, {

--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -1,5 +1,7 @@
 import { DapperTs } from "../index";
 
+const communityId = "riskofrain2";
+const namespaceId = "TestTeam";
 let dapper: DapperTs;
 
 beforeAll(() => {
@@ -11,12 +13,12 @@ it("executes getCommunities without errors", async () => {
 });
 
 it("executes getCommunity without errors", async () => {
-  await expect(dapper.getCommunity("riskofrain2")).resolves.not.toThrowError();
+  await expect(dapper.getCommunity(communityId)).resolves.not.toThrowError();
 });
 
 it("executes getCommunityFilters without errors", async () => {
   await expect(
-    dapper.getCommunityFilters("riskofrain2")
+    dapper.getCommunityFilters(communityId)
   ).resolves.not.toThrowError();
 });
 
@@ -33,24 +35,36 @@ it("executes getPackageDependencies without errors", async () => {
   await expect(dapper.getPackageDependencies()).resolves.not.toThrowError();
 });
 
-it("executes getPackageListings without errors", async () => {
-  await expect(dapper.getPackageListings()).resolves.not.toThrowError();
+it("executes getPackageListings for community without errors", async () => {
+  await expect(
+    dapper.getPackageListings({ kind: "community", communityId })
+  ).resolves.not.toThrowError();
+});
+
+it("executes getPackageListings for namespace without errors", async () => {
+  await expect(
+    dapper.getPackageListings({
+      kind: "namespace",
+      communityId,
+      namespaceId,
+    })
+  ).resolves.not.toThrowError();
 });
 
 it("executes getTeamDetails without errors", async () => {
-  await expect(dapper.getTeamDetails("TestTeam")).resolves.not.toThrowError();
+  await expect(dapper.getTeamDetails(namespaceId)).resolves.not.toThrowError();
 });
 
 // TODO: this should be tested/mocked with sessionId too.
 it("executes getTeamMembers with 401 error", async () => {
-  await expect(dapper.getTeamMembers("TestTeam")).rejects.toThrowError(
+  await expect(dapper.getTeamMembers(namespaceId)).rejects.toThrowError(
     "401: Unauthorized"
   );
 });
 
 // TODO: this should be tested/mocked with sessionId too.
 it("executes getTeamServiceAccounts with 401 error", async () => {
-  await expect(dapper.getTeamServiceAccounts("TestTeam")).rejects.toThrowError(
+  await expect(dapper.getTeamServiceAccounts(namespaceId)).rejects.toThrowError(
     "401: Unauthorized"
   );
 });

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -4,6 +4,7 @@ import { RequestConfig } from "@thunderstore/thunderstore-api";
 import { getCommunities, getCommunity } from "./methods/communities";
 import { getCommunityFilters } from "./methods/communityFilters";
 import { getCurrentUser } from "./methods/currentUser";
+import { getPackageListings } from "./methods/packageListings";
 import {
   getTeamDetails,
   getTeamMembers,
@@ -32,6 +33,7 @@ export class DapperTs implements DapperTsInterface {
     this.getCommunity = this.getCommunity.bind(this);
     this.getCommunityFilters = this.getCommunityFilters.bind(this);
     this.getCurrentUser = this.getCurrentUser.bind(this);
+    this.getPackageListings = this.getPackageListings.bind(this);
     this.getTeamDetails = this.getTeamDetails.bind(this);
     this.getTeamMembers = this.getTeamMembers.bind(this);
     this.getTeamServiceAccounts = this.getTeamServiceAccounts.bind(this);
@@ -41,11 +43,11 @@ export class DapperTs implements DapperTsInterface {
   public getCommunity = getCommunity;
   public getCommunityFilters = getCommunityFilters;
   public getCurrentUser = getCurrentUser;
+  public getPackageListings = getPackageListings;
   public getTeamDetails = getTeamDetails;
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
 
   public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;
-  public getPackageListings = NotImplemented;
 }

--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -6,6 +6,7 @@ import {
 
 import { DapperTsInterface } from "../index";
 import { paginatedResults } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const communitySchema = z.object({
   name: z.string().nonempty(),
@@ -31,8 +32,7 @@ export async function getCommunities(
   const parsed = communitiesSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return {
@@ -50,8 +50,7 @@ export async function getCommunity(
   const parsed = communitySchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -3,6 +3,7 @@ import { fetchCommunityFilters } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
 import { PackageCategory } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const Section = z.object({
   uuid: z.string().uuid(),
@@ -24,8 +25,7 @@ export async function getCommunityFilters(
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -2,12 +2,7 @@ import { z } from "zod";
 import { fetchCommunityFilters } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
-
-const PackageCategory = z.object({
-  id: z.number().nonnegative(),
-  name: z.string().nonempty(),
-  slug: z.string().nonempty(),
-});
+import { PackageCategory } from "../sharedSchemas";
 
 const Section = z.object({
   uuid: z.string().uuid(),

--- a/packages/dapper-ts/src/methods/currentUser.ts
+++ b/packages/dapper-ts/src/methods/currentUser.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { fetchCurrentUser } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
+import { formatErrorMessage } from "../utils";
 
 const oAuthConnectionSchema = z.object({
   provider: z.string().nonempty(),
@@ -42,8 +43,7 @@ export async function getCurrentUser(this: DapperTsInterface) {
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   // For legacy support, the backend returns teams in two formats.

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -34,8 +34,8 @@ export async function getPackageListings(
   ordering = "last-updated",
   page = 1,
   q = "",
-  includedCategories: number[] = [],
-  excludedCategories: number[] = [],
+  includedCategories: string[] = [],
+  excludedCategories: string[] = [],
   section = "",
   nsfw = false,
   deprecated = false

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -8,6 +8,7 @@ import { PackageListingQueryParams } from "@thunderstore/thunderstore-api/types"
 
 import { DapperTsInterface } from "../index";
 import { PackageCategory, paginatedResults } from "../sharedSchemas";
+import { formatErrorMessage } from "../utils";
 
 const packageListingSchema = z.object({
   categories: PackageCategory.array(),
@@ -73,8 +74,7 @@ export async function getPackageListings(
   const parsed = schema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return {

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -3,6 +3,7 @@ import { PackageListingType } from "@thunderstore/dapper/types";
 import {
   fetchCommunityPackageListings,
   fetchNamespacePackageListings,
+  fetchPackageDependantsListings,
 } from "@thunderstore/thunderstore-api";
 import { PackageListingQueryParams } from "@thunderstore/thunderstore-api/types";
 
@@ -63,6 +64,14 @@ export async function getPackageListings(
       this.config,
       type.communityId,
       type.namespaceId,
+      options
+    );
+  } else if (type.kind === "package-dependants") {
+    data = await fetchPackageDependantsListings(
+      this.config,
+      type.communityId,
+      type.namespaceId,
+      type.packageName,
       options
     );
   } else {

--- a/packages/dapper-ts/src/methods/team.ts
+++ b/packages/dapper-ts/src/methods/team.ts
@@ -6,6 +6,7 @@ import {
 } from "@thunderstore/thunderstore-api";
 
 import { DapperTsInterface } from "../index";
+import { formatErrorMessage } from "../utils";
 
 const detailsSchema = z.object({
   identifier: z.number().int().gt(0),
@@ -45,8 +46,7 @@ export async function getTeamMembers(
   const parsed = membersSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;
@@ -68,8 +68,7 @@ export async function getTeamServiceAccounts(
   const parsed = serviceAccountSchema.safeParse(data);
 
   if (!parsed.success) {
-    // TODO: add Sentry support and log parsed.error.
-    throw new Error("Invalid data received from backend");
+    throw new Error(formatErrorMessage(parsed.error));
   }
 
   return parsed.data;

--- a/packages/dapper-ts/src/sharedSchemas.ts
+++ b/packages/dapper-ts/src/sharedSchemas.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+export const PackageCategory = z.object({
+  id: z.number().nonnegative(),
+  name: z.string().nonempty(),
+  slug: z.string().nonempty(),
+});
+
 export const paginatedResults = <T extends z.ZodTypeAny>(resultType: T) =>
   z.object({
     count: z.number().int().min(0),

--- a/packages/dapper-ts/src/sharedSchemas.ts
+++ b/packages/dapper-ts/src/sharedSchemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const PackageCategory = z.object({
-  id: z.number().nonnegative(),
+  id: z.string().nonempty(),
   name: z.string().nonempty(),
   slug: z.string().nonempty(),
 });

--- a/packages/dapper-ts/src/utils.ts
+++ b/packages/dapper-ts/src/utils.ts
@@ -1,0 +1,13 @@
+import { ZodError } from "zod";
+
+export const formatErrorMessage = (errors: ZodError) => {
+  const issues = errors.issues.map(
+    (issue) => `  ${issue.path.join(".")}: ${issue.message}`
+  );
+
+  issues.unshift(
+    `Invalid data received from backend (${errors.issues.length}):`
+  );
+
+  return issues.join("\n");
+};

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -36,8 +36,8 @@ export type GetPackageListings = (
   ordering?: string,
   page?: number,
   q?: string,
-  includedCategories?: number[],
-  excludedCategories?: number[],
+  includedCategories?: string[],
+  excludedCategories?: string[],
   section?: string,
   nsfw?: boolean,
   deprecated?: boolean

--- a/packages/dapper/src/types/props.ts
+++ b/packages/dapper/src/types/props.ts
@@ -13,4 +13,10 @@ export type PackageListingType =
       kind: "namespace";
       communityId: string;
       namespaceId: string;
+    }
+  | {
+      kind: "package-dependants";
+      communityId: string;
+      namespaceId: string;
+      packageName: string;
     };

--- a/packages/dapper/src/types/shared.ts
+++ b/packages/dapper/src/types/shared.ts
@@ -4,7 +4,7 @@ export type DynamicLink = {
 };
 
 export interface PackageCategory {
-  id: number;
+  id: string;
   name: string;
   slug: string;
 }

--- a/packages/thunderstore-api/.gitignore
+++ b/packages/thunderstore-api/.gitignore
@@ -1,3 +1,3 @@
-/dist/
+**/dist/
 /node_modules/
 /tsconfig.tsbuildinfo

--- a/packages/thunderstore-api/package.json
+++ b/packages/thunderstore-api/package.json
@@ -5,9 +5,20 @@
   "repository": "https://github.com/thunderstore-io/thunderstore-ui/",
   "main": "dist/thunderstore-thunderstore-api.cjs.js",
   "module": "dist/thunderstore-thunderstore-api.esm.js",
-  "types": "dist/thunderstore-thunderstore-api.cjs.d.ts",
+  "exports": {
+    ".": {
+      "module": "./dist/thunderstore-thunderstore-api.esm.js",
+      "default": "./dist/thunderstore-thunderstore-api.cjs.js"
+    },
+    "./types": {
+      "module": "./types/dist/thunderstore-thunderstore-api-types.esm.js",
+      "default": "./types/dist/thunderstore-thunderstore-api-types.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "build": "tsc",
@@ -20,5 +31,12 @@
     "@types/jest": "^29.5.3",
     "jest": "^29.6.3",
     "ts-jest": "^29.1.1"
+  },
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts",
+      "types/index.ts"
+    ],
+    "exports": true
   }
 }

--- a/packages/thunderstore-api/src/fetch/__tests__/communityPackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/communityPackageListings.ts
@@ -1,0 +1,18 @@
+import { config } from "./defaultConfig";
+import { fetchCommunityPackageListings } from "../communityPackageListings";
+
+interface PartialPackage {
+  community_identifier: string;
+}
+
+it("receives community scoped paginated package listing", async () => {
+  const communityId = "riskofrain2";
+  const response = await fetchCommunityPackageListings(config, communityId);
+
+  expect(typeof response.count).toEqual("number");
+  expect(Array.isArray(response.results)).toEqual(true);
+
+  response.results.forEach((pkg: PartialPackage) => {
+    expect(pkg.community_identifier.toLowerCase()).toStrictEqual(communityId);
+  });
+});

--- a/packages/thunderstore-api/src/fetch/__tests__/namespacePackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/namespacePackageListings.ts
@@ -1,0 +1,25 @@
+import { config } from "./defaultConfig";
+import { fetchNamespacePackageListings } from "../namespacePackageListings";
+
+interface PartialPackage {
+  community_identifier: string;
+  namespace: string;
+}
+
+it("receives namespace scoped paginated package listing", async () => {
+  const communityId = "riskofrain2";
+  const namespaceId = "testteam";
+  const response = await fetchNamespacePackageListings(
+    config,
+    communityId,
+    namespaceId
+  );
+
+  expect(typeof response.count).toEqual("number");
+  expect(Array.isArray(response.results)).toEqual(true);
+
+  response.results.forEach((pkg: PartialPackage) => {
+    expect(pkg.community_identifier.toLowerCase()).toStrictEqual(communityId);
+    expect(pkg.namespace.toLowerCase()).toStrictEqual(namespaceId);
+  });
+});

--- a/packages/thunderstore-api/src/fetch/__tests__/packageDependantsListings.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/packageDependantsListings.ts
@@ -1,0 +1,26 @@
+import { config } from "./defaultConfig";
+import { fetchPackageDependantsListings } from "../packageDependantsListings";
+
+interface PartialPackage {
+  community_identifier: string;
+  namespace: string;
+}
+
+it("receives listing of packages depending on given package", async () => {
+  const communityId = "riskofrain2";
+  const namespaceId = "testteam";
+  const packageName = "packagename";
+  const response = await fetchPackageDependantsListings(
+    config,
+    communityId,
+    namespaceId,
+    packageName
+  );
+
+  expect(typeof response.count).toEqual("number");
+  expect(Array.isArray(response.results)).toEqual(true);
+
+  response.results.forEach((pkg: PartialPackage) => {
+    expect(pkg.community_identifier.toLowerCase()).toStrictEqual(communityId);
+  });
+});

--- a/packages/thunderstore-api/src/fetch/communityPackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/communityPackageListings.ts
@@ -1,0 +1,26 @@
+import { RequestConfig } from "../index";
+import { apiFetch } from "../apiFetch";
+import { serializeQueryString } from "../queryString";
+import { PackageListingQueryParams } from "../types";
+
+export async function fetchCommunityPackageListings(
+  config: RequestConfig,
+  communityId: string,
+  options?: PackageListingQueryParams
+) {
+  const path = `api/cyberstorm/package/${communityId.toLowerCase()}/`;
+
+  const queryParams = [
+    { key: "ordering", value: options?.ordering, impotent: "last-updated" },
+    { key: "page", value: options?.page, impotent: 1 },
+    { key: "q", value: options?.q.trim() },
+    { key: "included_categories", value: options?.includedCategories },
+    { key: "excluded_categories", value: options?.excludedCategories },
+    { key: "section", value: options?.section },
+    { key: "nsfw", value: options?.nsfw, impotent: false },
+    { key: "deprecated", value: options?.deprecated, impotent: false },
+  ];
+  const query = serializeQueryString(queryParams);
+
+  return await apiFetch(config, path, query);
+}

--- a/packages/thunderstore-api/src/fetch/namespacePackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/namespacePackageListings.ts
@@ -1,0 +1,27 @@
+import { RequestConfig } from "../index";
+import { apiFetch } from "../apiFetch";
+import { serializeQueryString } from "../queryString";
+import { PackageListingQueryParams } from "../types";
+
+export async function fetchNamespacePackageListings(
+  config: RequestConfig,
+  communityId: string,
+  namespaceId: string,
+  options?: PackageListingQueryParams
+) {
+  const path = `api/cyberstorm/package/${communityId.toLowerCase()}/${namespaceId.toLowerCase()}/`;
+
+  const queryParams = [
+    { key: "ordering", value: options?.ordering, impotent: "last-updated" },
+    { key: "page", value: options?.page, impotent: 1 },
+    { key: "q", value: options?.q.trim() },
+    { key: "included_categories", value: options?.includedCategories },
+    { key: "excluded_categories", value: options?.excludedCategories },
+    { key: "section", value: options?.section },
+    { key: "nsfw", value: options?.nsfw, impotent: false },
+    { key: "deprecated", value: options?.deprecated, impotent: false },
+  ];
+  const query = serializeQueryString(queryParams);
+
+  return await apiFetch(config, path, query);
+}

--- a/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
+++ b/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
@@ -1,0 +1,31 @@
+import { RequestConfig } from "../index";
+import { apiFetch } from "../apiFetch";
+import { serializeQueryString } from "../queryString";
+import { PackageListingQueryParams } from "../types";
+
+export async function fetchPackageDependantsListings(
+  config: RequestConfig,
+  communityId: string,
+  namespaceId: string,
+  packageName: string,
+  options?: PackageListingQueryParams
+) {
+  const c = communityId.toLocaleLowerCase();
+  const n = namespaceId.toLocaleLowerCase();
+  const p = packageName.toLocaleLowerCase();
+  const path = `api/cyberstorm/package/${c}/${n}/${p}/dependants/`;
+
+  const queryParams = [
+    { key: "ordering", value: options?.ordering, impotent: "last-updated" },
+    { key: "page", value: options?.page, impotent: 1 },
+    { key: "q", value: options?.q.trim() },
+    { key: "included_categories", value: options?.includedCategories },
+    { key: "excluded_categories", value: options?.excludedCategories },
+    { key: "section", value: options?.section },
+    { key: "nsfw", value: options?.nsfw, impotent: false },
+    { key: "deprecated", value: options?.deprecated, impotent: false },
+  ];
+  const query = serializeQueryString(queryParams);
+
+  return await apiFetch(config, path, query);
+}

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -9,7 +9,9 @@ export interface RequestConfig {
 export * from "./fetch/community";
 export * from "./fetch/communityFilters";
 export * from "./fetch/communityList";
+export * from "./fetch/communityPackageListings";
 export * from "./fetch/currentUser";
+export * from "./fetch/namespacePackageListings";
 export * from "./fetch/teamDetails";
 export * from "./fetch/teamMembers";
 export * from "./fetch/teamServiceAccounts";

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -12,6 +12,7 @@ export * from "./fetch/communityList";
 export * from "./fetch/communityPackageListings";
 export * from "./fetch/currentUser";
 export * from "./fetch/namespacePackageListings";
+export * from "./fetch/packageDependantsListings";
 export * from "./fetch/teamDetails";
 export * from "./fetch/teamMembers";
 export * from "./fetch/teamServiceAccounts";

--- a/packages/thunderstore-api/src/types/index.ts
+++ b/packages/thunderstore-api/src/types/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Parameters for ordering, paginating, and filtering package lists.
+ */
+export interface PackageListingQueryParams {
+  /** Ordering for the results */
+  ordering: string;
+  /** Page number for the paginated results */
+  page: number;
+  /** Free text search for filtering e.g. by package name */
+  q: string;
+  /** Ids of categories the package MUST belong to */
+  includedCategories: number[];
+  /** Ids of categories the package MUST NOT belong to */
+  excludedCategories: number[];
+  /**
+   * UUID of community's section the package MUST fit.
+   *
+   * Sections are community-specific shorthands for filtering by
+   * multiple included and excluded categories at once.
+   * */
+  section: string;
+  /** Should NSFW packages be included (by default they're not) */
+  nsfw: boolean;
+  /** Should deprecated packages be included (by default they're not) */
+  deprecated: boolean;
+}

--- a/packages/thunderstore-api/src/types/index.ts
+++ b/packages/thunderstore-api/src/types/index.ts
@@ -9,9 +9,9 @@ export interface PackageListingQueryParams {
   /** Free text search for filtering e.g. by package name */
   q: string;
   /** Ids of categories the package MUST belong to */
-  includedCategories: number[];
+  includedCategories: string[];
   /** Ids of categories the package MUST NOT belong to */
-  excludedCategories: number[];
+  excludedCategories: string[];
   /**
    * UUID of community's section the package MUST fit.
    *

--- a/packages/thunderstore-api/types/package.json
+++ b/packages/thunderstore-api/types/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/thunderstore-thunderstore-api-types.cjs.js",
+  "module": "dist/thunderstore-thunderstore-api-types.esm.js"
+}


### PR DESCRIPTION
Also contains changes from PRs #901, #902, #904, and #913, which couldn't be merged due to tests in the first PR getting outdated while waiting for the backend changes to get merged.