### PR TITLE
Prepare PackageDetailLayout for Dapper implementation

### DIFF
--- a/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
+++ b/apps/cyberstorm-nextjs/app/c/[community]/p/[namespace]/[package]/page.tsx
@@ -7,8 +7,8 @@ export default function Page({
 }) {
   return (
     <PackageDetailLayout
-      community={params.community}
-      namespace={params.namespace}
+      communityId={params.community}
+      namespaceId={params.namespace}
       packageName={params.package}
     />
   );

--- a/apps/cyberstorm-storybook/stories/layouts/PackageDetailLayout.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/layouts/PackageDetailLayout.stories.tsx
@@ -8,28 +8,14 @@ const meta = {
 } as Meta<typeof PackageDetailLayout>;
 
 const Template: StoryFn<typeof PackageDetailLayout> = (args) => (
-  <div>
-    <PackageDetailLayout {...args} />
-  </div>
+  <PackageDetailLayout {...args} />
 );
 
-const defaultArgs = {
-  community: "Train City 2042",
-  namespace: "Mechanics",
-  packagepackageNameId: "Thomas the Dankiest Engine",
-};
-
 const ReferencePackageDetailLayout = Template.bind({});
-ReferencePackageDetailLayout.args = defaultArgs;
-
-const ManagePackageDetailLayout = Template.bind({});
-ManagePackageDetailLayout.args = {
-  ...defaultArgs,
-  managementDialogIsOpen: true,
+ReferencePackageDetailLayout.args = {
+  communityId: "Train City 2042",
+  namespaceId: "Mechanics",
+  packageName: "Thomas the Dankiest Engine",
 };
 
-export {
-  meta as default,
-  ReferencePackageDetailLayout as PackageDetails,
-  ManagePackageDetailLayout as PackageDetailsDialog,
-};
+export { meta as default, ReferencePackageDetailLayout as PackageDetails };

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.tsx
@@ -1,55 +1,49 @@
-import styles from "../PackageDependencyDialog/PackageDependencyDialog.module.css";
 import { PackageDependency } from "@thunderstore/dapper/types";
+
+import styles from "../PackageDependencyDialog/PackageDependencyDialog.module.css";
 import { PackageLink, PackageVersionLink } from "../../../../Links/Links";
 
-export interface PackageDependencyDialogProps {
-  packages?: PackageDependency[];
+export interface Props {
+  packages: PackageDependency[];
 }
 
-export function PackageDependencyDialog(props: PackageDependencyDialogProps) {
-  const { packages = [] } = props;
-  return (
-    <div className={styles.root}>
-      {packages.map((packageData, index) => {
-        return (
-          <div key={index} className={styles.item}>
-            <img
-              className={styles.image}
-              src={packageData.imageSource}
-              alt={`Thumbnail of the package ${packageData.name}`}
-            />
-            <div>
-              <div className={styles.title}>
-                <PackageLink
-                  community={packageData.community}
-                  namespace={packageData.namespace}
-                  package={packageData.name}
-                >
-                  {packageData.name}
-                </PackageLink>
-              </div>
-              <div className={styles.description}>
-                {packageData.shortDescription}
-              </div>
-              <p className={styles.preferredVersion}>
-                Preferred version:{" "}
-                <span className={styles.preferredVersion__version}>
-                  <PackageVersionLink
-                    community={packageData.community}
-                    namespace={packageData.namespace}
-                    package={packageData.name}
-                    version={packageData.version}
-                  >
-                    {packageData.version}
-                  </PackageVersionLink>
-                </span>
-              </p>
-            </div>
+export const PackageDependencyDialog = (props: Props) => (
+  <div className={styles.root}>
+    {props.packages.map((packageData, index) => (
+      <div key={index} className={styles.item}>
+        <img
+          className={styles.image}
+          src={packageData.icon_url ?? undefined}
+          alt=""
+        />
+        <div>
+          <div className={styles.title}>
+            <PackageLink
+              community={packageData.community_identifier}
+              namespace={packageData.namespace}
+              package={packageData.name}
+            >
+              {packageData.name}
+            </PackageLink>
           </div>
-        );
-      })}
-    </div>
-  );
-}
+          <div className={styles.description}>{packageData.description}</div>
+          <p className={styles.preferredVersion}>
+            Preferred version:{" "}
+            <span className={styles.preferredVersion__version}>
+              <PackageVersionLink
+                community={packageData.community_identifier}
+                namespace={packageData.namespace}
+                package={packageData.name}
+                version={packageData.version_number}
+              >
+                {packageData.version_number}
+              </PackageVersionLink>
+            </span>
+          </p>
+        </div>
+      </div>
+    ))}
+  </div>
+);
 
 PackageDependencyDialog.displayName = "PackageDependencyDialog";

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
@@ -28,23 +28,19 @@ function PackageDependencyListItem(props: PackageDependencyListItemProps) {
 
   return (
     <PackageLink
-      package={packageData.name}
-      community={packageData.community}
+      community={packageData.community_identifier}
       namespace={packageData.namespace}
+      package={packageData.name}
     >
       <div className={styles.item}>
         <img
-          src={
-            packageData.imageSource ? packageData.imageSource : defaultImageSrc
-          }
+          src={packageData.icon_url ?? defaultImageSrc}
           className={styles.itemImage}
-          alt={packageData.name}
+          alt=""
         />
         <div>
           <div className={styles.itemTitle}>{packageData.name}</div>
-          <p className={styles.itemDescription}>
-            {packageData.shortDescription}
-          </p>
+          <p className={styles.itemDescription}>{packageData.description}</p>
         </div>
       </div>
     </PackageLink>

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faUsers } from "@fortawesome/pro-regular-svg-icons";
 import {
   faDonate,
@@ -116,21 +116,6 @@ export function PackageDetailLayout(props: Props) {
       </a>
     );
   }
-  if (packageData.discordLink) {
-    packageDetailsMeta.push(
-      <a key="discord" href={packageData.discordLink}>
-        <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
-          <Button.ButtonIcon>
-            <FontAwesomeIcon icon={faDiscord} />
-          </Button.ButtonIcon>
-          <Button.ButtonLabel>Discord</Button.ButtonLabel>
-          <Button.ButtonIcon>
-            <FontAwesomeIcon icon={faArrowUpRight} />
-          </Button.ButtonIcon>
-        </Button.Root>
-      </a>
-    );
-  }
 
   return (
     <BaseLayout
@@ -164,7 +149,7 @@ export function PackageDetailLayout(props: Props) {
                 />
               ) : undefined
             }
-            description={packageData.shortDescription}
+            description={packageData.description}
             meta={packageDetailsMeta}
           />
           <div className={styles.headerActions}>

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -1,17 +1,6 @@
 "use client";
-import styles from "./PackageDetailLayout.module.css";
-import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
-import {
-  CommunitiesLink,
-  CommunityLink,
-  PackageDependantsLink,
-  TeamLink,
-} from "../../Links/Links";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import * as Button from "../../Button/";
-import { PackageManagementForm } from "./PackageManagementForm/PackageManagementForm";
-import { BaseLayout } from "../BaseLayout/BaseLayout";
-import { MetaInfoItemList } from "../../MetaInfoItemList/MetaInfoItemList";
+import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
+import { faUsers } from "@fortawesome/pro-regular-svg-icons";
 import {
   faDonate,
   faDownload,
@@ -24,28 +13,40 @@ import {
   faArrowUpRight,
   faBoxes,
 } from "@fortawesome/pro-solid-svg-icons";
-import { faUsers } from "@fortawesome/pro-regular-svg-icons";
-import { PackageDependencyList } from "./PackageDependencyList/PackageDependencyList";
-import { CopyButton } from "../../CopyButton/CopyButton";
-import { formatFileSize, formatInteger } from "../../../utils/utils";
-import { useState } from "react";
-import { Tabs } from "../../Tabs/Tabs";
-import { PackageChangeLog } from "./PackageChangeLog/PackageChangeLog";
-import { PackageVersions } from "./PackageVersions/PackageVersions";
-import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
-import { PageHeader } from "../BaseLayout/PageHeader/PageHeader";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useDapper } from "@thunderstore/dapper";
 import { Package } from "@thunderstore/dapper/types";
+import { usePromise } from "@thunderstore/use-promise";
+import { useState } from "react";
+
+import { PackageChangeLog } from "./PackageChangeLog/PackageChangeLog";
+import styles from "./PackageDetailLayout.module.css";
+import { PackageDependencyList } from "./PackageDependencyList/PackageDependencyList";
+import { PackageManagementForm } from "./PackageManagementForm/PackageManagementForm";
 import { PackageTagList } from "./PackageTagList/PackageTagList";
 import { PackageTeamMemberList } from "./PackageTeamMemberList/PackageTeamMemberList";
-import { ThunderstoreLogo } from "../../../svg/svg";
-import { usePromise } from "@thunderstore/use-promise";
-import { WrapperCard } from "../../WrapperCard/WrapperCard";
-import { Tag } from "../../Tag/Tag";
-import { Icon } from "../../Icon/Icon";
+import { PackageVersions } from "./PackageVersions/PackageVersions";
+import { PageHeader } from "../BaseLayout/PageHeader/PageHeader";
 import { PLACEHOLDER } from "../Developers/MarkdownPreview/MarkdownPlaceholder";
+import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
+import * as Button from "../../Button/";
+import {
+  CommunitiesLink,
+  CommunityLink,
+  PackageDependantsLink,
+  TeamLink,
+} from "../../Links/Links";
+import { BaseLayout } from "../BaseLayout/BaseLayout";
+import { CopyButton } from "../../CopyButton/CopyButton";
+import * as Dialog from "../../Dialog";
+import { Icon } from "../../Icon/Icon";
 import markdownStyles from "../../Markdown/Markdown.module.css";
-import { Dialog } from "../../..";
+import { MetaInfoItemList } from "../../MetaInfoItemList/MetaInfoItemList";
+import { Tabs } from "../../Tabs/Tabs";
+import { Tag } from "../../Tag/Tag";
+import { WrapperCard } from "../../WrapperCard/WrapperCard";
+import { ThunderstoreLogo } from "../../../svg/svg";
+import { formatFileSize, formatInteger } from "../../../utils/utils";
 
 export interface PackageDetailLayoutProps {
   community: string;
@@ -69,15 +70,16 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
     namespace,
     packageName,
   } = props;
+
+  const [currentTab, setCurrentTab] = useState(1);
   const dapper = useDapper();
   const packageData = usePromise(dapper.getPackage, [
     community,
     namespace,
     packageName,
   ]);
-  const metaInfoData = getMetaInfoData(packageData);
 
-  const [currentTab, setCurrentTab] = useState(1);
+  const metaInfoData = getMetaInfoData(packageData);
 
   const mappedPackageTagList = packageData.categories.map((category) => {
     return (

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -48,11 +48,10 @@ import { WrapperCard } from "../../WrapperCard/WrapperCard";
 import { ThunderstoreLogo } from "../../../svg/svg";
 import { formatFileSize, formatInteger } from "../../../utils/utils";
 
-export interface PackageDetailLayoutProps {
-  community: string;
-  namespace: string;
+export interface Props {
+  communityId: string;
+  namespaceId: string;
   packageName: string;
-  managementDialogIsOpen?: boolean;
 }
 
 /**
@@ -63,19 +62,14 @@ export interface PackageDetailLayoutProps {
  *       than undefined if image URLs are not available, as this is what
  *       backend returns. (Unless we have a default image.)
  */
-export function PackageDetailLayout(props: PackageDetailLayoutProps) {
-  const {
-    managementDialogIsOpen = false,
-    community,
-    namespace,
-    packageName,
-  } = props;
+export function PackageDetailLayout(props: Props) {
+  const { communityId, namespaceId, packageName } = props;
 
   const [currentTab, setCurrentTab] = useState(1);
   const dapper = useDapper();
   const packageData = usePromise(dapper.getPackage, [
-    community,
-    namespace,
+    communityId,
+    namespaceId,
     packageName,
   ]);
 
@@ -175,7 +169,6 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
           />
           <div className={styles.headerActions}>
             <Dialog.Root
-              defaultOpen={managementDialogIsOpen}
               title="Manage Package"
               trigger={
                 <Button.Root colorScheme="primary" paddingSize="medium">
@@ -259,7 +252,10 @@ export function PackageDetailLayout(props: PackageDetailLayoutProps) {
             }
           />
           <PackageTagList packageData={packageData} />
-          <PackageDependencyList namespace={namespace} community={community} />
+          <PackageDependencyList
+            namespace={namespaceId}
+            community={communityId}
+          />
           <PackageTeamMemberList
             community={packageData.community_identifier}
             teamName={packageData.namespace}

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faUsers } from "@fortawesome/pro-regular-svg-icons";
 import {
   faDonate,
@@ -99,23 +98,16 @@ export function PackageDetailLayout(props: Props) {
         <Button.ButtonLabel>{packageData.namespace}</Button.ButtonLabel>
       </Button.Root>
     </TeamLink>,
-  ];
 
-  if (packageData.gitHubLink) {
-    packageDetailsMeta.push(
-      <a key="github" href={packageData.gitHubLink}>
-        <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
-          <Button.ButtonIcon>
-            <FontAwesomeIcon icon={faGithub} />
-          </Button.ButtonIcon>
-          <Button.ButtonLabel>GitHub</Button.ButtonLabel>
-          <Button.ButtonIcon>
-            <FontAwesomeIcon icon={faArrowUpRight} />
-          </Button.ButtonIcon>
-        </Button.Root>
-      </a>
-    );
-  }
+    <a key="website" href={packageData.website_url}>
+      <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
+        <Button.ButtonLabel>{packageData.website_url}</Button.ButtonLabel>
+        <Button.ButtonIcon>
+          <FontAwesomeIcon icon={faArrowUpRight} />
+        </Button.ButtonIcon>
+      </Button.Root>
+    </a>,
+  ];
 
   return (
     <BaseLayout
@@ -263,8 +255,8 @@ function getMetaInfoData(packageData: Package) {
     },
     {
       key: "2",
-      label: "First Updated",
-      content: <>{packageData.firstUploaded}</>,
+      label: "First Uploaded",
+      content: <>{packageData.datetime_created}</>,
     },
     {
       key: "3",
@@ -287,12 +279,12 @@ function getMetaInfoData(packageData: Package) {
       content: (
         <div className={styles.dependencyStringWrapper}>
           <div
-            title={packageData.dependencyString}
+            title={packageData.full_version_name}
             className={styles.dependencyString}
           >
-            {packageData.dependencyString}
+            {packageData.full_version_name}
           </div>
-          <CopyButton text={packageData.dependencyString} />
+          <CopyButton text={packageData.full_version_name} />
         </div>
       ),
     },
@@ -306,7 +298,7 @@ function getMetaInfoData(packageData: Package) {
           package={packageData.name}
         >
           <div className={styles.dependantsLink}>
-            {packageData.dependantCount + " other mods"}
+            {packageData.dependant_count + " other mods"}
           </div>
         </PackageDependantsLink>
       ),

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -91,10 +91,7 @@ export { HomeLayout } from "./components/Layout/HomeLayout/HomeLayout";
 export { LoginLayout } from "./components/Layout/LoginLayout/LoginLayout";
 export { BetaLoginLayout } from "./components/Layout/LoginLayout/BetaLoginLayout";
 export { CommunityProfileLayout } from "./components/Layout/CommunityProfileLayout/CommunityProfileLayout";
-export {
-  PackageDetailLayout,
-  type PackageDetailLayoutProps,
-} from "./components/Layout/PackageDetailLayout/PackageDetailLayout";
+export { PackageDetailLayout } from "./components/Layout/PackageDetailLayout/PackageDetailLayout";
 export { PackageDependantsLayout } from "./components/Layout/PackageDependantsLayout/PackageDependantsLayout";
 export { SettingsLayout } from "./components/Layout/Settings/SettingsLayout";
 export { TeamSettingsLayout } from "./components/Layout/Teams/TeamSettings/TeamSettingsLayout";

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -79,16 +79,13 @@ export const getFakePackage = async (
   return {
     ...getFakePackagePreview(community, namespace),
 
-    community_identifier: community,
     community_name: faker.word.sample(),
-    discordLink: faker.internet.url(),
     author: faker.person.fullName(),
     dependantCount: faker.number.int({ min: 0, max: 2000 }),
     dependencies: await getFakeDependencies(community, namespace, name),
     dependencyString: faker.string.uuid(),
     firstUploaded: faker.date.past({ years: 2 }).toDateString(),
     gitHubLink: faker.internet.url(),
-    shortDescription: faker.company.buzzPhrase(),
     team: {
       name: faker.word.words(3),
       members: await getFakeTeamMembers(seed),

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -51,9 +51,6 @@ export const getFakePackageListings = async (
   ),
 });
 
-// TODO: the methods below this point don't yet match what the backend
-// will be actually returning.
-
 export const getFakeDependencies = async (
   community: string,
   namespace: string,
@@ -63,11 +60,16 @@ export const getFakeDependencies = async (
   setSeed(`${community}-${namespace}-${name ?? "package"}`);
 
   return range(count).map(() => ({
-    ...getPackageBase(community, namespace),
-    version: getVersionNumber(),
+    community_identifier: community,
+    description: faker.company.buzzPhrase(),
+    icon_url: faker.helpers.maybe(getFakeImg, { probability: 0.9 }) ?? null,
+    name: (name ?? faker.word.words(3)).split(" ").join("_"),
+    namespace,
+    version_number: getVersionNumber(),
   }));
 };
 
+// Content used to render Package's detail view.
 export const getFakePackage = async (
   community: string,
   namespace: string,
@@ -92,18 +94,6 @@ export const getFakePackage = async (
     website_url: faker.internet.url(),
   };
 };
-
-const getPackageBase = (
-  community?: string,
-  namespace?: string,
-  name?: string
-) => ({
-  community: community ?? faker.word.sample(),
-  namespace: namespace ?? faker.word.sample(),
-  name: (name ?? faker.word.words(3)).split(" ").join("_"),
-  shortDescription: faker.company.buzzPhrase(),
-  imageSource: getFakeImg(),
-});
 
 const getPackageVersion = () => ({
   version_number: getVersionNumber(),

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -18,7 +18,7 @@ const getFakePackagePreview = (community?: string, namespace?: string) => {
     is_deprecated: faker.datatype.boolean(0.1),
     is_nsfw: faker.datatype.boolean(0.1),
     is_pinned: faker.datatype.boolean(0.1),
-    last_updated: faker.date.recent({ days: 700 }).toDateString(),
+    last_updated: faker.date.recent({ days: 700 }).toISOString(),
     name: faker.word.words(3).split(" ").join("_"),
     namespace: namespace ?? faker.word.sample(),
     rating_count: faker.number.int({ min: 0, max: 100000 }),
@@ -80,17 +80,16 @@ export const getFakePackage = async (
     ...getFakePackagePreview(community, namespace),
 
     community_name: faker.word.sample(),
-    author: faker.person.fullName(),
-    dependantCount: faker.number.int({ min: 0, max: 2000 }),
+    datetime_created: faker.date.past({ years: 2 }).toISOString(),
+    dependant_count: faker.number.int({ min: 0, max: 2000 }),
     dependencies: await getFakeDependencies(community, namespace, name),
-    dependencyString: faker.string.uuid(),
-    firstUploaded: faker.date.past({ years: 2 }).toDateString(),
-    gitHubLink: faker.internet.url(),
+    full_version_name: `${namespace}-${name}-${getVersionNumber()}`,
     team: {
       name: faker.word.words(3),
       members: await getFakeTeamMembers(seed),
     },
     versions: range(20).map(getPackageVersion),
+    website_url: faker.internet.url(),
   };
 };
 

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -106,10 +106,10 @@ const getPackageBase = (
 });
 
 const getPackageVersion = () => ({
-  version: getVersionNumber(),
+  version_number: getVersionNumber(),
   changelog: faker.company.buzzPhrase(),
-  uploadDate: faker.date.recent({ days: 700 }).toDateString(),
-  downloadCount: faker.number.int({ min: 1000000, max: 10000000 }),
+  datetime_created: faker.date.recent({ days: 700 }).toISOString(),
+  download_count: faker.number.int({ min: 1000000, max: 10000000 }),
 });
 
 const getVersionNumber = (min = 0, max = 10) => {

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -26,7 +26,7 @@ export interface Package extends PackagePreview {
   dependencies?: PackageDependency[];
   full_version_name: string;
   team: PackageTeam;
-  versions?: PackageVersion[];
+  versions: PackageVersion[];
   website_url: string;
 }
 
@@ -45,8 +45,8 @@ interface PackageTeam {
 }
 
 interface PackageVersion {
-  version: string;
+  version_number: string;
   changelog: string;
-  uploadDate: string;
-  downloadCount: number;
+  datetime_created: string;
+  download_count: number;
 }

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -21,10 +21,7 @@ export type PackagePreviews = PaginatedList<PackagePreview>;
 
 export interface Package extends PackagePreview {
   community_name: string;
-  shortDescription?: string;
-  additionalImages?: string[];
   gitHubLink?: string;
-  discordLink?: string;
   firstUploaded?: string;
   dependencyString: string;
   dependencies?: PackageDependency[];

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -21,13 +21,13 @@ export type PackagePreviews = PaginatedList<PackagePreview>;
 
 export interface Package extends PackagePreview {
   community_name: string;
-  gitHubLink?: string;
-  firstUploaded?: string;
-  dependencyString: string;
+  datetime_created: string;
+  dependant_count: number;
   dependencies?: PackageDependency[];
-  dependantCount: number;
+  full_version_name: string;
   team: PackageTeam;
   versions?: PackageVersion[];
+  website_url: string;
 }
 
 export interface PackageDependency {

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -23,7 +23,6 @@ export interface Package extends PackagePreview {
   community_name: string;
   datetime_created: string;
   dependant_count: number;
-  dependencies?: PackageDependency[];
   full_version_name: string;
   team: PackageTeam;
   versions: PackageVersion[];
@@ -31,12 +30,12 @@ export interface Package extends PackagePreview {
 }
 
 export interface PackageDependency {
+  community_identifier: string;
+  description: string;
+  icon_url: string | null;
   name: string;
   namespace: string;
-  community: string;
-  shortDescription: string;
-  imageSource?: string;
-  version: string;
+  version_number: string;
 }
 
 interface PackageTeam {


### PR DESCRIPTION
@thunderstore/cyberstorm: light cleanup for PackageDetailLayout

Reorder things for better readability.

Refs TS-1979

@thunderstore/cyberstorm: adjust PackageDetailLayout props

- Use the same prop names as the other layouts that accept the same
  props, like PackageDependantsLayout
- Don't export the prop type since it's not necessary
- Remove managementDialogIsOpen prop from the layout. This was used to
  control Storybook stories, but by and large makes little sense on a
  layout component. Considered removing the prop from the Dialog
  component altogether but decided to leave it for now to avoid scope
  creep
- Remove the aforementioned Storybook story and cleanup the related
  code

Refs TS-1979

@thunderstore/dapper: remove fields from Package interface

- Remove shortDescription somce backend only has one description to
  return, and it's already included in the Package interface via
  PackagePreview interface
- Remove additionalImages since we don't have any and they aren't
  used anyway
- Remove discordLink since package doesn't have one. Community might
  have one, but I don't think it makes sense to show it on package's
  detail page, since the package or its author might have nothing to
  do with that Discord server

Refs TS-1979

@thunderstore/dapper: rename Package interface fields

- Rename githubLink to website_url. Package has one link, but it
  doesn't necessarily point to GitHub. The link is guaranteed to exist,
  since it's a required field in the package's manifest.json. Rendering
  imitates how the old website renders these links
- Rename firstUploaded to datetime_created. This is consistent with
  other fields returned by Dapper (for some reason backend has named this
  field date_created, although it's a datatime field). The field is
  guaranteed to exist, obviously. Fix the label shown in the UI. Fix the
  data returned by dapper-fake to match the format backend actually
  returns
- Rename dependencyString to full_version_name to match backend naming.
  Fix the data returned by dapper-fake to something more authentic
- Rename dependantCount to dependant_count to match backend naming

Refs TS-1979

@thunderstore/dapper: rename Package.versions fields

- Rename version to version_number and downloadCount to download_count
  to match the naming in backend
- Rename uploadDate to datetime_created and and change the format in
  dapper-fake to match the data returned by backend
- Since the versions are shown on a separate tab, the versions might
  end up being fetched with a separate dedicated dapper call in the
  future

Refs TS-1979

@thunderstore/dapper: rename PackageDependency fields

- Rename fields to match backend naming
- Change dapper-fake to return data matchign the actual data
- Remove dependencies field from Package interface since it's really
  not used there. Dependencies have their own (unimplemented) Dapper
  method

Refs TS-1979