### PR TITLE
@thunderstore/cyberstorm: add PackageMetaItems

### DIFF
--- a/apps/cyberstorm-storybook/stories/components/MetaInfoItem.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/components/MetaInfoItem.stories.tsx
@@ -1,17 +1,11 @@
 import { StoryFn, Meta } from "@storybook/react";
-import {
-  CopyButton,
-  MetaInfoItem,
-  MetaInfoItemProps,
-} from "@thunderstore/cyberstorm";
+import { CopyButton, MetaInfoItem } from "@thunderstore/cyberstorm";
 import React from "react";
 
 const meta = {
   title: "Cyberstorm/Components/MetaInfoItem",
   component: MetaInfoItem,
 } as Meta<typeof MetaInfoItem>;
-
-const defaultArgs: MetaInfoItemProps = {};
 
 const Template: StoryFn<typeof MetaInfoItem> = (args) => (
   <div style={{ width: "400px" }}>
@@ -21,14 +15,12 @@ const Template: StoryFn<typeof MetaInfoItem> = (args) => (
 
 const ReferenceMetaInfoItem = Template.bind({});
 ReferenceMetaInfoItem.args = {
-  ...defaultArgs,
   label: "Likes",
   content: "375",
 };
 
 const MetaInfoItemWithCopyButton = Template.bind({});
 MetaInfoItemWithCopyButton.args = {
-  ...defaultArgs,
   label: "Server code",
   content: (
     <>

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -22,6 +22,7 @@ import { PackageChangeLog } from "./PackageChangeLog/PackageChangeLog";
 import styles from "./PackageDetailLayout.module.css";
 import { PackageDependencyList } from "./PackageDependencyList/PackageDependencyList";
 import { PackageManagementForm } from "./PackageManagementForm/PackageManagementForm";
+import { PackageMetaItems } from "./PackageMetaItems/PackageMetaItems";
 import { PackageTagList } from "./PackageTagList/PackageTagList";
 import { PackageTeamMemberList } from "./PackageTeamMemberList/PackageTeamMemberList";
 import { PackageVersions } from "./PackageVersions/PackageVersions";
@@ -29,23 +30,15 @@ import { PageHeader } from "../BaseLayout/PageHeader/PageHeader";
 import { PLACEHOLDER } from "../Developers/MarkdownPreview/MarkdownPlaceholder";
 import { BreadCrumbs } from "../../BreadCrumbs/BreadCrumbs";
 import * as Button from "../../Button/";
-import {
-  CommunitiesLink,
-  CommunityLink,
-  PackageDependantsLink,
-  TeamLink,
-} from "../../Links/Links";
+import { CommunitiesLink, CommunityLink, TeamLink } from "../../Links/Links";
 import { BaseLayout } from "../BaseLayout/BaseLayout";
-import { CopyButton } from "../../CopyButton/CopyButton";
 import * as Dialog from "../../Dialog";
 import { Icon } from "../../Icon/Icon";
 import markdownStyles from "../../Markdown/Markdown.module.css";
-import { MetaInfoItemList } from "../../MetaInfoItemList/MetaInfoItemList";
 import { Tabs } from "../../Tabs/Tabs";
 import { Tag } from "../../Tag/Tag";
 import { WrapperCard } from "../../WrapperCard/WrapperCard";
 import { ThunderstoreLogo } from "../../../svg/svg";
-import { formatFileSize, formatInteger } from "../../../utils/utils";
 
 export interface Props {
   communityId: string;
@@ -71,8 +64,6 @@ export function PackageDetailLayout(props: Props) {
     namespaceId,
     packageName,
   ]);
-
-  const metaInfoData = getMetaInfoData(packageData);
 
   const mappedPackageTagList = packageData.categories.map((category) => {
     return (
@@ -214,7 +205,7 @@ export function PackageDetailLayout(props: Props) {
               </Button.ButtonIcon>
             </Button.Root>
           </div>
-          <MetaInfoItemList items={metaInfoData} />
+          <PackageMetaItems package={packageData} />
           <WrapperCard
             title="Categories"
             content={
@@ -245,66 +236,6 @@ export function PackageDetailLayout(props: Props) {
 }
 
 PackageDetailLayout.displayName = "PackageDetailLayout";
-
-function getMetaInfoData(packageData: Package) {
-  return [
-    {
-      key: "1",
-      label: "Last Updated",
-      content: <>{packageData.last_updated}</>,
-    },
-    {
-      key: "2",
-      label: "First Uploaded",
-      content: <>{packageData.datetime_created}</>,
-    },
-    {
-      key: "3",
-      label: "Downloads",
-      content: <>{formatInteger(packageData.download_count)}</>,
-    },
-    {
-      key: "4",
-      label: "Likes",
-      content: <>{formatInteger(packageData.rating_count)}</>,
-    },
-    {
-      key: "5",
-      label: "Size",
-      content: <>{formatFileSize(packageData.size)}</>,
-    },
-    {
-      key: "6",
-      label: "Dependency string",
-      content: (
-        <div className={styles.dependencyStringWrapper}>
-          <div
-            title={packageData.full_version_name}
-            className={styles.dependencyString}
-          >
-            {packageData.full_version_name}
-          </div>
-          <CopyButton text={packageData.full_version_name} />
-        </div>
-      ),
-    },
-    {
-      key: "7",
-      label: "Dependants",
-      content: (
-        <PackageDependantsLink
-          community={packageData.community_identifier}
-          namespace={packageData.namespace}
-          package={packageData.name}
-        >
-          <div className={styles.dependantsLink}>
-            {packageData.dependant_count + " other mods"}
-          </div>
-        </PackageDependantsLink>
-      ),
-    },
-  ];
-}
 
 const tabs = [
   {

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -214,7 +214,7 @@ export function PackageDetailLayout(props: Props) {
               </Button.ButtonIcon>
             </Button.Root>
           </div>
-          <MetaInfoItemList metaInfoData={metaInfoData} />
+          <MetaInfoItemList items={metaInfoData} />
           <WrapperCard
             title="Categories"
             content={

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageMetaItems/PackageMetaItems.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageMetaItems/PackageMetaItems.tsx
@@ -1,0 +1,75 @@
+import { Package } from "@thunderstore/dapper/types";
+
+import styles from "../PackageDetailLayout.module.css";
+import { CopyButton } from "../../../CopyButton/CopyButton";
+import { PackageDependantsLink } from "../../../Links/Links";
+import { MetaInfoItemList } from "../../../MetaInfoItemList/MetaInfoItemList";
+import { formatFileSize, formatInteger } from "../../../../utils/utils";
+
+interface Props {
+  package: Package;
+}
+
+export const PackageMetaItems = (props: Props) => (
+  <MetaInfoItemList
+    items={[
+      {
+        key: "last-updated",
+        label: "Last Updated",
+        content: props.package.last_updated,
+      },
+      {
+        key: "first-uploaded",
+        label: "First Uploaded",
+        content: props.package.datetime_created,
+      },
+      {
+        key: "downloads",
+        label: "Downloads",
+        content: formatInteger(props.package.download_count),
+      },
+      {
+        key: "likes",
+        label: "Likes",
+        content: formatInteger(props.package.rating_count),
+      },
+      {
+        key: "file-size",
+        label: "Size",
+        content: formatFileSize(props.package.size),
+      },
+      {
+        key: "dependency-string",
+        label: "Dependency string",
+        content: (
+          <div className={styles.dependencyStringWrapper}>
+            <div
+              title={props.package.full_version_name}
+              className={styles.dependencyString}
+            >
+              {props.package.full_version_name}
+            </div>
+            <CopyButton text={props.package.full_version_name} />
+          </div>
+        ),
+      },
+      {
+        key: "dependants",
+        label: "Dependants",
+        content: (
+          <PackageDependantsLink
+            community={props.package.community_identifier}
+            namespace={props.package.namespace}
+            package={props.package.name}
+          >
+            <div className={styles.dependantsLink}>
+              {props.package.dependant_count} other mods
+            </div>
+          </PackageDependantsLink>
+        ),
+      },
+    ]}
+  />
+);
+
+PackageMetaItems.displayName = "PackageMetaItems";

--- a/packages/cyberstorm/src/components/MetaInfoItem/MetaInfoItem.tsx
+++ b/packages/cyberstorm/src/components/MetaInfoItem/MetaInfoItem.tsx
@@ -2,11 +2,12 @@
 import React, { ReactNode, useRef } from "react";
 import styles from "./MetaInfoItem.module.css";
 
-export type MetaInfoItemProps = {
-  label?: string;
+type Props = {
+  label: string;
   content?: ReactNode;
 };
-export const MetaInfoItem = React.forwardRef<HTMLDivElement, MetaInfoItemProps>(
+
+export const MetaInfoItem = React.forwardRef<HTMLDivElement, Props>(
   (props, forwardedRef) => {
     const { label, content, ...forwardedProps } = props;
 
@@ -16,7 +17,7 @@ export const MetaInfoItem = React.forwardRef<HTMLDivElement, MetaInfoItemProps>(
     return (
       <div {...forwardedProps} ref={ref} className={styles.root}>
         <div className={styles.label}>{label}</div>
-        <>{content}</>
+        {content}
       </div>
     );
   }

--- a/packages/cyberstorm/src/components/MetaInfoItemList/MetaInfoItemList.tsx
+++ b/packages/cyberstorm/src/components/MetaInfoItemList/MetaInfoItemList.tsx
@@ -1,36 +1,24 @@
+import React, { ReactNode } from "react";
 import styles from "./MetaInfoItemList.module.css";
 import { MetaInfoItem } from "../MetaInfoItem/MetaInfoItem";
-import React, { ReactElement } from "react";
 
-interface metaInfoData {
-  key: string;
-  label: string;
-  content?: ReactElement;
-}
-
-export type MetaInfoItemListProps = {
-  metaInfoData?: Array<metaInfoData>;
+type Props = {
+  items: {
+    key: string;
+    label: string;
+    content?: ReactNode;
+  }[];
 };
 
 /**
  * Cyberstorm component for listing MetaInfoItems.
  */
-export const MetaInfoItemList: React.FC<MetaInfoItemListProps> = (props) => {
-  const { metaInfoData = [] } = props;
-  const metaItemList = metaInfoData?.map((metaInfoDataItem) => {
-    return (
-      <MetaInfoItem
-        key={metaInfoDataItem.key}
-        label={metaInfoDataItem.label}
-        content={metaInfoDataItem.content}
-      />
-    );
-  });
-  return (
-    <div>
-      <div className={styles.root}>{metaItemList}</div>
-    </div>
-  );
-};
+export const MetaInfoItemList: React.FC<Props> = (props) => (
+  <div className={styles.root}>
+    {props.items.map((item) => (
+      <MetaInfoItem {...item} key={item.key} />
+    ))}
+  </div>
+);
 
 MetaInfoItemList.displayName = "MetaInfoItemList";

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -51,10 +51,7 @@ export { Markdown } from "./components/Markdown/Markdown";
 export * as MenuItem from "./components/MenuItem/";
 export type { MenuItemProps } from "./components/MenuItem/";
 export { MetaItem, type MetaItemProps } from "./components/MetaItem/MetaItem";
-export {
-  MetaInfoItem,
-  type MetaInfoItemProps,
-} from "./components/MetaInfoItem/MetaInfoItem";
+export { MetaInfoItem } from "./components/MetaInfoItem/MetaInfoItem";
 export {
   MetaInfoItemList,
   type MetaInfoItemListProps,

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -52,10 +52,7 @@ export * as MenuItem from "./components/MenuItem/";
 export type { MenuItemProps } from "./components/MenuItem/";
 export { MetaItem, type MetaItemProps } from "./components/MetaItem/MetaItem";
 export { MetaInfoItem } from "./components/MetaInfoItem/MetaInfoItem";
-export {
-  MetaInfoItemList,
-  type MetaInfoItemListProps,
-} from "./components/MetaInfoItemList/MetaInfoItemList";
+export { MetaInfoItemList } from "./components/MetaInfoItemList/MetaInfoItemList";
 export { Switch, type SwitchProps } from "./components/Switch/Switch";
 export { PackageCard } from "./components/PackageCard/PackageCard";
 export {


### PR DESCRIPTION
@thunderstore/cyberstorm: clean up MetaInfoItem

Label was changed from optional to required prop, since having
labelless items makes little sense to me. Especially since it's a
required prop in MetaInfoList. In a pinch an empty string can be used,
but this forces the developer to make the decisions explicitly.

Other changes shouldn't affect functionality.

Refs TS-1975

@thunderstore/cyberstorm: clean up MetaInfoItemList

Change content prop's type to ReactNode to match the type expected by
MetaInfoItem. Otherwise shouldn't affect functionality.

Refs TS-1979

@thunderstore/cyberstorm: separate PackageMetaItems from layout

PackageDetailLayout has so much going on that splitting it to more
subcomponents improves the code quality.

Refs TS-1979