### PR TITLE
@thunderstore/cyberstorm: add NewTabs

### DIFF
--- a/apps/cyberstorm-storybook/stories/components/NewTabs.stories.tsx
+++ b/apps/cyberstorm-storybook/stories/components/NewTabs.stories.tsx
@@ -1,0 +1,48 @@
+import { StoryFn, Meta } from "@storybook/react";
+import { NewTabs } from "@thunderstore/cyberstorm";
+import { usePromise } from "@thunderstore/use-promise";
+import { Suspense } from "react";
+import { faCog, faFlag, faThumbsUp } from "@fortawesome/pro-solid-svg-icons";
+
+const meta = {
+  title: "Cyberstorm/Components/Tabs",
+  component: NewTabs,
+} as Meta<typeof NewTabs>;
+
+const promiseLoader = () =>
+  new Promise<void>((resolve) => setTimeout(() => resolve(), 2000)).then(
+    () => "Content loaded and cached."
+  );
+
+const AsyncContent = () => {
+  const content = usePromise(promiseLoader, []);
+  return <p>{content}</p>;
+};
+
+const Template: StoryFn<typeof NewTabs> = () => (
+  <NewTabs defaultActive="defaultTab">
+    <NewTabs.Tab name="firstTab" label="First" icon={faCog}>
+      <h1>First tab</h1>
+      <p>Not the default, though</p>
+    </NewTabs.Tab>
+
+    <NewTabs.Tab name="defaultTab" label="Second" icon={faThumbsUp}>
+      <h1>Second tab</h1>
+      <p>Shown by default when the page loads</p>
+    </NewTabs.Tab>
+
+    <NewTabs.Tab name="disabled" label="Disabled" icon={faFlag} disabled>
+      <p>You will never see this</p>
+    </NewTabs.Tab>
+
+    <NewTabs.Tab name="async" label="Async">
+      <Suspense fallback={<p>Loading...</p>}>
+        <AsyncContent />
+      </Suspense>
+    </NewTabs.Tab>
+  </NewTabs>
+);
+
+const NewTabsStory = Template.bind({});
+
+export { meta as default, NewTabsStory as NewTabs };

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -14,9 +14,7 @@ import {
 } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useDapper } from "@thunderstore/dapper";
-import { Package } from "@thunderstore/dapper/types";
 import { usePromise } from "@thunderstore/use-promise";
-import { useState } from "react";
 
 import { PackageChangeLog } from "./PackageChangeLog/PackageChangeLog";
 import styles from "./PackageDetailLayout.module.css";
@@ -35,7 +33,7 @@ import { BaseLayout } from "../BaseLayout/BaseLayout";
 import * as Dialog from "../../Dialog";
 import { Icon } from "../../Icon/Icon";
 import markdownStyles from "../../Markdown/Markdown.module.css";
-import { Tabs } from "../../Tabs/Tabs";
+import Tabs from "../../NewTabs/Tabs";
 import { Tag } from "../../Tag/Tag";
 import { WrapperCard } from "../../WrapperCard/WrapperCard";
 import { ThunderstoreLogo } from "../../../svg/svg";
@@ -57,7 +55,6 @@ export interface Props {
 export function PackageDetailLayout(props: Props) {
   const { communityId, namespaceId, packageName } = props;
 
-  const [currentTab, setCurrentTab] = useState(1);
   const dapper = useDapper();
   const packageData = usePromise(dapper.getPackage, [
     communityId,
@@ -162,10 +159,24 @@ export function PackageDetailLayout(props: Props) {
           </div>
         </div>
       }
-      tabs={
-        <Tabs tabs={tabs} onTabChange={setCurrentTab} currentTab={currentTab} />
+      mainContent={
+        <Tabs>
+          <Tabs.Tab name="details" label="Details" icon={faFileLines}>
+            <div
+              dangerouslySetInnerHTML={{ __html: PLACEHOLDER() }}
+              className={markdownStyles.root}
+            />
+          </Tabs.Tab>
+
+          <Tabs.Tab name="changelog" label="Changelog" icon={faFilePlus}>
+            <PackageChangeLog packageId={packageData.name} />
+          </Tabs.Tab>
+
+          <Tabs.Tab name="versions" label="Versions" icon={faCodeBranch}>
+            <PackageVersions />
+          </Tabs.Tab>
+        </Tabs>
       }
-      mainContent={<>{getTabContent(currentTab, packageData)}</>}
       rightSidebarContent={
         <div className={styles.metaInfo}>
           <div className={styles.metaButtonWrapper}>
@@ -233,42 +244,4 @@ export function PackageDetailLayout(props: Props) {
       }
     />
   );
-}
-
-PackageDetailLayout.displayName = "PackageDetailLayout";
-
-const tabs = [
-  {
-    key: 1,
-    label: "Details",
-    icon: <FontAwesomeIcon icon={faFileLines} className={styles.tabIcon} />,
-  },
-  {
-    key: 2,
-    label: "Changelog",
-    icon: <FontAwesomeIcon icon={faFilePlus} className={styles.tabIcon} />,
-  },
-  {
-    key: 3,
-    label: "Versions",
-    icon: <FontAwesomeIcon icon={faCodeBranch} className={styles.tabIcon} />,
-  },
-];
-
-function getTabContent(currentTab: number, packageData: Package) {
-  const placeholder = PLACEHOLDER();
-  let tabContent = null;
-  if (currentTab === 1) {
-    tabContent = (
-      <div
-        dangerouslySetInnerHTML={{ __html: placeholder }}
-        className={markdownStyles.root}
-      />
-    );
-  } else if (currentTab === 2) {
-    tabContent = <PackageChangeLog packageId={packageData.name} />;
-  } else if (currentTab === 3) {
-    tabContent = <PackageVersions />;
-  }
-  return tabContent;
 }

--- a/packages/cyberstorm/src/components/NewTabs/Tabs.module.css
+++ b/packages/cyberstorm/src/components/NewTabs/Tabs.module.css
@@ -1,0 +1,54 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space--32);
+}
+
+.buttons {
+  display: flex;
+  overflow: auto;
+}
+
+.button {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  gap: var(--space--12);
+  align-items: center;
+  justify-content: center;
+
+  padding: var(--space--12) var(--space--16);
+  border-bottom: 3px solid var(--color-purple--5);
+  color: var(--tab-color);
+  background-color: transparent;
+
+  --tab-color: var(--color-text--default);
+}
+
+.button.active {
+  border-color: var(--tab-color);
+
+  --tab-color: var(--color-green--5);
+}
+
+.button:disabled {
+  --tab-color: var(--color-border--highlight);
+}
+
+.icon {
+  color: var(--color-border--highlight);
+}
+
+.button.active .icon {
+  color: var(--tab-color);
+}
+
+.button:not(.active, :disabled):hover > .icon {
+  color: var(--color-text--tertiary);
+}
+
+.label {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size--l);
+  line-height: 1.3;
+}

--- a/packages/cyberstorm/src/components/NewTabs/Tabs.tsx
+++ b/packages/cyberstorm/src/components/NewTabs/Tabs.tsx
@@ -1,0 +1,148 @@
+"use client";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import React, { PropsWithChildren, startTransition, useState } from "react";
+
+import styles from "./Tabs.module.css";
+import { Icon } from "../Icon/Icon";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { classnames } from "../../utils/utils";
+
+interface Props extends PropsWithChildren {
+  /**
+   * Name prop of the Tab that should be shown by default.
+   * If omitted, the first Tab acts as the default Tab.
+   */
+  defaultActive?: string;
+}
+
+/**
+ * Wrapper components for Tab components.
+ *
+ * Validates the passed Tab components and handles switching between
+ * them.
+ */
+const Tabs = (props: Props) => {
+  const { defaultActive } = props;
+
+  // Sanity checking the child components.
+  const children = React.Children.toArray(props.children);
+  const seenNames: string[] = [];
+
+  children.forEach((child) => {
+    if (!React.isValidElement(child) || child.type !== Tab) {
+      throw new Error("Tabs component only allows Tab child components");
+    }
+    if (seenNames.includes(child.props.name)) {
+      throw new Error(`Non-unique Tab.name "${child.props.name}" in Tabs`);
+    }
+    seenNames.push(child.props.name);
+  });
+
+  if (defaultActive && !seenNames.includes(defaultActive)) {
+    throw new Error(
+      `Tabs.defaultActive "${defaultActive}" matches no child Tab.name`
+    );
+  }
+
+  const [activeTab, setActiveTab] = useState(defaultActive || seenNames[0]);
+
+  // Throw away the ease-of-use Tab components and render internal
+  // components instead.
+  const buttons: JSX.Element[] = [];
+  const contents: JSX.Element[] = [];
+
+  children.forEach((child) => {
+    if (React.isValidElement(child)) {
+      buttons.push(
+        <InternalTabButton
+          key={child.props.name}
+          active={child.props.name === activeTab}
+          setActive={() => setActiveTab(child.props.name)}
+          {...child.props}
+        />
+      );
+      contents.push(
+        <InternalTabContent
+          key={child.props.name}
+          active={child.props.name === activeTab}
+        >
+          {child.props.children}
+        </InternalTabContent>
+      );
+    }
+  });
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.buttons}>{buttons}</div>
+      <div>{contents}</div>
+    </div>
+  );
+};
+
+Tabs.displayName = "Tabs";
+
+interface TabProps extends PropsWithChildren {
+  /** Unique identifier for the Tab in the context of Tabs */
+  name: string;
+  /** Text shown on the Tab activator */
+  label: string;
+  /**
+   * Prevents user from selecting the Tab.
+   *
+   * Note that if default Tab is disabled, the contents will be shown
+   * initially, but user can't reselect the Tab once they leave it.
+   */
+  disabled?: boolean;
+  /** Icon shown on the Tab activator */
+  icon?: IconDefinition;
+}
+
+const Tab = (props: TabProps) => props && null;
+
+Tab.displayName = "Tab";
+
+export default Object.assign(Tabs, { Tab: Tab });
+
+interface InternalTabButtonProps {
+  label: string;
+  active: boolean;
+  setActive: () => void;
+  disabled?: boolean;
+  icon?: IconDefinition;
+}
+
+/** Only for internal use by Tabs and thus not exported. */
+const InternalTabButton = (props: InternalTabButtonProps) => {
+  const { active, disabled = false, icon, label, setActive } = props;
+
+  return (
+    <button
+      type="button"
+      aria-current={active}
+      className={classnames(styles.button, active ? styles.active : "")}
+      disabled={disabled}
+      onClick={() => startTransition(setActive)}
+    >
+      {icon ? (
+        <Icon inline wrapperClasses={styles.icon}>
+          <FontAwesomeIcon icon={icon} />
+        </Icon>
+      ) : null}
+      <span className={styles.label}>{label}</span>
+    </button>
+  );
+};
+
+InternalTabButton.displayName = "InternalTabButton";
+
+interface InternalTabContentProps extends PropsWithChildren {
+  active: boolean;
+}
+
+/** Only for internal use by Tabs and thus not exported. */
+const InternalTabContent = (props: InternalTabContentProps) => {
+  return props.active ? <>{props.children}</> : <></>;
+};
+
+InternalTabContent.displayName = "InternalTabContent";

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -53,6 +53,7 @@ export type { MenuItemProps } from "./components/MenuItem/";
 export { MetaItem, type MetaItemProps } from "./components/MetaItem/MetaItem";
 export { MetaInfoItem } from "./components/MetaInfoItem/MetaInfoItem";
 export { MetaInfoItemList } from "./components/MetaInfoItemList/MetaInfoItemList";
+export { default as NewTabs } from "./components/NewTabs/Tabs";
 export { Switch, type SwitchProps } from "./components/Switch/Switch";
 export { PackageCard } from "./components/PackageCard/PackageCard";
 export {


### PR DESCRIPTION
@thunderstore/cyberstorm: add NewTabs

Add an improved version Tabs component. The old Tabs component is
retained for now to avoid scope creep. Ideally eventually all of the
old components will be replaced, the old implementation removed and
NewTabs renamed to Tabs.

The main motivation for the new implementation is an usecase from
PackageDetailLayout. Dapper will initally load only content for the
default tab. Additionally it will load flags defining whether other
tabs have content. E.g. if the changelog tab has no content, the tab is
disabled. If changelog exists, it's loaded with a separate Dapper call.

Additional improvements include:

- Moving away from "children as props" approach
- Ease of use when developer doesn't have to provide the tab buttons
  and contents separately
- Ease of use when the Tabs component will internally handle switching
  between the tabs
- Probably cleaner support for Suspenses

Refs TS-1979

@thunderstore/cyberstorm-nextjs: add stories for NewTabs

Refs TS-1979

@thunderstore/cyberstorm: use NewTabs in PackageDetailLayout

This is in preparation for how the data will be fetched to different
Tabs with Dapper.

Refs TS-1979