### PR TITLE
@thunderstore/dapper: rename method and interfaces

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -51,7 +51,7 @@ export function PackageDetailLayout(props: Props) {
 
   const dapper = useDapper();
   const community = usePromise(dapper.getCommunity, [communityId]);
-  const packageData = usePromise(dapper.getPackage, [
+  const packageData = usePromise(dapper.getPackageListingDetails, [
     communityId,
     namespaceId,
     packageName,

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageMetaItems/PackageMetaItems.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageMetaItems/PackageMetaItems.tsx
@@ -1,4 +1,4 @@
-import { Package } from "@thunderstore/dapper/types";
+import { PackageListingDetails } from "@thunderstore/dapper/types";
 
 import styles from "../PackageDetailLayout.module.css";
 import { CopyButton } from "../../../CopyButton/CopyButton";
@@ -8,7 +8,7 @@ import { RelativeTime } from "../../../RelativeTime/RelativeTime";
 import { formatFileSize, formatInteger } from "../../../../utils/utils";
 
 interface Props {
-  package: Package;
+  package: PackageListingDetails;
 }
 
 export const PackageMetaItems = (props: Props) => (

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageTagList/PackageTagList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageTagList/PackageTagList.tsx
@@ -1,5 +1,5 @@
 import styles from "./PackageTagList.module.css";
-import { Package } from "@thunderstore/dapper/types";
+import { PackageListingDetails } from "@thunderstore/dapper/types";
 import { WrapperCard } from "../../../WrapperCard/WrapperCard";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTag } from "@fortawesome/pro-regular-svg-icons";
@@ -13,7 +13,7 @@ import {
 import { ReactNode } from "react";
 
 export interface PackageTagListProps {
-  packageData: Package;
+  packageData: PackageListingDetails;
 }
 
 export function PackageTagList(props: PackageTagListProps) {
@@ -34,7 +34,7 @@ export function PackageTagList(props: PackageTagListProps) {
 
 PackageTagList.displayName = "PackageTagList";
 
-function getPackageFlags(packageData: Package) {
+function getPackageFlags(packageData: PackageListingDetails) {
   const updateTimeDelta = Math.round(
     (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );

--- a/packages/cyberstorm/src/components/PackageCard/PackageCard.tsx
+++ b/packages/cyberstorm/src/components/PackageCard/PackageCard.tsx
@@ -11,12 +11,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { Tag } from "../Tag/Tag";
 import { classnames, formatInteger } from "../../utils/utils";
-import { PackagePreview } from "@thunderstore/dapper/types";
+import { PackageListing } from "@thunderstore/dapper/types";
 import { PackageLink, TeamLink } from "../Links/Links";
 import { faLips, faSparkles } from "@fortawesome/pro-solid-svg-icons";
 
 interface Props {
-  package: PackagePreview;
+  package: PackageListing;
 }
 
 /**
@@ -78,7 +78,7 @@ export function PackageCard(props: Props) {
 
 PackageCard.displayName = "PackageCard";
 
-function getPackageFlags(packageData: PackagePreview) {
+function getPackageFlags(packageData: PackageListing) {
   const updateTimeDelta = Math.round(
     (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );
@@ -135,7 +135,7 @@ function getPackageFlags(packageData: PackagePreview) {
   return <div className={styles.flagWrapper}>{flagList}</div>;
 }
 
-function getMetaItemList(packageData: PackagePreview) {
+function getMetaItemList(packageData: PackageListing) {
   const updateTimeDelta = Math.round(
     (Date.now() - Date.parse(packageData.last_updated)) / 86400000
   );

--- a/packages/cyberstorm/src/utils/utils.ts
+++ b/packages/cyberstorm/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { Package } from "@thunderstore/dapper/types";
+import { PackageListingDetails } from "@thunderstore/dapper/types";
 
 export const range = (start: number, end: number) => {
   const length = end - start + 1;
@@ -31,11 +31,11 @@ export const classnames = (
   return classnames.filter(String).join(" ");
 };
 
-export const getDownloadUrl = (p: Package) =>
+export const getDownloadUrl = (p: PackageListingDetails) =>
   `https://thunderstore.io/package/download/${getPath(p)}/`;
 
-export const getInstallUrl = (p: Package) =>
+export const getInstallUrl = (p: PackageListingDetails) =>
   `ror2mm://v1/install/thunderstore.io/${getPath(p)}/`;
 
-const getPath = (p: Package) =>
+const getPath = (p: PackageListingDetails) =>
   `${p.namespace}/${p.name}/${p.latest_version_number}`;

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -5,7 +5,7 @@ import { getFakeImg, getFakePackageCategories, range, setSeed } from "./utils";
 import { getFakeTeamMembers } from "./team";
 
 // Content used to render one PackageCard in a list view.
-const getFakePackagePreview = (
+const getFakePackageListing = (
   community?: string,
   namespace?: string,
   name?: string
@@ -48,7 +48,7 @@ export const getFakePackageListings = async (
   count: 200,
   hasMore: true,
   results: range(20).map(() =>
-    getFakePackagePreview(
+    getFakePackageListing(
       type.communityId,
       type.kind === "namespace" ? type.namespaceId : faker.word.sample()
     )
@@ -83,7 +83,7 @@ export const getFakePackage = async (
   setSeed(seed);
 
   return {
-    ...getFakePackagePreview(community, namespace, name),
+    ...getFakePackageListing(community, namespace, name),
 
     community_name: faker.word.sample(),
     datetime_created: faker.date.past({ years: 2 }).toISOString(),

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -74,7 +74,7 @@ export const getFakeDependencies = async (
 };
 
 // Content used to render Package's detail view.
-export const getFakePackage = async (
+export const getFakePackageListingDetails = async (
   community: string,
   namespace: string,
   name: string

--- a/packages/dapper-fake/src/index.ts
+++ b/packages/dapper-fake/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "./fakers/community";
 import {
   getFakeDependencies,
-  getFakePackage,
+  getFakePackageListingDetails,
   getFakePackageListings,
 } from "./fakers/package";
 import { getFakeServiceAccounts } from "./fakers/serviceAccount";
@@ -19,7 +19,7 @@ export class DapperFake implements DapperInterface {
   public getCommunity = getFakeCommunity;
   public getCommunityFilters = getFakeCommunityFilters;
   public getCurrentUser = getFakeCurrentUser;
-  public getPackage = getFakePackage;
+  public getPackage = getFakePackageListingDetails;
   public getPackageDependencies = getFakeDependencies;
   public getPackageListings = getFakePackageListings;
   public getTeamDetails = getFakeTeamDetails;

--- a/packages/dapper-fake/src/index.ts
+++ b/packages/dapper-fake/src/index.ts
@@ -19,8 +19,8 @@ export class DapperFake implements DapperInterface {
   public getCommunity = getFakeCommunity;
   public getCommunityFilters = getFakeCommunityFilters;
   public getCurrentUser = getFakeCurrentUser;
-  public getPackage = getFakePackageListingDetails;
   public getPackageDependencies = getFakeDependencies;
+  public getPackageListingDetails = getFakePackageListingDetails;
   public getPackageListings = getFakePackageListings;
   public getTeamDetails = getFakeTeamDetails;
   public getTeamMembers = getFakeTeamMembers;

--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -27,12 +27,12 @@ it("executes getCurrentUser without errors", async () => {
   await expect(dapper.getCurrentUser()).resolves.not.toThrowError();
 });
 
-it("executes getPackage without errors", async () => {
-  await expect(dapper.getPackage()).resolves.not.toThrowError();
-});
-
 it("executes getPackageDependencies without errors", async () => {
   await expect(dapper.getPackageDependencies()).resolves.not.toThrowError();
+});
+
+it("executes getPackageListingDetails without errors", async () => {
+  await expect(dapper.getPackageListingDetails()).resolves.not.toThrowError();
 });
 
 it("executes getPackageListings for community without errors", async () => {

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -48,6 +48,6 @@ export class DapperTs implements DapperTsInterface {
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
 
-  public getPackage = NotImplemented;
   public getPackageDependencies = NotImplemented;
+  public getPackageListingDetails = NotImplemented;
 }

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -5,8 +5,8 @@ export interface DapperInterface {
   getCommunity: methods.GetCommunity;
   getCommunityFilters: methods.GetCommunityFilters;
   getCurrentUser: methods.GetCurrentUser;
-  getPackage: methods.GetPackage;
   getPackageDependencies: methods.GetPackageDependencies;
+  getPackageListingDetails: methods.GetPackageListingDetails;
   getPackageListings: methods.GetPackageListings;
   getTeamDetails: methods.GetTeamDetails;
   getTeamMembers: methods.GetTeamMembers;

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,5 +1,9 @@
 import { Communities, Community, CommunityFilters } from "./community";
-import { Package, PackageDependency, PackageListings } from "./package";
+import {
+  PackageDependency,
+  PackageListingDetails,
+  PackageListings,
+} from "./package";
 import { PackageListingType } from "./props";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
@@ -22,7 +26,7 @@ export type GetPackage = (
   community: string,
   namespace: string,
   name: string
-) => Promise<Package>;
+) => Promise<PackageListingDetails>;
 
 // TODO: is this right? how do we fetch dependencies without knowing the
 // package name?

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,5 +1,5 @@
 import { Communities, Community, CommunityFilters } from "./community";
-import { Package, PackageDependency, PackagePreviews } from "./package";
+import { Package, PackageDependency, PackageListings } from "./package";
 import { PackageListingType } from "./props";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
@@ -41,7 +41,7 @@ export type GetPackageListings = (
   section?: string,
   nsfw?: boolean,
   deprecated?: boolean
-) => Promise<PackagePreviews>;
+) => Promise<PackageListings>;
 
 export type GetTeamDetails = (teamName: string) => Promise<TeamDetails>;
 

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -22,7 +22,7 @@ export type GetCommunityFilters = (
 
 export type GetCurrentUser = () => Promise<CurrentUser>;
 
-export type GetPackage = (
+export type GetPackageListingDetails = (
   community: string,
   namespace: string,
   name: string

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -1,7 +1,7 @@
 import { PackageCategory, PaginatedList } from "./shared";
 import { TeamMember } from "./team";
 
-export interface PackagePreview {
+export interface PackageListing {
   categories: PackageCategory[];
   community_identifier: string;
   description: string;
@@ -17,9 +17,9 @@ export interface PackagePreview {
   size: number;
 }
 
-export type PackagePreviews = PaginatedList<PackagePreview>;
+export type PackageListings = PaginatedList<PackageListing>;
 
-export interface Package extends PackagePreview {
+export interface Package extends PackageListing {
   community_name: string;
   datetime_created: string;
   dependant_count: number;

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -19,7 +19,7 @@ export interface PackageListing {
 
 export type PackageListings = PaginatedList<PackageListing>;
 
-export interface Package extends PackageListing {
+export interface PackageListingDetails extends PackageListing {
   community_name: string;
   datetime_created: string;
   dependant_count: number;


### PR DESCRIPTION
@thunderstore/dapper rename PackagePreview to PackageListing

The naming is more accurate, since the included data contains community
specific information. Packages exist separately from the communities,
so we might eventually want to fetch just package data.

Refs TS-1980

@thunderstore/dapper rename Package to PackageListingDetails

The naming is more accurate, since the included data contains community
specific information. Packages exist separately from the communities,
so we might eventually want to fetch just package data.

Refs TS-1980

@thunderstore/dapper: rename getPackage to getPackageListingDetails

The naming is more accurate, since the included data contains community
specific information. Packages exist separately from the communities,
so we might eventually want to fetch just package data.

Refs TS-1980