### PR TITLE
@thunderstore/cyberstorm: change PackageDependencyList props

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
@@ -1,110 +1,91 @@
-import styles from "./PackageDependencyList.module.css";
-import { PackageDependency } from "@thunderstore/dapper/types";
-import { PackageLink } from "../../../Links/Links";
-import { WrapperCard } from "../../../WrapperCard/WrapperCard";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBoxOpen } from "@fortawesome/pro-regular-svg-icons";
 import { faCaretRight } from "@fortawesome/pro-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PackageDependency } from "@thunderstore/dapper/types";
+
 import { PackageDependencyDialog } from "./PackageDependencyDialog/PackageDependencyDialog";
+import styles from "./PackageDependencyList.module.css";
 import * as Button from "../../../Button/";
-import { useDapper } from "@thunderstore/dapper";
-import { usePromise } from "@thunderstore/use-promise";
+import { PackageLink } from "../../../Links/Links";
+import { WrapperCard } from "../../../WrapperCard/WrapperCard";
 import { Dialog } from "../../../../index";
 
 // TODO: actual placeholder
 const defaultImageSrc = "/images/logo.png";
 
-export interface PackageDependencyListProps {
-  namespace: string;
-  community: string;
+interface Props {
+  dependencies: PackageDependency[];
 }
 
-export interface PackageDependencyListItemProps {
-  packageData: PackageDependency;
-}
-
-function PackageDependencyListItem(props: PackageDependencyListItemProps) {
-  const { packageData } = props;
+export function PackageDependencyList(props: Props) {
+  const { dependencies } = props;
 
   return (
-    <PackageLink
-      community={packageData.community_identifier}
-      namespace={packageData.namespace}
-      package={packageData.name}
-    >
-      <div className={styles.item}>
-        <img
-          src={packageData.icon_url ?? defaultImageSrc}
-          className={styles.itemImage}
-          alt=""
-        />
-        <div>
-          <div className={styles.itemTitle}>{packageData.name}</div>
-          <p className={styles.itemDescription}>{packageData.description}</p>
-        </div>
-      </div>
-    </PackageLink>
-  );
-}
-
-export function PackageDependencyList(props: PackageDependencyListProps) {
-  const { namespace, community } = props;
-
-  const dapper = useDapper();
-  const packageDependencyData = usePromise(dapper.getPackageDependencies, [
-    community,
-    namespace,
-  ]);
-
-  const mappedPackageDependencyList = packageDependencyData?.map(
-    (packageData: PackageDependency, index: number) => {
-      return (
-        <div key={index}>
-          <PackageDependencyListItem packageData={packageData} />
-        </div>
-      );
-    }
-  );
-
-  return (
-    <>
-      <WrapperCard
-        title="Required Mods"
-        content={
-          <div className={styles.root}>
-            <div className={styles.listWrapper}>
-              <div className={styles.list}>{mappedPackageDependencyList}</div>
+    <WrapperCard
+      title="Required Mods"
+      content={
+        <div className={styles.root}>
+          <div className={styles.listWrapper}>
+            <div className={styles.list}>
+              {dependencies.map((d) => (
+                <PackageDependencyListItem
+                  {...d}
+                  key={`${d.namespace}-${d.name}`}
+                />
+              ))}
             </div>
           </div>
-        }
-        headerIcon={<FontAwesomeIcon icon={faBoxOpen} />}
-        headerRightContent={
-          <Dialog.Root
-            showHeaderBorder
-            title="Required mods"
-            trigger={
-              <div className={styles.dependencyDialogTrigger}>
-                <Button.Root
-                  fontSize="medium"
-                  paddingSize="none"
-                  colorScheme="transparentPrimary"
-                >
-                  <Button.ButtonLabel fontWeight="600">
-                    See all
-                  </Button.ButtonLabel>
-                  <Button.ButtonIcon>
-                    <FontAwesomeIcon icon={faCaretRight} />
-                  </Button.ButtonIcon>
-                </Button.Root>
-              </div>
-            }
-          >
-            <PackageDependencyDialog packages={packageDependencyData} />
-          </Dialog.Root>
-        }
-      />
-    </>
+        </div>
+      }
+      headerIcon={<FontAwesomeIcon icon={faBoxOpen} />}
+      headerRightContent={
+        <Dialog.Root
+          showHeaderBorder
+          title="Required mods"
+          trigger={
+            <div className={styles.dependencyDialogTrigger}>
+              <Button.Root
+                fontSize="medium"
+                paddingSize="none"
+                colorScheme="transparentPrimary"
+              >
+                <Button.ButtonLabel fontWeight="600">
+                  See all
+                </Button.ButtonLabel>
+                <Button.ButtonIcon>
+                  <FontAwesomeIcon icon={faCaretRight} />
+                </Button.ButtonIcon>
+              </Button.Root>
+            </div>
+          }
+        >
+          <PackageDependencyDialog packages={dependencies} />
+        </Dialog.Root>
+      }
+    />
   );
 }
 
 PackageDependencyList.displayName = "PackageDependencyList";
+
+const PackageDependencyListItem = (props: PackageDependency) => (
+  <PackageLink
+    community={props.community_identifier}
+    namespace={props.namespace}
+    package={props.name}
+  >
+    <div className={styles.item}>
+      <img
+        src={props.icon_url ?? defaultImageSrc}
+        className={styles.itemImage}
+        alt=""
+      />
+      <div>
+        <div className={styles.itemTitle}>{props.name}</div>
+        <p className={styles.itemDescription}>{props.description}</p>
+      </div>
+    </div>
+  </PackageLink>
+);
+
+PackageDependencyListItem.displayName = "PackageDependencyListItem";

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -190,10 +190,7 @@ export function PackageDetailLayout(props: Props) {
             }
           />
           <PackageTagList packageData={packageData} />
-          <PackageDependencyList
-            namespace={namespaceId}
-            community={communityId}
-          />
+          <PackageDependencyList dependencies={packageData.dependencies} />
           <PackageTeamMemberList
             community={packageData.community_identifier}
             teamName={packageData.namespace}


### PR DESCRIPTION
The component now accepts a list of dependencies as a prop instead of
fetching the data itself with Dapper. This was changed because it made
more sense to fetch the dependencies with the same request as the rest
of PackageDetailLayout's contents (excluding tabs).

Also includes some generic cleanup.

Refs TS-1980
