### PR TITLE
@thunderstore/dapper: remove getDependencies

### DIFF
--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -55,7 +55,7 @@ export const getFakePackageListings = async (
   ),
 });
 
-export const getFakeDependencies = async (
+const getFakeDependencies = async (
   community: string,
   namespace: string,
   name?: string,

--- a/packages/dapper-fake/src/index.ts
+++ b/packages/dapper-fake/src/index.ts
@@ -6,7 +6,6 @@ import {
   getFakeCommunityFilters,
 } from "./fakers/community";
 import {
-  getFakeDependencies,
   getFakePackageListingDetails,
   getFakePackageListings,
 } from "./fakers/package";
@@ -19,7 +18,6 @@ export class DapperFake implements DapperInterface {
   public getCommunity = getFakeCommunity;
   public getCommunityFilters = getFakeCommunityFilters;
   public getCurrentUser = getFakeCurrentUser;
-  public getPackageDependencies = getFakeDependencies;
   public getPackageListingDetails = getFakePackageListingDetails;
   public getPackageListings = getFakePackageListings;
   public getTeamDetails = getFakeTeamDetails;

--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -28,10 +28,6 @@ it("executes getCurrentUser without errors", async () => {
   await expect(dapper.getCurrentUser()).resolves.not.toThrowError();
 });
 
-it("executes getPackageDependencies without errors", async () => {
-  await expect(dapper.getPackageDependencies()).resolves.not.toThrowError();
-});
-
 it("executes getPackageListingDetails without errors", async () => {
   await expect(
     dapper.getPackageListingDetails(communityId, namespaceId, packageName)

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -14,15 +14,6 @@ import {
   getTeamServiceAccounts,
 } from "./methods/team";
 
-// Original idea was for NotImlemented to throw an error, but that
-// causes the build cyberstorm-nextjs to fail, which causes CI pipeline
-// to block merging.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const NotImplemented: any = async () => {
-  console.error("DapperTs has not implemented a provider method");
-  return [];
-};
-
 export interface DapperTsInterface extends DapperInterface {
   config: RequestConfig;
 }
@@ -52,6 +43,4 @@ export class DapperTs implements DapperTsInterface {
   public getTeamDetails = getTeamDetails;
   public getTeamMembers = getTeamMembers;
   public getTeamServiceAccounts = getTeamServiceAccounts;
-
-  public getPackageDependencies = NotImplemented;
 }

--- a/packages/dapper/src/dapper.ts
+++ b/packages/dapper/src/dapper.ts
@@ -5,7 +5,6 @@ export interface DapperInterface {
   getCommunity: methods.GetCommunity;
   getCommunityFilters: methods.GetCommunityFilters;
   getCurrentUser: methods.GetCurrentUser;
-  getPackageDependencies: methods.GetPackageDependencies;
   getPackageListingDetails: methods.GetPackageListingDetails;
   getPackageListings: methods.GetPackageListings;
   getTeamDetails: methods.GetTeamDetails;

--- a/packages/dapper/src/types/methods.ts
+++ b/packages/dapper/src/types/methods.ts
@@ -1,9 +1,5 @@
 import { Communities, Community, CommunityFilters } from "./community";
-import {
-  PackageDependency,
-  PackageListingDetails,
-  PackageListings,
-} from "./package";
+import { PackageListingDetails, PackageListings } from "./package";
 import { PackageListingType } from "./props";
 import { TeamDetails, ServiceAccount, TeamMember } from "./team";
 import { CurrentUser } from "./user";
@@ -27,13 +23,6 @@ export type GetPackageListingDetails = (
   namespace: string,
   name: string
 ) => Promise<PackageListingDetails>;
-
-// TODO: is this right? how do we fetch dependencies without knowing the
-// package name?
-export type GetPackageDependencies = (
-  community: string,
-  namespace: string
-) => Promise<PackageDependency[]>;
 
 export type GetPackageListings = (
   type: PackageListingType,


### PR DESCRIPTION
The method is not needed, the data is received in the
getPackageListingDetails response.

Refs TS-1980