### PR TITLE
Fix z-index interaction between Header, Dialog and Dialog content

### DIFF
--- a/packages/cyberstorm/src/components/Dialog/Dialog.module.css
+++ b/packages/cyberstorm/src/components/Dialog/Dialog.module.css
@@ -1,28 +1,26 @@
 .overlay {
   position: fixed;
-  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-color: var(--color-shadow-1);
+  animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
   inset: 0;
 }
 
 .content {
   position: fixed;
-  top: var(--top);
-  left: var(--left);
-  z-index: 999;
   display: flex;
   flex-direction: column;
-  width: 90vw;
   max-width: 40rem;
   max-height: 80vh;
   border: var(--border);
   border-radius: var(--border-radius--8);
   background-color: var(--color-surface--2);
-  box-shadow: var(--box-shadow-default);
-  transform: translate(calc(var(--left) * -1), calc(var(--top) * -1));
 
-  --top: 50%;
-  --left: 50%;
+  box-shadow: hsl(206deg 22% 7% / 0.35) 0 10px 38px -10px, hsl(206deg 22% 7% / 0.2) 0 10px 20px -15px;
+  animation: contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
   --border: var(--border-width--px) solid var(--color-surface--5);
 }
 

--- a/packages/cyberstorm/src/components/Header/Header.module.css
+++ b/packages/cyberstorm/src/components/Header/Header.module.css
@@ -1,7 +1,6 @@
 .root {
   position: sticky;
   top: 0;
-  z-index: 999;
   display: flex;
   gap: var(--gap--32);
   align-items: center;


### PR DESCRIPTION
Fix an issue where; if something with z-index: auto
is in a dialog, its placed behind the dialog.