### PR TITLE
Add metaData prop to ApiForm

### DIFF
--- a/packages/cyberstorm-forms/src/forms/CreateTeamForm.tsx
+++ b/packages/cyberstorm-forms/src/forms/CreateTeamForm.tsx
@@ -21,6 +21,7 @@ export function CreateTeamForm() {
     <ApiForm
       {...toaster}
       schema={createTeamFormSchema}
+      meta={{}}
       endpoint={createTeam}
       formProps={{ className: styles.root }}
     >

--- a/packages/ts-api-react-forms/src/ApiForm.tsx
+++ b/packages/ts-api-react-forms/src/ApiForm.tsx
@@ -9,23 +9,27 @@ import { useApiForm } from "./useApiForm";
 
 export type ApiFormProps<
   Schema extends ZodObject<Z>,
+  Meta extends object,
   Result extends object,
   Z extends ZodRawShape
 > = {
   schema: Schema;
-  endpoint: ApiEndpoint<z.infer<Schema>, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
+  meta: Meta;
   onSubmitSuccess?: (result: Result) => void;
   onSubmitError?: (error: Error | ApiError | unknown) => void;
   formProps?: Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">;
 };
 export function ApiForm<
   Schema extends ZodObject<Z>,
+  Meta extends object,
   Result extends object,
   Z extends ZodRawShape
->(props: PropsWithChildren<ApiFormProps<Schema, Result, Z>>) {
-  const { schema, endpoint, onSubmitSuccess, onSubmitError } = props;
+>(props: PropsWithChildren<ApiFormProps<Schema, Meta, Result, Z>>) {
+  const { schema, meta, endpoint, onSubmitSuccess, onSubmitError } = props;
   const { form, submitHandler } = useApiForm({
     schema: schema,
+    meta: meta,
     endpoint: endpoint,
   });
   const onSubmit = useCallback(

--- a/packages/ts-api-react-forms/src/useApiForm.ts
+++ b/packages/ts-api-react-forms/src/useApiForm.ts
@@ -8,11 +8,13 @@ import { ApiEndpoint, useApiCall } from "@thunderstore/ts-api-react";
 
 export type UseApiFormArgs<
   Schema extends ZodObject<Z>,
+  Meta extends object,
   Result extends object,
   Z extends ZodRawShape
 > = {
   schema: Schema;
-  endpoint: ApiEndpoint<z.infer<Schema>, Result>;
+  meta: Meta;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
 };
 export type UseApiFormReturn<
   Schema extends ZodObject<Z>,
@@ -24,12 +26,13 @@ export type UseApiFormReturn<
 };
 export function useApiForm<
   Schema extends ZodObject<Z>,
+  Meta extends object,
   Result extends object,
   Z extends ZodRawShape
 >(
-  args: UseApiFormArgs<Schema, Result, Z>
+  args: UseApiFormArgs<Schema, Meta, Result, Z>
 ): UseApiFormReturn<Schema, Result, Z> {
-  const { schema, endpoint } = args;
+  const { schema, meta, endpoint } = args;
   const apiCall = useApiCall(endpoint);
 
   const form = useForm<z.infer<Schema>>({
@@ -38,7 +41,7 @@ export function useApiForm<
   });
   const submitHandler = async (data: z.infer<Schema>) => {
     try {
-      return await apiCall(data);
+      return await apiCall(data, meta);
     } catch (e) {
       handleFormApiErrors(e, schema, form.setError);
       throw e;

--- a/packages/ts-api-react/src/useApiCall.ts
+++ b/packages/ts-api-react/src/useApiCall.ts
@@ -1,13 +1,14 @@
 import { RequestConfig } from "@thunderstore/thunderstore-api";
 import { useApiConfig } from "./useApiConfig";
 
-export type ApiEndpoint<Data, Result> = (
+export type ApiEndpoint<Data, Meta, Result> = (
   config: RequestConfig,
-  data: Data
+  data: Data,
+  meta: Meta
 ) => Promise<Result>;
-export function useApiCall<Data, Result>(
-  endpoint: ApiEndpoint<Data, Result>
-): (data: Data) => Promise<Result> {
+export function useApiCall<Data, Meta, Result>(
+  endpoint: ApiEndpoint<Data, Meta, Result>
+): (data: Data, meta: Meta) => Promise<Result> {
   const apiConfig = useApiConfig();
-  return (data: Data) => endpoint(apiConfig, data);
+  return (data: Data, meta: Meta) => endpoint(apiConfig, data, meta);
 }


### PR DESCRIPTION
metaData props purpose is to carry data that
should not be inserted into the payload,
to the fetch function

First use-case is carryin the teamName to
fetch function so that it can be inserted into
the url