### PR TITLE
Add ApiAction and useApiAction functions

### DIFF
--- a/packages/ts-api-react/src/ApiAction.tsx
+++ b/packages/ts-api-react/src/ApiAction.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback } from "react";
+import { z, ZodObject, ZodRawShape } from "zod";
+import { ApiError } from "@thunderstore/thunderstore-api";
+import { useApiAction } from "./useApiAction";
+import { ApiEndpoint } from "./useApiCall";
+
+export interface ApiActionProps<
+  Schema extends ZodObject<Z>,
+  Meta extends object,
+  Result extends object,
+  Z extends ZodRawShape
+> {
+  schema: Schema;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
+  meta: Meta;
+  onSubmitSuccess?: (result: Result) => void;
+  onSubmitError?: (error: Error | ApiError | unknown) => void;
+}
+
+export function ApiAction<
+  Schema extends ZodObject<Z>,
+  Meta extends object,
+  Result extends object,
+  Z extends ZodRawShape
+>(props: ApiActionProps<Schema, Meta, Result, Z>) {
+  const { meta, endpoint, onSubmitSuccess, onSubmitError } = props;
+  const submitHandler = useApiAction({
+    meta: meta,
+    endpoint: endpoint,
+  });
+  const onSubmit = useCallback(
+    async (data: z.infer<Schema>) => {
+      try {
+        const result = await submitHandler(data);
+        if (onSubmitSuccess) {
+          onSubmitSuccess(result);
+        }
+      } catch (e) {
+        if (onSubmitError) {
+          onSubmitError(e);
+        } else {
+          throw e;
+        }
+      }
+    },
+    [onSubmitSuccess, onSubmitError]
+  );
+
+  return onSubmit;
+}
+
+ApiAction.displayName = "ApiAction";

--- a/packages/ts-api-react/src/index.ts
+++ b/packages/ts-api-react/src/index.ts
@@ -1,3 +1,4 @@
+export { ApiAction } from "./ApiAction";
 export { useApiConfig } from "./useApiConfig";
 export { useApiCall } from "./useApiCall";
 export type { ApiEndpoint } from "./useApiCall";

--- a/packages/ts-api-react/src/useApiAction.ts
+++ b/packages/ts-api-react/src/useApiAction.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { z, ZodObject, ZodRawShape } from "zod";
+import { ApiEndpoint, useApiCall } from "./useApiCall";
+
+export type UseApiActionArgs<
+  Schema extends ZodObject<Z>,
+  Meta extends object,
+  Result extends object,
+  Z extends ZodRawShape
+> = {
+  meta: Meta;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
+};
+export function useApiAction<
+  Schema extends ZodObject<Z>,
+  Meta extends object,
+  Result extends object,
+  Z extends ZodRawShape
+>(args: UseApiActionArgs<Schema, Meta, Result, Z>) {
+  const { meta, endpoint } = args;
+  const apiCall = useApiCall(endpoint);
+
+  const submitHandler = async (data: z.infer<Schema>) => {
+    return await apiCall(data, meta);
+  };
+
+  return submitHandler;
+}


### PR DESCRIPTION
Add ApiAction and useApiAction functions to centralize
CS API endpoint calls, that are made without forms.