### PR TITLE
Use download/install URLs generated by the backend

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -37,7 +37,6 @@ import Tabs from "../../NewTabs/Tabs";
 import { Tag } from "../../Tag/Tag";
 import { WrapperCard } from "../../WrapperCard/WrapperCard";
 import { ThunderstoreLogo } from "../../../svg/svg";
-import { getDownloadUrl, getInstallUrl } from "../../../utils/utils";
 
 export interface Props {
   communityId: string;
@@ -133,10 +132,7 @@ export function PackageDetailLayout(props: Props) {
             <Dialog.Root title="Manage Package" trigger={<ManageButton />}>
               <PackageManagementForm isDeprecated={packageData.is_deprecated} />
             </Dialog.Root>
-            <a
-              href={getInstallUrl(packageData)}
-              className={styles.installButton}
-            >
+            <a href={packageData.install_url} className={styles.installButton}>
               <InstallButton />
             </a>
           </div>
@@ -165,7 +161,7 @@ export function PackageDetailLayout(props: Props) {
         <div className={styles.metaInfo}>
           <div className={styles.metaButtonWrapper}>
             <a
-              href={getDownloadUrl(packageData)}
+              href={packageData.download_url}
               className={styles.metaDownloadButton}
             >
               <DownloadButton />

--- a/packages/cyberstorm/src/utils/utils.ts
+++ b/packages/cyberstorm/src/utils/utils.ts
@@ -1,5 +1,3 @@
-import { PackageListingDetails } from "@thunderstore/dapper/types";
-
 export const range = (start: number, end: number) => {
   const length = end - start + 1;
   return Array.from({ length }, (_, idx) => idx + start);
@@ -30,12 +28,3 @@ export const classnames = (
 ): string => {
   return classnames.filter(String).join(" ");
 };
-
-export const getDownloadUrl = (p: PackageListingDetails) =>
-  `https://thunderstore.io/package/download/${getPath(p)}/`;
-
-export const getInstallUrl = (p: PackageListingDetails) =>
-  `ror2mm://v1/install/thunderstore.io/${getPath(p)}/`;
-
-const getPath = (p: PackageListingDetails) =>
-  `${p.namespace}/${p.name}/${p.latest_version_number}`;

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -82,6 +82,8 @@ export const getFakePackageListingDetails = async (
   const seed = `${community}-${namespace}-${name}`;
   setSeed(seed);
 
+  const version = getVersionNumber();
+
   return {
     ...getFakePackageListing(community, namespace, name),
 
@@ -89,8 +91,10 @@ export const getFakePackageListingDetails = async (
     datetime_created: faker.date.past({ years: 2 }).toISOString(),
     dependant_count: faker.number.int({ min: 0, max: 2000 }),
     dependencies: await getFakeDependencies(community, namespace, name),
-    full_version_name: `${namespace}-${name}-${getVersionNumber()}`,
+    download_url: `https://thunderstore.io/package/download/${namespace}/${name}/${version}/`,
+    full_version_name: `${namespace}-${name}-${version}}`,
     has_changelog: true,
+    install_url: `ror2mm://v1/install/thunderstore.io/${namespace}/${name}/${version}/`,
     latest_version_number: getVersionNumber(),
     team: {
       name: faker.word.words(3),

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -109,8 +109,10 @@ const packageListingDetailSchema = packageListingSchema.extend({
   datetime_created: z.string().datetime(),
   dependant_count: z.number().int().gte(0),
   dependencies: dependencyShema.array(),
+  download_url: z.string().nonempty(),
   full_version_name: z.string().nonempty(),
   has_changelog: z.boolean(),
+  install_url: z.string().nonempty(),
   latest_version_number: z.string().nonempty(),
   team: z.object({
     name: z.string().nonempty(),

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -24,8 +24,10 @@ export interface PackageListingDetails extends PackageListing {
   datetime_created: string;
   dependant_count: number;
   dependencies: PackageDependency[];
+  download_url: string;
   full_version_name: string;
   has_changelog: boolean;
+  install_url: string;
   latest_version_number: string;
   team: PackageTeam;
   website_url: string | null;


### PR DESCRIPTION
It's better to manage the URLs in the backend so it'll be easier to
change them in the future if we need to. Also reduces duplicate code
in the different clients.

Refs TS-1980