### PR TITLE
@thunderstore/dapper: make PackageListingDetail.website_url optional

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -81,16 +81,20 @@ export function PackageDetailLayout(props: Props) {
         <Button.ButtonLabel>{packageData.namespace}</Button.ButtonLabel>
       </Button.Root>
     </TeamLink>,
-
-    <a key="website" href={packageData.website_url}>
-      <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
-        <Button.ButtonLabel>{packageData.website_url}</Button.ButtonLabel>
-        <Button.ButtonIcon>
-          <FontAwesomeIcon icon={faArrowUpRight} />
-        </Button.ButtonIcon>
-      </Button.Root>
-    </a>,
   ];
+
+  if (packageData.website_url) {
+    packageDetailsMeta.push(
+      <a key="website" href={packageData.website_url}>
+        <Button.Root plain colorScheme="transparentPrimary" paddingSize="small">
+          <Button.ButtonLabel>{packageData.website_url}</Button.ButtonLabel>
+          <Button.ButtonIcon>
+            <FontAwesomeIcon icon={faArrowUpRight} />
+          </Button.ButtonIcon>
+        </Button.Root>
+      </a>
+    );
+  }
 
   return (
     <BaseLayout

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -96,7 +96,8 @@ export const getFakePackageListingDetails = async (
       name: faker.word.words(3),
       members: await getFakeTeamMembers(seed),
     },
-    website_url: faker.internet.url(),
+    website_url:
+      faker.helpers.maybe(faker.internet.url, { probability: 0.9 }) ?? null,
   };
 };
 

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -27,7 +27,7 @@ export interface PackageListingDetails extends PackageListing {
   has_changelog: boolean;
   latest_version_number: string;
   team: PackageTeam;
-  website_url: string;
+  website_url: string | null;
 }
 
 export interface PackageDependency {


### PR DESCRIPTION
Although the field is almost certain to have a value, in some cases it
doesn't. For example some of the packages in the QA environment don't
have the field filled.

Refs TS-1980