### PR TITLE
@thunderstore/dapper: add dependency_count to PackageListingDetails

### DIFF
--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.module.css
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.module.css
@@ -1,23 +1,14 @@
 .root {
-  width: 100%;
-  height: var(--height);
-
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap--8);
   border-radius: 8px;
-
-  --height: 272px;
 }
 
-.list {
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-}
-
-.listWrapper {
-  position: relative;
-  width: 100%;
-  height: var(--height);
-  border-radius: var(--border-radius--8);
+.countDescription {
+  padding: 0 var(--space--8);
+  color: var(--color-text--tertiary);
+  font-size: var(--font-size--m);
 }
 
 .item {

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
@@ -10,12 +10,22 @@ import { PackageLink } from "../../../Links/Links";
 import { WrapperCard } from "../../../WrapperCard/WrapperCard";
 import { Dialog } from "../../../../index";
 
+const PREVIEW_LIMIT = 4;
+
 interface Props {
   dependencies: PackageDependency[];
+  totalCount: number;
 }
 
 export function PackageDependencyList(props: Props) {
-  const { dependencies } = props;
+  const { dependencies, totalCount } = props;
+  let countDescription = "";
+
+  if (totalCount === 0) {
+    countDescription = "This mod doesn't depend on other mods.";
+  } else if (totalCount > PREVIEW_LIMIT) {
+    countDescription = `+ ${totalCount - PREVIEW_LIMIT} more`;
+  }
 
   return (
     <WrapperCard
@@ -24,7 +34,7 @@ export function PackageDependencyList(props: Props) {
         <div className={styles.root}>
           <div className={styles.listWrapper}>
             <div className={styles.list}>
-              {dependencies.map((d) => (
+              {dependencies.slice(0, PREVIEW_LIMIT).map((d) => (
                 <PackageDependencyListItem
                   {...d}
                   key={`${d.namespace}-${d.name}`}
@@ -32,32 +42,37 @@ export function PackageDependencyList(props: Props) {
               ))}
             </div>
           </div>
+          {countDescription === "" ? null : (
+            <p className={styles.countDescription}>{countDescription}</p>
+          )}
         </div>
       }
       headerIcon={<FontAwesomeIcon icon={faBoxOpen} />}
       headerRightContent={
-        <Dialog.Root
-          showHeaderBorder
-          title="Required mods"
-          trigger={
-            <div className={styles.dependencyDialogTrigger}>
-              <Button.Root
-                fontSize="medium"
-                paddingSize="none"
-                colorScheme="transparentPrimary"
-              >
-                <Button.ButtonLabel fontWeight="600">
-                  See all
-                </Button.ButtonLabel>
-                <Button.ButtonIcon>
-                  <FontAwesomeIcon icon={faCaretRight} />
-                </Button.ButtonIcon>
-              </Button.Root>
-            </div>
-          }
-        >
-          <PackageDependencyDialog packages={dependencies} />
-        </Dialog.Root>
+        totalCount > PREVIEW_LIMIT ? (
+          <Dialog.Root
+            showHeaderBorder
+            title="Required mods"
+            trigger={
+              <div className={styles.dependencyDialogTrigger}>
+                <Button.Root
+                  fontSize="medium"
+                  paddingSize="none"
+                  colorScheme="transparentPrimary"
+                >
+                  <Button.ButtonLabel fontWeight="600">
+                    See all
+                  </Button.ButtonLabel>
+                  <Button.ButtonIcon>
+                    <FontAwesomeIcon icon={faCaretRight} />
+                  </Button.ButtonIcon>
+                </Button.Root>
+              </div>
+            }
+          >
+            <PackageDependencyDialog packages={dependencies} />
+          </Dialog.Root>
+        ) : null
       }
     />
   );

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDetailLayout.tsx
@@ -192,7 +192,10 @@ export function PackageDetailLayout(props: Props) {
             }
           />
           <PackageTagList packageData={packageData} />
-          <PackageDependencyList dependencies={packageData.dependencies} />
+          <PackageDependencyList
+            dependencies={packageData.dependencies}
+            totalCount={packageData.dependency_count}
+          />
           <PackageTeamMemberList
             community={packageData.community_identifier}
             teamName={packageData.namespace}

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -83,6 +83,7 @@ export const getFakePackageListingDetails = async (
   setSeed(seed);
 
   const version = getVersionNumber();
+  const dependencies = await getFakeDependencies(community, namespace, name);
 
   return {
     ...getFakePackageListing(community, namespace, name),
@@ -90,7 +91,8 @@ export const getFakePackageListingDetails = async (
     community_name: faker.word.sample(),
     datetime_created: faker.date.past({ years: 2 }).toISOString(),
     dependant_count: faker.number.int({ min: 0, max: 2000 }),
-    dependencies: await getFakeDependencies(community, namespace, name),
+    dependencies,
+    dependency_count: dependencies.length,
     download_url: `https://thunderstore.io/package/download/${namespace}/${name}/${version}/`,
     full_version_name: `${namespace}-${name}-${version}}`,
     has_changelog: true,

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -109,6 +109,7 @@ const packageListingDetailSchema = packageListingSchema.extend({
   datetime_created: z.string().datetime(),
   dependant_count: z.number().int().gte(0),
   dependencies: dependencyShema.array(),
+  dependency_count: z.number().int().gte(0),
   download_url: z.string().nonempty(),
   full_version_name: z.string().nonempty(),
   has_changelog: z.boolean(),

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -24,6 +24,7 @@ export interface PackageListingDetails extends PackageListing {
   datetime_created: string;
   dependant_count: number;
   dependencies: PackageDependency[];
+  dependency_count: number;
   download_url: string;
   full_version_name: string;
   has_changelog: boolean;


### PR DESCRIPTION
@thunderstore/dapper: add dependency_count to PackageListingDetails

To avoid bloat on packages with a large number of dependencies, backend
initially returns up to 4 items. More can be loaded later if user so
wishes (method not implemented yet).

Total number of dependencies is returned in a separate field so UI can
indicate that the shown list of dependencies is incomplete.

Refs TS-2012

@thunderstore/cyberstorm: change PackageDependencyList functionality

- Show only four items (this is a fail-safe, Dapper should return only
  four items anyway to avoid slowing down the page load)
- Show description if there's no dependencies, or if there are more
  dependencies than can be shown on the card component
- Show "show more" link only if there's actually more than the four
  visible dependencies
- Remove the fixed height from the component, so it doesn't take up
  space unnecessarily
- Clean up some (no longer needed) styles

Refs TS-2012