### PR TITLE
@thunderstore/dapper: support deactivated dependencies

### DIFF
--- a/packages/cyberstorm/src/components/ImageWithFallback/ImageWithFallback.module.css
+++ b/packages/cyberstorm/src/components/ImageWithFallback/ImageWithFallback.module.css
@@ -1,3 +1,17 @@
+.isSquare {
+  --aspect-ratio: 1;
+  --image-width: 50%;
+}
+
+.is3By4 {
+  --aspect-ratio: 3 / 4;
+  --image-width: 30%;
+}
+
+.fullWidth {
+  --image-width: 100%;
+}
+
 .imageWrapper {
   display: flex;
   align-items: center;
@@ -7,14 +21,14 @@
   color: var(--color-purple--9);
   background-color: var(--color-purple--4);
   transition: 0.2s;
-  aspect-ratio: 3 / 4;
+  aspect-ratio: var(--aspect-ratio);
 }
 
 .imageContent {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30%;
+  width: var(--image-width);
   aspect-ratio: 1;
   transition: 0.2s;
 }
@@ -23,11 +37,7 @@
   height: auto;
 }
 
-.fullWidth {
-  width: 100%;
-}
-
 .image {
   object-fit: cover;
-  aspect-ratio: 3 / 4;
+  aspect-ratio: var(--aspect-ratio);
 }

--- a/packages/cyberstorm/src/components/ImageWithFallback/ImageWithFallback.tsx
+++ b/packages/cyberstorm/src/components/ImageWithFallback/ImageWithFallback.tsx
@@ -1,4 +1,4 @@
-import { faGamepadModern } from "@fortawesome/pro-solid-svg-icons";
+import { faBan, faGamepadModern } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import styles from "./ImageWithFallback.module.css";
@@ -8,7 +8,7 @@ import { classnames } from "../../utils/utils";
 interface Props {
   src: string | null;
   /** Type of the image defines the icon used as the fallback. */
-  type: "community";
+  type: "community" | "package";
   /** Alt text for the image. Leave empty for decorative images. */
   alt?: string;
   /**
@@ -19,17 +19,24 @@ interface Props {
    * needs to be done in the CSS module of the parent component.
    */
   rootClass?: string;
+  /** Force 1:1 aspect ratio */
+  square?: boolean;
 }
 
 /**
  * Show the image, or use predefined icon as the fallback.
  */
 export const ImageWithFallback = (props: Props) => {
-  const { src, type, alt = "", rootClass } = props;
+  const { src, type, alt = "", rootClass, square = false } = props;
+  const rootClasses = classnames(
+    styles.imageWrapper,
+    rootClass,
+    square ? styles.isSquare : styles.is3By4
+  );
 
   if (src) {
     return (
-      <div className={classnames(styles.imageWrapper, rootClass)}>
+      <div className={rootClasses}>
         <div className={classnames(styles.imageContent, styles.fullWidth)}>
           <img src={src} alt={alt} className={styles.image} />
         </div>
@@ -38,7 +45,7 @@ export const ImageWithFallback = (props: Props) => {
   }
 
   return (
-    <div className={classnames(styles.imageWrapper, rootClass)}>
+    <div className={rootClasses}>
       <Icon wrapperClasses={styles.imageContent}>
         <FontAwesomeIcon icon={getIcon(type)} />
       </Icon>
@@ -51,4 +58,5 @@ ImageWithFallback.displayName = "ImageWithFallback";
 const getIcon = (type: Props["type"] = "community") =>
   ({
     community: faGamepadModern,
+    package: faBan,
   }[type]);

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.module.css
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.module.css
@@ -4,9 +4,7 @@
 }
 
 .image {
-  height: 80px;
-  aspect-ratio: 1 / 1;
-  border-radius: var(--border-radius--8);
+  width: 5rem;
 }
 
 .title {

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyDialog/PackageDependencyDialog.tsx
@@ -2,6 +2,7 @@ import { PackageDependency } from "@thunderstore/dapper/types";
 
 import styles from "../PackageDependencyDialog/PackageDependencyDialog.module.css";
 import { PackageLink, PackageVersionLink } from "../../../../Links/Links";
+import { ImageWithFallback } from "../../../../ImageWithFallback/ImageWithFallback";
 
 export interface Props {
   packages: PackageDependency[];
@@ -11,7 +12,9 @@ export const PackageDependencyDialog = (props: Props) => (
   <div className={styles.root}>
     {props.packages.map((packageData, index) => (
       <div key={index} className={styles.item}>
-        <img className={styles.image} src={packageData.icon_url} alt="" />
+        <div className={styles.image}>
+          <ImageWithFallback src={packageData.icon_url} type="package" square />
+        </div>
         <div>
           <div className={styles.title}>
             <PackageLink

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.module.css
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.module.css
@@ -23,9 +23,7 @@
 }
 
 .itemImage {
-  width: auto;
-  height: 3rem;
-  border-radius: var(--border-radius--8);
+  width: 5rem;
 }
 
 .itemTitle {

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageDependencyList/PackageDependencyList.tsx
@@ -9,6 +9,7 @@ import * as Button from "../../../Button/";
 import { PackageLink } from "../../../Links/Links";
 import { WrapperCard } from "../../../WrapperCard/WrapperCard";
 import { Dialog } from "../../../../index";
+import { ImageWithFallback } from "../../../ImageWithFallback/ImageWithFallback";
 
 const PREVIEW_LIMIT = 4;
 
@@ -87,7 +88,9 @@ const PackageDependencyListItem = (props: PackageDependency) => (
     package={props.name}
   >
     <div className={styles.item}>
-      <img src={props.icon_url} className={styles.itemImage} alt="" />
+      <div className={styles.itemImage}>
+        <ImageWithFallback src={props.icon_url} type="package" square />
+      </div>
       <div>
         <div className={styles.itemTitle}>{props.name}</div>
         <p className={styles.itemDescription}>{props.description}</p>

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -63,14 +63,29 @@ const getFakeDependencies = async (
 ) => {
   setSeed(`${community}-${namespace}-${name ?? "package"}`);
 
-  return range(count).map(() => ({
-    community_identifier: community,
-    description: faker.company.buzzPhrase(),
-    icon_url: getFakeImg(),
-    name: (name ?? faker.word.words(3)).split(" ").join("_"),
-    namespace,
-    version_number: getVersionNumber(),
-  }));
+  return range(count).map(() => {
+    // Deactivated packages show no description or icon.
+    const deactivatableFields = faker.helpers.maybe(
+      () => ({
+        description: faker.company.buzzPhrase(),
+        icon_url: getFakeImg(256, 256),
+        is_active: true,
+      }),
+      { probability: 0.8 }
+    ) ?? {
+      description: "This package has been removed.",
+      icon_url: null,
+      is_active: false,
+    };
+
+    return {
+      ...deactivatableFields,
+      community_identifier: community,
+      name: (name ?? faker.word.words(3)).split(" ").join("_"),
+      namespace,
+      version_number: getVersionNumber(),
+    };
+  });
 };
 
 // Content used to render Package's detail view.

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -98,7 +98,8 @@ export async function getPackageListings(
 const dependencyShema = z.object({
   community_identifier: z.string().nonempty(),
   description: z.string(),
-  icon_url: z.string().nonempty(),
+  icon_url: z.string().nonempty().nullable(),
+  is_active: z.boolean(),
   name: z.string().nonempty(),
   namespace: z.string().nonempty(),
   version_number: z.string().nonempty(),

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -37,7 +37,8 @@ export interface PackageListingDetails extends PackageListing {
 export interface PackageDependency {
   community_identifier: string;
   description: string;
-  icon_url: string;
+  icon_url: string | null;
+  is_active: boolean;
   name: string;
   namespace: string;
   version_number: string;


### PR DESCRIPTION
@thunderstore/dapper: support deactivated dependencies

Since deactivated dependencies are still required to use a mod, backend
will return them with the rest of the dependencies from now on. New
field is_active is returned with the data. Since the reason for
deactivation might be a gross icon or description text, null and a
placeholder text is returned instead.

Refs TS-2013

@thunderstore/cyberstorm: support deactivated dependencies

To accommodate for the fact that deactivated dependencies will return
a null instead of icon URL:

- Use ImageWithFallback component instead of img element
- Add support for package icon type to ImageWithFallback
- Add support for square images to ImageWithFallback

These changes were done since it's the minimum required to prevent the
build from breaking. The following changes were considered out of scope
for this task:

- Components currently try to link to the deactivated packages, but
  their name should be shown as plain text instead
- Deactivated dependencies should have "Removed" tag on the sidebar
  of the PackageDependencyList and PackageDependencyDialog

The description for the deactivated dependencies is also censored by
the backend, but that requires no action from the client.

Refs TS-2013