### PR TITLE
Fix issues with rehydration of components that use Dapper

### DIFF
--- a/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/CommunityProfileLayout/CommunityProfileLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { faDiscord } from "@fortawesome/free-brands-svg-icons";
 import { faBoxOpen, faDownload } from "@fortawesome/pro-regular-svg-icons";
 import { faArrowUpRight } from "@fortawesome/pro-solid-svg-icons";

--- a/packages/cyberstorm/src/components/Layout/HomeLayout/HomeLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/HomeLayout/HomeLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styles from "./HomeLayout.module.css";
 import { CommunityCard } from "../../CommunityCard/CommunityCard";
 import { PackageCard } from "../../PackageCard/PackageCard";

--- a/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDependantsLayout/PackageDependantsLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageChangeLog/PackageChangeLog.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageChangeLog/PackageChangeLog.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageReadme/PackageReadme.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageReadme/PackageReadme.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 

--- a/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageVersions/PackageVersions.tsx
+++ b/packages/cyberstorm/src/components/Layout/PackageDetailLayout/PackageVersions/PackageVersions.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { faCircleExclamation } from "@fortawesome/free-solid-svg-icons";
 import { faBoltLightning } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
+++ b/packages/cyberstorm/src/components/Layout/TeamProfileLayout/TeamProfileLayout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 

--- a/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamDetails/TeamDetails.tsx
+++ b/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamDetails/TeamDetails.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 import styles from "./TeamDetails.module.css";

--- a/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamMembers/TeamMembers.tsx
+++ b/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamMembers/TeamMembers.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useDapper } from "@thunderstore/dapper";
 import { usePromise } from "@thunderstore/use-promise";
 import styles from "./TeamMembers.module.css";

--- a/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamServiceAccounts/TeamServiceAccounts.tsx
+++ b/packages/cyberstorm/src/components/Layout/Teams/TeamSettings/TeamServiceAccounts/TeamServiceAccounts.tsx
@@ -1,3 +1,4 @@
+"use client";
 import styles from "./TeamServiceAccounts.module.css";
 import { SettingItem } from "../../../../SettingItem/SettingItem";
 import * as Button from "../../../../Button/";


### PR DESCRIPTION
I'm not 100% certain I understand everything that's going on here, but it seemed components that call useDapper and don't have "use client" defined work nicely when building the project or when accessed in the browser with a direct url (server-side rendered?). But then they break when accessed by navigation from another page (client-side rendered?).

Error messages shown on server's logs show that when rehydrating(?) the page neither ServerDapper nor ClientDapper context provided the Dapper for these pages. Also it seemed that the errors were logged before the actual navigation event, but this might be due NextJs prefetching the content. The error didn't affect components that fetched content with Dapper without navigation (e.g. changelog tab on package listing page).

Or I might be completely misunderstanding this.

Anyway, adding "use client" seemed to fix the issue, so this commit adds it to all components that call useDapper, just to be safe.

Refs TS-1896