### PR TITLE
Internalize "Button to Anchor" logic into Button component

### DIFF
--- a/packages/cyberstorm/src/components/Button/Button.tsx
+++ b/packages/cyberstorm/src/components/Button/Button.tsx
@@ -11,7 +11,9 @@ import { classnames } from "../../utils/utils";
 
 export interface ButtonProps {
   children?: ReactNode | ReactNode[];
+  className?: string;
   plain?: boolean;
+  href?: string;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
   iconAlignment?: "default" | "side";
@@ -75,6 +77,7 @@ const Button = React.forwardRef<
 >((props: PropsWithChildren<ButtonProps>, forwardedRef) => {
   const {
     children,
+    className,
     plain = false,
     type,
     colorScheme = "default",
@@ -90,6 +93,29 @@ const Button = React.forwardRef<
   const fallbackRef = useRef(null);
 
   if (plain) {
+    if (forwardedProps.href) {
+      const fRef = forwardedRef as React.ForwardedRef<HTMLAnchorElement>;
+      const ref = fRef || fallbackRef;
+      // TODO: Add disabled mode
+      return (
+        <TooltipWrapper tooltipText={tooltipText}>
+          <a
+            {...forwardedProps}
+            ref={ref}
+            className={classnames(
+              styles.root,
+              getFontSize(fontSize),
+              getIconAlignment(iconAlignment),
+              getStyle(colorScheme),
+              getPaddingSize(paddingSize),
+              className
+            )}
+          >
+            {children}
+          </a>
+        </TooltipWrapper>
+      );
+    }
     const fRef = forwardedRef as React.ForwardedRef<HTMLDivElement>;
     const ref = fRef || fallbackRef;
     // TODO: Add disabled mode
@@ -103,7 +129,8 @@ const Button = React.forwardRef<
             getFontSize(fontSize),
             getIconAlignment(iconAlignment),
             getStyle(colorScheme),
-            getPaddingSize(paddingSize)
+            getPaddingSize(paddingSize),
+            className
           )}
         >
           {children}
@@ -124,7 +151,8 @@ const Button = React.forwardRef<
             getFontSize(fontSize),
             getIconAlignment(iconAlignment),
             getStyle(colorScheme),
-            getPaddingSize(paddingSize)
+            getPaddingSize(paddingSize),
+            className
           )}
           onClick={onClick}
           disabled={disabled}

--- a/packages/cyberstorm/src/components/Footer/Footer.module.css
+++ b/packages/cyberstorm/src/components/Footer/Footer.module.css
@@ -141,7 +141,7 @@
 
 .adButton {
   display: flex;
-  width: 10em;
+  width: 12em;
 }
 
 .img {

--- a/packages/cyberstorm/src/components/Footer/Footer.tsx
+++ b/packages/cyberstorm/src/components/Footer/Footer.tsx
@@ -129,16 +129,20 @@ export function Footer() {
                       <FontAwesomeIcon icon={faBoltLightning} />
                     </Icon>
                   </div>
-                  <a href="/" className={styles.adButton}>
-                    <Button.Root plain colorScheme="accent" paddingSize="large">
-                      <Button.ButtonLabel fontSize="large">
-                        Get Manager
-                      </Button.ButtonLabel>
-                      <Button.ButtonIcon>
-                        <FontAwesomeIcon icon={faArrowUpRight} />
-                      </Button.ButtonIcon>
-                    </Button.Root>
-                  </a>
+                  <Button.Root
+                    plain
+                    colorScheme="accent"
+                    paddingSize="large"
+                    href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager"
+                    className={styles.adButton}
+                  >
+                    <Button.ButtonLabel fontSize="large">
+                      Get Manager
+                    </Button.ButtonLabel>
+                    <Button.ButtonIcon>
+                      <FontAwesomeIcon icon={faArrowUpRight} />
+                    </Button.ButtonIcon>
+                  </Button.Root>
                 </div>
                 <img
                   alt="Screenshot of the Thunderstore Mod Manager"

--- a/packages/cyberstorm/src/components/Header/Header.tsx
+++ b/packages/cyberstorm/src/components/Header/Header.tsx
@@ -1,4 +1,8 @@
-import { faUpload, faUser } from "@fortawesome/pro-solid-svg-icons";
+import {
+  faArrowUpRight,
+  faUpload,
+  faUser,
+} from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import styles from "./Header.module.css";
@@ -46,13 +50,19 @@ export function Header() {
       <nav className={styles.item}>
         <ul className={styles.nav}>
           <li className={styles.navButtons}>
-            <a href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager">
-              <Button.Root paddingSize="large" colorScheme="accent">
-                <Button.ButtonLabel fontWeight="800">
-                  Get Manager
-                </Button.ButtonLabel>
-              </Button.Root>
-            </a>
+            <Button.Root
+              paddingSize="large"
+              colorScheme="accent"
+              plain
+              href="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager"
+            >
+              <Button.ButtonLabel fontWeight="800">
+                Get Manager
+              </Button.ButtonLabel>
+              <Button.ButtonIcon>
+                <FontAwesomeIcon icon={faArrowUpRight} />
+              </Button.ButtonIcon>
+            </Button.Root>
           </li>
           <li>
             {/* TODO: This is a bit bad, since old upload pages exist on per community basis. Good enough until new upload page is deployed. */}


### PR DESCRIPTION
Internalize "Button to Anchor" logic into Button component

Sometimes Button might be used as a link and in these cases we
want to have Button component as <a> instead of div wrapped with <a>

Fix "Get Manager" buttons

Remove anchor wrappers
Fix styles to be up to specs