### PR TITLE
Remove "Try again" button from error rendering

### DIFF
--- a/apps/cyberstorm-nextjs/app/error.tsx
+++ b/apps/cyberstorm-nextjs/app/error.tsx
@@ -20,12 +20,7 @@ export default function Error({
             <span>{500}</span>
           </div>
           <div className={errorStyles.description}>Internal server error</div>
-          <div className={errorStyles.flavor}>
-            Beep boop. Server something error happens.
-          </div>
-          <Button.Root onClick={() => reset()}>
-            <Button.ButtonLabel>Try again</Button.ButtonLabel>
-          </Button.Root>
+          <div className={errorStyles.flavor}>Failed to fetch data.</div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Remove the "Try again" button from the error rendering component as it does not seem to do anything in the place it currently turns up on.

In other words, either it's misleading & pointless or it's broken.