### PR TITLE
Change config in Dapper and ApiForms/ApiActions to be a callable

### DIFF
--- a/apps/cyberstorm-remix/app/c/community.tsx
+++ b/apps/cyberstorm-remix/app/c/community.tsx
@@ -27,10 +27,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 export async function loader({ request, params }: LoaderFunctionArgs) {
   if (params.communityId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       const searchParams = new URL(request.url).searchParams;
       const ordering =

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -69,10 +69,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const order = searchParams.get("order") ?? SortOptions.Popular;
   const search = searchParams.get("search");
   const page = undefined;
-  const dapper = new DapperTs({
-    apiHost: process.env.PUBLIC_API_URL,
-    sessionId: undefined,
-    csrfToken: undefined,
+  const dapper = new DapperTs(() => {
+    return {
+      apiHost: process.env.PUBLIC_API_URL,
+      sessionId: undefined,
+      csrfToken: undefined,
+    };
   });
   return await dapper.getCommunities(page, order ?? "", search ?? "");
 }

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -63,10 +63,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       return {
         community: await dapper.getCommunity(params.communityId),
@@ -129,8 +131,6 @@ export default function Community() {
 
   const [isLiked, setIsLiked] = useState(false);
 
-  // TODO: VERY CRITICAL TO FIGURE OUT !!! Figure out if this is stupid or not? I'm not sure if Remix will let fetch part of the client loader.
-  // Ideally we could just tell Remix to use the clientLoader to fetch all related data, but it seems like it just doesnt do it, so we have to do this.
   const fetchAndSetRatedPackages = async () => {
     const dapper = window.Dapper;
     if (currentUser?.username) {

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -7,10 +7,12 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       return {
         status: "ok",

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -7,10 +7,12 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       return {
         status: "ok",

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -9,10 +9,12 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       return {
         listing: await dapper.getPackageListingDetails(

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -22,10 +22,12 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
     try {
-      const dapper = new DapperTs({
-        apiHost: process.env.PUBLIC_API_URL,
-        sessionId: undefined,
-        csrfToken: undefined,
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: process.env.PUBLIC_API_URL,
+          sessionId: undefined,
+          csrfToken: undefined,
+        };
       });
       return {
         status: "ok",

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -67,7 +67,7 @@ declare global {
 
 export type OutletContextShape = {
   currentUser: CurrentUser | undefined;
-  requestConfig: RequestConfig;
+  requestConfig: () => RequestConfig;
 };
 
 export const meta: MetaFunction = () => {
@@ -193,23 +193,22 @@ function App() {
   const [currentUser, setCurrentUser] = useState<CurrentUser | undefined>(
     undefined
   );
-  const [requestConfig, setRequestConfig] = useState<RequestConfig>();
+  const [rcCallable, setRcCallable] = useState<() => RequestConfig>();
 
   const session = useSession();
   useEffect(() => {
     // INIT DAPPER
-    window.Dapper = new DapperTs(session.getConfig(), () => {
+    window.Dapper = new DapperTs(session.getConfig, () => {
       session.clearSession();
       redirect("/communities");
     });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    setRcCallable((prevRcCallable) => session.getConfig);
     setCurrentUser(session.getSessionCurrentUser(true));
-    setRequestConfig(session.getConfig());
   }, []);
 
   return (
-    <Outlet
-      context={{ currentUser: currentUser, requestConfig: requestConfig }}
-    />
+    <Outlet context={{ currentUser: currentUser, requestConfig: rcCallable }} />
   );
 }
 

--- a/apps/cyberstorm-remix/cyberstorm/dapper/sessionUtils.ts
+++ b/apps/cyberstorm-remix/cyberstorm/dapper/sessionUtils.ts
@@ -10,15 +10,17 @@ export function getDapper(isClient = false) {
   if (isClient) {
     const session = useSession();
     // TODO: Add "ValidateDapper" and stop always returning a new dapper.
-    return new DapperTs(session.getConfig(), () => {
+    return new DapperTs(session.getConfig, () => {
       session.clearSession();
       redirect("/communities");
     });
   } else {
-    return new DapperTs({
-      apiHost: process.env.PUBLIC_API_URL,
-      sessionId: undefined,
-      csrfToken: undefined,
+    return new DapperTs(() => {
+      return {
+        apiHost: process.env.PUBLIC_API_URL,
+        sessionId: undefined,
+        csrfToken: undefined,
+      };
     });
   }
 }

--- a/packages/cyberstorm-forms/src/actions/PackageDeprecateAction.tsx
+++ b/packages/cyberstorm-forms/src/actions/PackageDeprecateAction.tsx
@@ -13,7 +13,7 @@ export function PackageDeprecateAction(props: {
   namespace: string;
   isDeprecated: boolean;
   dataUpdateTrigger: () => Promise<void>;
-  config: RequestConfig;
+  config: () => RequestConfig;
 }) {
   const { onSubmitSuccess, onSubmitError } = useFormToaster({
     successMessage: `${

--- a/packages/cyberstorm-forms/src/actions/PackageLikeAction.tsx
+++ b/packages/cyberstorm-forms/src/actions/PackageLikeAction.tsx
@@ -11,7 +11,7 @@ export function PackageLikeAction(props: {
   namespace: string;
   isLiked: boolean;
   dataUpdateTrigger: () => Promise<void>;
-  config: RequestConfig;
+  config: () => RequestConfig;
 }) {
   const { onSubmitSuccess, onSubmitError } = useFormToaster({
     successMessage: `${props.isLiked ? "Unliked" : "Liked"} package ${

--- a/packages/cyberstorm-forms/src/forms/PackageEditForm.tsx
+++ b/packages/cyberstorm-forms/src/forms/PackageEditForm.tsx
@@ -31,7 +31,7 @@ export function PackageEditForm(props: {
   isDeprecated: boolean;
   deprecationButton: ReactNode;
   dataUpdateTrigger: () => Promise<void>;
-  config: RequestConfig;
+  config: () => RequestConfig;
 }) {
   const { onSubmitSuccess, onSubmitError } = useFormToaster({
     successMessage: "Changes saved!",

--- a/packages/dapper-ts/src/__tests__/index.ts
+++ b/packages/dapper-ts/src/__tests__/index.ts
@@ -6,7 +6,9 @@ const packageName = "Testitute";
 let dapper: DapperTs;
 
 beforeAll(() => {
-  dapper = new DapperTs({ apiHost: "https://thunderstore.dev" });
+  dapper = new DapperTs(() => {
+    return { apiHost: "https://thunderstore.dev" };
+  });
 });
 
 it("executes getCommunities without errors", async () => {

--- a/packages/dapper-ts/src/index.ts
+++ b/packages/dapper-ts/src/index.ts
@@ -26,15 +26,15 @@ import {
 } from "./methods/team";
 
 export interface DapperTsInterface extends DapperInterface {
-  config: RequestConfig;
+  config: () => RequestConfig;
   removeSessionHook?: () => void;
 }
 
 export class DapperTs implements DapperTsInterface {
-  config: RequestConfig;
+  config: () => RequestConfig;
   removeSessionHook?: () => void;
 
-  constructor(config: RequestConfig, removeSessionHook?: () => void) {
+  constructor(config: () => RequestConfig, removeSessionHook?: () => void) {
     this.config = config;
     this.removeSessionHook = removeSessionHook;
     this.getDynamicHTML = this.getDynamicHTML.bind(this);

--- a/packages/dapper-ts/src/methods/currentUser.ts
+++ b/packages/dapper-ts/src/methods/currentUser.ts
@@ -45,7 +45,7 @@ export const emptyUser = {
 };
 
 export async function getCurrentUser(this: DapperTsInterface) {
-  if (typeof this.config.sessionId !== "string") {
+  if (typeof this.config().sessionId !== "string") {
     return emptyUser;
   }
 

--- a/packages/thunderstore-api/src/apiFetch.ts
+++ b/packages/thunderstore-api/src/apiFetch.ts
@@ -36,7 +36,7 @@ function sleep(delay: number) {
 }
 
 export type apiFetchArgs = {
-  config: RequestConfig;
+  config: () => RequestConfig;
   path: string;
   query?: string;
   request?: Omit<RequestInit, "headers">;
@@ -45,9 +45,9 @@ export type apiFetchArgs = {
 export async function apiFetch2(args: apiFetchArgs) {
   const { config, path, request, query, useSession = false } = args;
   const usedConfig: RequestConfig = useSession
-    ? config
+    ? config()
     : {
-        apiHost: config.apiHost,
+        apiHost: config().apiHost,
         csrfToken: undefined,
         sessionId: undefined,
       };
@@ -69,7 +69,7 @@ export async function apiFetch2(args: apiFetchArgs) {
 }
 
 export function apiFetch(
-  config: RequestConfig,
+  config: () => RequestConfig,
   path: string,
   query?: string,
   request?: Omit<RequestInit, "headers">,

--- a/packages/thunderstore-api/src/fetch/__tests__/defaultConfig.ts
+++ b/packages/thunderstore-api/src/fetch/__tests__/defaultConfig.ts
@@ -1,5 +1,7 @@
-export const config = {
-  apiHost: process.env.TEST_API_DOMAIN ?? "https://thunderstore.dev",
+export const config = () => {
+  return {
+    apiHost: process.env.TEST_API_DOMAIN ?? "https://thunderstore.dev",
+  };
 };
 
 /**

--- a/packages/thunderstore-api/src/fetch/community.ts
+++ b/packages/thunderstore-api/src/fetch/community.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchCommunity(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string
 ) {
   const path = `api/cyberstorm/community/${communityId}/`;

--- a/packages/thunderstore-api/src/fetch/communityFilters.ts
+++ b/packages/thunderstore-api/src/fetch/communityFilters.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchCommunityFilters(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string
 ) {
   const path = `api/cyberstorm/community/${communityId}/filters/`;

--- a/packages/thunderstore-api/src/fetch/communityList.ts
+++ b/packages/thunderstore-api/src/fetch/communityList.ts
@@ -3,7 +3,7 @@ import { apiFetch } from "../apiFetch";
 import { serializeQueryString } from "../queryString";
 
 export async function fetchCommunityList(
-  config: RequestConfig,
+  config: () => RequestConfig,
   page = 1,
   ordering = "name",
   search?: string

--- a/packages/thunderstore-api/src/fetch/communityPackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/communityPackageListings.ts
@@ -4,7 +4,7 @@ import { serializeQueryString } from "../queryString";
 import { PackageListingQueryParams } from "../types";
 
 export async function fetchCommunityPackageListings(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string,
   options?: PackageListingQueryParams
 ) {

--- a/packages/thunderstore-api/src/fetch/currentUser.ts
+++ b/packages/thunderstore-api/src/fetch/currentUser.ts
@@ -1,7 +1,7 @@
 import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
-export async function fetchCurrentUser(config: RequestConfig) {
+export async function fetchCurrentUser(config: () => RequestConfig) {
   const path = "api/experimental/current-user/";
   const request = { cache: "no-store" as RequestCache };
 

--- a/packages/thunderstore-api/src/fetch/dynamicHTML.ts
+++ b/packages/thunderstore-api/src/fetch/dynamicHTML.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchDynamicHTML(
-  config: RequestConfig,
+  config: () => RequestConfig,
   placement: string
 ) {
   const path = `api/cyberstorm/dynamichtml/${placement}`;

--- a/packages/thunderstore-api/src/fetch/namespacePackageListings.ts
+++ b/packages/thunderstore-api/src/fetch/namespacePackageListings.ts
@@ -4,7 +4,7 @@ import { serializeQueryString } from "../queryString";
 import { PackageListingQueryParams } from "../types";
 
 export async function fetchNamespacePackageListings(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string,
   namespaceId: string,
   options?: PackageListingQueryParams

--- a/packages/thunderstore-api/src/fetch/packageChangelog.ts
+++ b/packages/thunderstore-api/src/fetch/packageChangelog.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchPackageChangelog(
-  config: RequestConfig,
+  config: () => RequestConfig,
   namespaceId: string,
   packageName: string,
   versionNumber?: string

--- a/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
+++ b/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
@@ -4,7 +4,7 @@ import { serializeQueryString } from "../queryString";
 import { PackageListingQueryParams } from "../types";
 
 export async function fetchPackageDependantsListings(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string,
   namespaceId: string,
   packageName: string,

--- a/packages/thunderstore-api/src/fetch/packageDeprecate.ts
+++ b/packages/thunderstore-api/src/fetch/packageDeprecate.ts
@@ -11,7 +11,7 @@ export type packageDeprecateApiArgs = {
 };
 
 export function packageDeprecate(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: packageDeprecateApiArgs,
   meta: packageDeprecateMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/packageEditCategories.ts
+++ b/packages/thunderstore-api/src/fetch/packageEditCategories.ts
@@ -13,7 +13,7 @@ export type PackageEditApiArgs = {
 };
 
 export function packageEditCategories(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: PackageEditApiArgs,
   meta: PackageEditMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/packageLike.ts
+++ b/packages/thunderstore-api/src/fetch/packageLike.ts
@@ -11,7 +11,7 @@ export type packageLikeApiArgs = {
 };
 
 export function packageLike(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: packageLikeApiArgs,
   meta: packageLikeMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/packageListingDetails.ts
+++ b/packages/thunderstore-api/src/fetch/packageListingDetails.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchPackageListingDetails(
-  config: RequestConfig,
+  config: () => RequestConfig,
   communityId: string,
   namespaceId: string,
   packageName: string

--- a/packages/thunderstore-api/src/fetch/packageReadme.ts
+++ b/packages/thunderstore-api/src/fetch/packageReadme.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchPackageReadme(
-  config: RequestConfig,
+  config: () => RequestConfig,
   namespaceId: string,
   packageName: string,
   versionNumber?: string

--- a/packages/thunderstore-api/src/fetch/packageVersions.ts
+++ b/packages/thunderstore-api/src/fetch/packageVersions.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchPackageVersions(
-  config: RequestConfig,
+  config: () => RequestConfig,
   namespaceId: string,
   packageName: string
 ) {

--- a/packages/thunderstore-api/src/fetch/ratedPackages.ts
+++ b/packages/thunderstore-api/src/fetch/ratedPackages.ts
@@ -1,7 +1,7 @@
 import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
-export async function fetchRatedPackages(config: RequestConfig) {
+export async function fetchRatedPackages(config: () => RequestConfig) {
   const path = "api/experimental/current-user/rated-packages/";
   const request = { cache: "no-store" as RequestCache };
 

--- a/packages/thunderstore-api/src/fetch/teamAddMember.ts
+++ b/packages/thunderstore-api/src/fetch/teamAddMember.ts
@@ -11,7 +11,7 @@ export type teamAddMemberApiArgs = {
 };
 
 export function teamAddMember(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: teamAddMemberApiArgs,
   meta: teamAddMemberMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamAddServiceAccount.ts
+++ b/packages/thunderstore-api/src/fetch/teamAddServiceAccount.ts
@@ -10,7 +10,7 @@ export type teamAddServiceAccountApiArgs = {
 };
 
 export function teamAddServiceAccount(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: teamAddServiceAccountApiArgs,
   meta: teamAddServiceAccountMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamCreate.ts
+++ b/packages/thunderstore-api/src/fetch/teamCreate.ts
@@ -5,7 +5,10 @@ export type CreateTeamApiArgs = {
   name: string;
 };
 
-export function createTeam(config: RequestConfig, data: CreateTeamApiArgs) {
+export function createTeam(
+  config: () => RequestConfig,
+  data: CreateTeamApiArgs
+) {
   // TODO: The endpoint doesn't exist, and once it does this won't be
   // the URL it's served from.
   const path = "api/cyberstorm/teams/create/";

--- a/packages/thunderstore-api/src/fetch/teamDetails.ts
+++ b/packages/thunderstore-api/src/fetch/teamDetails.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchTeamDetails(
-  config: RequestConfig,
+  config: () => RequestConfig,
   teamName: string
 ) {
   const path = `api/cyberstorm/team/${teamName}/`;

--- a/packages/thunderstore-api/src/fetch/teamDetailsEdit.ts
+++ b/packages/thunderstore-api/src/fetch/teamDetailsEdit.ts
@@ -10,7 +10,7 @@ export type teamDetailsEditApiArgs = {
 };
 
 export function teamDetailsEdit(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: teamDetailsEditApiArgs,
   meta: teamDetailsEditMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamDisbandTeam.ts
+++ b/packages/thunderstore-api/src/fetch/teamDisbandTeam.ts
@@ -10,7 +10,7 @@ export interface teamDisbandTeamApiArgs {
 }
 
 export function teamDisbandTeam(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: teamDisbandTeamApiArgs,
   meta: teamDisbandTeamMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamEditMember.ts
+++ b/packages/thunderstore-api/src/fetch/teamEditMember.ts
@@ -11,7 +11,7 @@ export type teamEditMemberApiArgs = {
 };
 
 export function teamEditMember(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: teamEditMemberApiArgs,
   meta: teamEditMemberMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamMembers.ts
+++ b/packages/thunderstore-api/src/fetch/teamMembers.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchTeamMembers(
-  config: RequestConfig,
+  config: () => RequestConfig,
   teamName: string
 ) {
   const path = `api/cyberstorm/team/${teamName}/member/`;

--- a/packages/thunderstore-api/src/fetch/teamRemoveMember.ts
+++ b/packages/thunderstore-api/src/fetch/teamRemoveMember.ts
@@ -7,7 +7,7 @@ export type teamRemoveMemberMetaArgs = {
 };
 
 export function teamRemoveMember(
-  config: RequestConfig,
+  config: () => RequestConfig,
   _data: object,
   meta: teamRemoveMemberMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamServiceAccountRemove.ts
+++ b/packages/thunderstore-api/src/fetch/teamServiceAccountRemove.ts
@@ -7,7 +7,7 @@ export type teamServiceAccountRemoveMetaArgs = {
 };
 
 export function teamServiceAccountRemove(
-  config: RequestConfig,
+  config: () => RequestConfig,
   _data: object,
   meta: teamServiceAccountRemoveMetaArgs
 ) {

--- a/packages/thunderstore-api/src/fetch/teamServiceAccounts.ts
+++ b/packages/thunderstore-api/src/fetch/teamServiceAccounts.ts
@@ -2,7 +2,7 @@ import { RequestConfig } from "../index";
 import { apiFetch } from "../apiFetch";
 
 export async function fetchTeamServiceAccounts(
-  config: RequestConfig,
+  config: () => RequestConfig,
   teamName: string
 ) {
   const path = `api/cyberstorm/team/${teamName}/service-account/`;

--- a/packages/thunderstore-api/src/fetch/toolsManifestValidate.ts
+++ b/packages/thunderstore-api/src/fetch/toolsManifestValidate.ts
@@ -7,7 +7,7 @@ export interface toolsManifestValidateApiArgs {
 }
 
 export function toolsManifestValidate(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: toolsManifestValidateApiArgs
 ) {
   const path = `/api/experimental/submission/validate/manifest-v1/`;

--- a/packages/thunderstore-api/src/fetch/toolsMarkdownPreview.ts
+++ b/packages/thunderstore-api/src/fetch/toolsMarkdownPreview.ts
@@ -6,7 +6,7 @@ export interface toolsMarkdownPreviewApiArgs {
 }
 
 export function toolsMarkdownPreview(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: toolsMarkdownPreviewApiArgs
 ) {
   const path = `/api/experimental/frontend/render-markdown/`;

--- a/packages/thunderstore-api/src/fetch/userDelete.ts
+++ b/packages/thunderstore-api/src/fetch/userDelete.ts
@@ -5,7 +5,10 @@ export interface userDeleteApiArgs {
   verification: string;
 }
 
-export function userDelete(config: RequestConfig, data: userDeleteApiArgs) {
+export function userDelete(
+  config: () => RequestConfig,
+  data: userDeleteApiArgs
+) {
   const path = `/api/cyberstorm/current-user/delete/`;
 
   return apiFetch2({

--- a/packages/thunderstore-api/src/fetch/userLinkedAccountDisconnect.ts
+++ b/packages/thunderstore-api/src/fetch/userLinkedAccountDisconnect.ts
@@ -6,7 +6,7 @@ export interface userLinkedAccountDisconnectApiArgs {
 }
 
 export function userLinkedAccountDisconnect(
-  config: RequestConfig,
+  config: () => RequestConfig,
   data: userLinkedAccountDisconnectApiArgs
 ) {
   const path = `/api/cyberstorm/current-user/linked-account-disconnect/`;

--- a/packages/ts-api-react-actions/src/ApiAction.tsx
+++ b/packages/ts-api-react-actions/src/ApiAction.tsx
@@ -11,11 +11,11 @@ export interface ApiActionProps<
   Z extends ZodRawShape,
 > {
   schema: Schema;
-  endpoint: ApiEndpoint<RequestConfig, z.infer<Schema>, Meta, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
   meta: Meta;
   onSubmitSuccess?: (result: Result) => void;
   onSubmitError?: (error: Error | ApiError | unknown) => void;
-  config: RequestConfig;
+  config: () => RequestConfig;
 }
 
 export function ApiAction<

--- a/packages/ts-api-react-actions/src/useApiAction.ts
+++ b/packages/ts-api-react-actions/src/useApiAction.ts
@@ -1,24 +1,23 @@
 import { z, ZodObject, ZodRawShape } from "zod";
 import { ApiEndpoint, useApiCall } from "@thunderstore/ts-api-react";
+import { RequestConfig } from "@thunderstore/thunderstore-api";
 
 export type UseApiActionArgs<
-  RequestConfig,
   Schema extends ZodObject<Z>,
   Meta extends object,
   Result extends object,
   Z extends ZodRawShape,
 > = {
-  config: RequestConfig;
+  config: () => RequestConfig;
   meta: Meta;
-  endpoint: ApiEndpoint<RequestConfig, z.infer<Schema>, Meta, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
 };
 export function useApiAction<
-  ConfigPromise,
   Schema extends ZodObject<Z>,
   Meta extends object,
   Result extends object,
   Z extends ZodRawShape,
->(args: UseApiActionArgs<ConfigPromise, Schema, Meta, Result, Z>) {
+>(args: UseApiActionArgs<Schema, Meta, Result, Z>) {
   const { config, meta, endpoint } = args;
   const apiCall = useApiCall(endpoint);
 

--- a/packages/ts-api-react-forms/src/ApiForm.tsx
+++ b/packages/ts-api-react-forms/src/ApiForm.tsx
@@ -14,11 +14,11 @@ export type ApiFormProps<
   Z extends ZodRawShape,
 > = {
   schema: Schema;
-  endpoint: ApiEndpoint<RequestConfig, z.infer<Schema>, Meta, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
   meta: Meta;
   onSubmitSuccess?: (result: Result) => void;
   onSubmitError?: (error: Error | ApiError | unknown) => void;
-  config: RequestConfig;
+  config: () => RequestConfig;
   formProps?: Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">;
 };
 export function ApiForm<

--- a/packages/ts-api-react-forms/src/useApiForm.ts
+++ b/packages/ts-api-react-forms/src/useApiForm.ts
@@ -13,7 +13,7 @@ export type UseApiFormArgs<
 > = {
   schema: Schema;
   meta: Meta;
-  endpoint: ApiEndpoint<RequestConfig, z.infer<Schema>, Meta, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
 };
 export type UseApiFormReturn<
   Schema extends ZodObject<Z>,
@@ -22,7 +22,7 @@ export type UseApiFormReturn<
 > = {
   form: UseFormReturn<z.infer<Schema>>;
   submitHandler: (
-    config: RequestConfig,
+    config: () => RequestConfig,
     data: z.infer<Schema>
   ) => Promise<Result>;
 };
@@ -42,7 +42,7 @@ export function useApiForm<
     resolver: zodResolver(schema),
   });
   const submitHandler = async (
-    config: RequestConfig,
+    config: () => RequestConfig,
     data: z.infer<Schema>
   ) => {
     try {

--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -165,7 +165,7 @@ export function SessionProvider(props: Props) {
   };
 
   const updateCurrentUser = async () => {
-    const dapper = new DapperTs(getConfig(), clearSession);
+    const dapper = new DapperTs(getConfig, clearSession);
     const currentUser = await dapper.getCurrentUser();
     storeCurrentUser(currentUser);
   };

--- a/packages/ts-api-react/src/useApiCall.ts
+++ b/packages/ts-api-react/src/useApiCall.ts
@@ -1,12 +1,14 @@
-export type ApiEndpoint<RequestConfig, Data, Meta, Result> = (
-  config: RequestConfig,
+import { RequestConfig } from "@thunderstore/thunderstore-api";
+
+export type ApiEndpoint<Data, Meta, Result> = (
+  config: () => RequestConfig,
   data: Data,
   meta: Meta
 ) => Promise<Result>;
-export function useApiCall<RequestConfig, Data, Meta, Result>(
-  endpoint: ApiEndpoint<RequestConfig, Data, Meta, Result>
-): (config: RequestConfig, data: Data, meta: Meta) => Promise<Result> {
-  return (config: RequestConfig, data: Data, meta: Meta) => {
+export function useApiCall<Data, Meta, Result>(
+  endpoint: ApiEndpoint<Data, Meta, Result>
+): (config: () => RequestConfig, data: Data, meta: Meta) => Promise<Result> {
+  return (config: () => RequestConfig, data: Data, meta: Meta) => {
     return endpoint(config, data, meta);
   };
 }


### PR DESCRIPTION
This is done in efforts to keep the config out of memory, so that it can
be refreshed and reliably used from the localStorage