### PR TITLE
Improve ApiAction and fix hook mismatch in PackageSearch re-renders

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -407,6 +407,12 @@ export function PackageSearch(props: Props) {
     }
   }, [currentUser]);
 
+  const likeAction = PackageLikeAction({
+    isLoggedIn: Boolean(currentUser?.username),
+    dataUpdateTrigger: fetchAndSetRatedPackages,
+    config: config,
+  });
+
   return (
     <div className="package-search">
       <div className="package-search__sidebar">
@@ -520,14 +526,16 @@ export function PackageSearch(props: Props) {
                   key={`${p.namespace}-${p.name}`}
                   packageData={p}
                   isLiked={ratedPackages.includes(`${p.namespace}-${p.name}`)}
-                  packageLikeAction={PackageLikeAction({
-                    isLoggedIn: Boolean(currentUser?.username),
-                    packageName: p.name,
-                    namespace: p.namespace,
-                    isLiked: ratedPackages.includes(`${p.namespace}-${p.name}`),
-                    dataUpdateTrigger: fetchAndSetRatedPackages,
-                    config: config,
-                  })}
+                  packageLikeAction={() => {
+                    if (likeAction) {
+                      likeAction(
+                        ratedPackages.includes(`${p.namespace}-${p.name}`),
+                        p.namespace,
+                        p.name,
+                        Boolean(currentUser?.username)
+                      );
+                    }
+                  }}
                 />
               ))}
             </div>

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -254,6 +254,12 @@ export default function PackageListing() {
   const isNew =
     Math.round((Date.now() - Date.parse(listing.last_updated)) / 86400000) < 3;
 
+  const likeAction = PackageLikeAction({
+    isLoggedIn: Boolean(currentUser?.username),
+    dataUpdateTrigger: fetchAndSetRatedPackages,
+    config: config,
+  });
+
   return (
     <div className="container container--y container--full layout__content">
       <NewBreadCrumbs rootClasses="layout__breadcrumbs">
@@ -497,14 +503,14 @@ export default function PackageListing() {
               ) : null}
               <NewButton
                 primitiveType="button"
-                onClick={PackageLikeAction({
-                  isLoggedIn: Boolean(currentUser?.username),
-                  packageName: listing.name,
-                  namespace: listing.namespace,
-                  isLiked: isLiked,
-                  dataUpdateTrigger: fetchAndSetRatedPackages,
-                  config: config,
-                })}
+                onClick={() =>
+                  likeAction(
+                    isLiked,
+                    listing.namespace,
+                    listing.name,
+                    Boolean(currentUser?.username)
+                  )
+                }
                 tooltipText="Like"
                 icon={faThumbsUp}
                 csVariant={isLiked ? "success" : "secondary"}

--- a/packages/cyberstorm-forms/src/useFormToaster.ts
+++ b/packages/cyberstorm-forms/src/useFormToaster.ts
@@ -1,33 +1,50 @@
 import { useToast } from "@thunderstore/cyberstorm/src/newComponents/Toast/Provider";
 
-export type UseFormToasterArgs = {
-  successMessage: string;
-  errorMessage?: string;
+export type UseFormToasterArgs<OnSubmitSuccessDataType, OnSubmitErrorDataType> =
+  {
+    successMessage: (props: OnSubmitSuccessDataType) => string | string;
+    errorMessage?: (props: OnSubmitErrorDataType) => string | string;
+  };
+export type UseFormToasterReturn<
+  OnSubmitSuccessDataType,
+  OnSubmitErrorDataType,
+> = {
+  onSubmitSuccess: (props?: OnSubmitSuccessDataType) => void;
+  onSubmitError: (props?: OnSubmitErrorDataType) => void;
 };
-export type UseFormToasterReturn = {
-  onSubmitSuccess: () => void;
-  onSubmitError: () => void;
-};
-export function useFormToaster({
+export function useFormToaster<OnSubmitSuccessDataType, OnSubmitErrorDataType>({
   successMessage,
   errorMessage,
-}: UseFormToasterArgs): UseFormToasterReturn {
+}: UseFormToasterArgs<
+  OnSubmitSuccessDataType,
+  OnSubmitErrorDataType
+>): UseFormToasterReturn<OnSubmitSuccessDataType, OnSubmitErrorDataType> {
   const toast = useToast();
 
   return {
-    onSubmitSuccess: () => {
+    onSubmitSuccess: (props) => {
       toast.addToast({
         csVariant: "success",
-        children: successMessage,
-        duration: 30000,
+        children:
+          typeof successMessage === "string"
+            ? successMessage
+            : props
+              ? successMessage(props)
+              : "OK",
+        duration: 2000,
       });
     },
-    onSubmitError: () => {
+    onSubmitError: (props) => {
       toast.addToast({
         csVariant: "danger",
         children: errorMessage
-          ? errorMessage
+          ? typeof errorMessage === "string"
+            ? errorMessage
+            : props
+              ? errorMessage(props)
+              : "Unknown error occurred. The error has been logged"
           : "Unknown error occurred. The error has been logged",
+        duration: 30000,
       });
     },
   };

--- a/packages/ts-api-react-actions/src/ApiAction.tsx
+++ b/packages/ts-api-react-actions/src/ApiAction.tsx
@@ -6,34 +6,33 @@ import { useApiAction } from "./useApiAction";
 
 export interface ApiActionProps<
   Schema extends ZodObject<Z>,
+  ReturnSchema extends ZodObject<Z>,
   Meta extends object,
-  Result extends object,
   Z extends ZodRawShape,
 > {
   schema: Schema;
-  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
-  meta: Meta;
-  onSubmitSuccess?: (result: Result) => void;
+  returnSchema: ReturnSchema;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, ReturnSchema>;
+  onSubmitSuccess?: (result: ReturnSchema) => void;
   onSubmitError?: (error: Error | ApiError | unknown) => void;
   config: () => RequestConfig;
 }
 
 export function ApiAction<
   Schema extends ZodObject<Z>,
+  ReturnSchema extends ZodObject<Z>,
   Meta extends object,
-  Result extends object,
   Z extends ZodRawShape,
->(props: ApiActionProps<Schema, Meta, Result, Z>) {
-  const { meta, endpoint, onSubmitSuccess, onSubmitError, config } = props;
+>(props: ApiActionProps<Schema, ReturnSchema, Meta, Z>) {
+  const { endpoint, onSubmitSuccess, onSubmitError, config } = props;
   const submitHandler = useApiAction({
     config,
-    meta: meta,
     endpoint: endpoint,
   });
   const onSubmit = useCallback(
-    async (data: z.infer<Schema>) => {
+    async (data: z.infer<Schema>, meta: Meta) => {
       try {
-        const result = await submitHandler(data);
+        const result = await submitHandler(data, meta);
         if (onSubmitSuccess) {
           onSubmitSuccess(result);
         }

--- a/packages/ts-api-react-actions/src/index.ts
+++ b/packages/ts-api-react-actions/src/index.ts
@@ -1,3 +1,6 @@
 export { ApiAction } from "./ApiAction";
-export { packageLikeActionSchema } from "./schema";
+export {
+  packageLikeActionSchema,
+  packageLikeActionReturnSchema,
+} from "./schema";
 export { PackageDeprecateActionSchema } from "./schema";

--- a/packages/ts-api-react-actions/src/schema.ts
+++ b/packages/ts-api-react-actions/src/schema.ts
@@ -4,6 +4,11 @@ export const packageLikeActionSchema = z.object({
   target_state: z.union([z.literal("rated"), z.literal("unrated")]),
 });
 
+export const packageLikeActionReturnSchema = z.object({
+  state: z.union([z.literal("rated"), z.literal("unrated")]),
+  score: z.number(),
+});
+
 export const PackageDeprecateActionSchema = z.object({
   is_deprecated: z.boolean(),
 });

--- a/packages/ts-api-react-actions/src/useApiAction.ts
+++ b/packages/ts-api-react-actions/src/useApiAction.ts
@@ -4,24 +4,23 @@ import { RequestConfig } from "@thunderstore/thunderstore-api";
 
 export type UseApiActionArgs<
   Schema extends ZodObject<Z>,
+  ReturnSchema extends ZodObject<Z>,
   Meta extends object,
-  Result extends object,
   Z extends ZodRawShape,
 > = {
   config: () => RequestConfig;
-  meta: Meta;
-  endpoint: ApiEndpoint<z.infer<Schema>, Meta, Result>;
+  endpoint: ApiEndpoint<z.infer<Schema>, Meta, ReturnSchema>;
 };
 export function useApiAction<
   Schema extends ZodObject<Z>,
+  ReturnSchema extends ZodObject<Z>,
   Meta extends object,
-  Result extends object,
   Z extends ZodRawShape,
->(args: UseApiActionArgs<Schema, Meta, Result, Z>) {
-  const { config, meta, endpoint } = args;
+>(args: UseApiActionArgs<Schema, ReturnSchema, Meta, Z>) {
+  const { config, endpoint } = args;
   const apiCall = useApiCall(endpoint);
 
-  const submitHandler = async (data: z.infer<Schema>) => {
+  const submitHandler = async (data: z.infer<Schema>, meta: Meta) => {
     return await apiCall(config, data, meta);
   };
 


### PR DESCRIPTION
In the last tag the ability to like packages was added to PackageSearch.
This caused React issues because there were different amount of hooks
between re-renders. The solution here is to generate the hook ones and
then just change the input data to that hook.

This solution though warranted some changes to how ApiAction accepts
data. Corresponding changes are done to the PackageLikeAction.

On the same go this commit improves success and error message displaying
via toasts. The changes to useFormToaster are only done to
PackageLikeAction at this moment, but considering all the other actions
and forms are un-used right now, the same changes to other "action" and
"form" functions can be done, when they are taken into use.

Additionally UseApiAction now has return data types.