### PR TITLE
Remove sessionid cookie when it's invalid

### DIFF
--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -237,7 +237,14 @@ export const updateCurrentUser = async (
     customGetConfig
       ? customGetConfig
       : (domain?: string) => getConfig(_storage, domain),
-    customClearSession ? customClearSession : () => clearSession(_storage)
+    customClearSession
+      ? customClearSession
+      : () => {
+          // This function gets called when the dapper getCurrentUser gets 401 as a response
+          clearSession(_storage);
+          // We want to clear the sessionid cookie if it's invalid.
+          clearCookies();
+        }
   );
   const currentUser = await dapper.getCurrentUser();
   storeCurrentUser(_storage, currentUser);


### PR DESCRIPTION
When getting the current user with getCurrentUser the only case when 401
is returned is, when the sessionid cookie / the session at Djangos end
is stale or invalid. Remove it at the same time when Nimbus session is
removed.