### PR TITLE
Remove case-insensitive conversions from namespace and package params

### DIFF
--- a/packages/thunderstore-api/src/fetch/packageChangelog.ts
+++ b/packages/thunderstore-api/src/fetch/packageChangelog.ts
@@ -7,10 +7,8 @@ export async function fetchPackageChangelog(
   packageName: string,
   versionNumber?: string
 ) {
-  const n = namespaceId.toLocaleLowerCase();
-  const p = packageName.toLocaleLowerCase();
   const v = versionNumber ? `v/${versionNumber}` : `latest`;
-  const path = `api/cyberstorm/package/${n}/${p}/${v}/changelog/`;
+  const path = `api/cyberstorm/package/${namespaceId}/${packageName}/${v}/changelog/`;
 
   return await apiFetch(config, path);
 }

--- a/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
+++ b/packages/thunderstore-api/src/fetch/packageDependantsListings.ts
@@ -11,9 +11,7 @@ export async function fetchPackageDependantsListings(
   options?: PackageListingQueryParams
 ) {
   const c = communityId.toLocaleLowerCase();
-  const n = namespaceId.toLocaleLowerCase();
-  const p = packageName.toLocaleLowerCase();
-  const path = `api/cyberstorm/listing/${c}/${n}/${p}/dependants/`;
+  const path = `api/cyberstorm/listing/${c}/${namespaceId}/${packageName}/dependants/`;
 
   const queryParams = [
     { key: "ordering", value: options?.ordering, impotent: "last-updated" },

--- a/packages/thunderstore-api/src/fetch/packageListingDetails.ts
+++ b/packages/thunderstore-api/src/fetch/packageListingDetails.ts
@@ -8,9 +8,7 @@ export async function fetchPackageListingDetails(
   packageName: string
 ) {
   const c = communityId.toLocaleLowerCase();
-  const n = namespaceId.toLocaleLowerCase();
-  const p = packageName.toLocaleLowerCase();
-  const path = `api/cyberstorm/listing/${c}/${n}/${p}/`;
+  const path = `api/cyberstorm/listing/${c}/${namespaceId}/${packageName}/`;
 
   return await apiFetch(config, path);
 }

--- a/packages/thunderstore-api/src/fetch/packageReadme.ts
+++ b/packages/thunderstore-api/src/fetch/packageReadme.ts
@@ -7,10 +7,8 @@ export async function fetchPackageReadme(
   packageName: string,
   versionNumber?: string
 ) {
-  const n = namespaceId.toLocaleLowerCase();
-  const p = packageName.toLocaleLowerCase();
   const v = versionNumber ? `v/${versionNumber}` : `latest`;
-  const path = `api/cyberstorm/package/${n}/${p}/${v}/readme/`;
+  const path = `api/cyberstorm/package/${namespaceId}/${packageName}/${v}/readme/`;
 
   return await apiFetch(config, path);
 }

--- a/packages/thunderstore-api/src/fetch/packageVersions.ts
+++ b/packages/thunderstore-api/src/fetch/packageVersions.ts
@@ -6,9 +6,7 @@ export async function fetchPackageVersions(
   namespaceId: string,
   packageName: string
 ) {
-  const n = namespaceId.toLocaleLowerCase();
-  const p = packageName.toLocaleLowerCase();
-  const path = `api/cyberstorm/package/${n}/${p}/versions/`;
+  const path = `api/cyberstorm/package/${namespaceId}/${packageName}/versions/`;
 
   return await apiFetch(config, path);
 }


### PR DESCRIPTION
This caused an issue with the Django APIs as those are now case
sensitive