### PR TITLE
Fix env variable grabbing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: get-node-version
     env:
-      NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
-      NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-      PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
-      PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+      VITE_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+      VITE_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+      VITE_AUTH_BASE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+      VITE_AUTH_RETURN_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node ${{ needs.get-node-version.outputs.node-version }}

--- a/apps/cyberstorm-remix/app/c/community.tsx
+++ b/apps/cyberstorm-remix/app/c/community.tsx
@@ -63,7 +63,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   if (params.communityId) {
     const dapper = new DapperTs(() => {
       return {
-        apiHost: import.meta.env.VITE_API_URL,
+        apiHost: process.env.VITE_API_URL,
         sessionId: undefined,
       };
     });

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -68,7 +68,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const page = undefined;
   const dapper = new DapperTs(() => {
     return {
-      apiHost: import.meta.env.VITE_API_URL,
+      apiHost: process.env.VITE_API_URL,
       sessionId: undefined,
     };
   });

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -27,7 +27,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/packageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/packageEdit.tsx
@@ -44,7 +44,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -132,7 +132,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -9,7 +9,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -9,7 +9,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -13,7 +13,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -32,7 +32,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -13,7 +13,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
-        apiHost: import.meta.env.VITE_API_URL,
+        apiHost: process.env.VITE_API_URL,
         sessionId: undefined,
       };
     });

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -10,7 +10,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
-        apiHost: import.meta.env.VITE_API_URL,
+        apiHost: process.env.VITE_API_URL,
         sessionId: undefined,
       };
     });

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -15,7 +15,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   ) {
     const dapper = new DapperTs(() => {
       return {
-        apiHost: import.meta.env.VITE_API_URL,
+        apiHost: process.env.VITE_API_URL,
         sessionId: undefined,
       };
     });

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -40,7 +40,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   ) {
     const dapper = new DapperTs(() => {
       return {
-        apiHost: import.meta.env.VITE_API_URL,
+        apiHost: process.env.VITE_API_URL,
         sessionId: undefined,
       };
     });

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -22,7 +22,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     try {
       const dapper = new DapperTs(() => {
         return {
-          apiHost: import.meta.env.VITE_API_URL,
+          apiHost: process.env.VITE_API_URL,
           sessionId: undefined,
         };
       });

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -108,7 +108,12 @@ const adContainerIds = ["right-column-1", "right-column-2", "right-column-3"];
 export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<RootClientLoader>("root");
 
-  const domain = import.meta.env.VITE_SITE_URL ?? "https://thunderstore.io";
+  let domain: string;
+  if (import.meta.env.SSR) {
+    domain = process.env.VITE_SITE_URL || "";
+  } else {
+    domain = import.meta.env.VITE_SITE_URL;
+  }
 
   const location = useLocation();
   const shouldShowAds = location.pathname.startsWith("/teams")
@@ -197,7 +202,12 @@ const TooltipProvider = memo(function TooltipProvider({
 
 function App() {
   // TODO: Remove this customization when legacy site is removed
-  const domain = import.meta.env.VITE_SITE_URL ?? "https://thunderstore.io";
+  let domain: string;
+  if (import.meta.env.SSR) {
+    domain = process.env.VITE_SITE_URL || "";
+  } else {
+    domain = import.meta.env.VITE_SITE_URL;
+  }
 
   const data = useRouteLoaderData<typeof clientLoader>("root");
   const dapper = new DapperTs(() => {

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -70,7 +70,7 @@ export async function loader() {
   // console.log("loader context", getSessionTools(context));
   const dapper = new DapperTs(() => {
     return {
-      apiHost: import.meta.env.VITE_API_URL,
+      apiHost: process.env.VITE_API_URL,
       sessionId: undefined,
     };
   });

--- a/apps/cyberstorm-remix/cyberstorm/utils/ThunderstoreAuth.tsx
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ThunderstoreAuth.tsx
@@ -4,11 +4,19 @@ interface Props {
 }
 
 export function buildAuthLoginUrl(props: Props) {
-  return `${import.meta.env.VITE_AUTH_BASE_URL}/auth/login/${props.type}/${
+  let domain: string;
+  let returnDomain: string;
+  if (import.meta.env.SSR) {
+    domain = process.env.VITE_SITE_URL || "";
+    returnDomain = process.env.VITE_AUTH_RETURN_URL || "";
+  } else {
+    domain = import.meta.env.VITE_SITE_URL;
+    returnDomain = import.meta.env.VITE_AUTH_RETURN_URL;
+  }
+
+  return `${domain}/auth/login/${props.type}/${
     props.nextUrl
       ? `?next=${encodeURIComponent(props.nextUrl)}`
-      : `?next=${encodeURIComponent(
-          `${import.meta.env.VITE_AUTH_RETURN_URL}/communities/`
-        )}`
+      : `?next=${encodeURIComponent(`${returnDomain}/communities/`)}`
   }`;
 }

--- a/apps/cyberstorm-storybook/constants.ts
+++ b/apps/cyberstorm-storybook/constants.ts
@@ -1,5 +1,4 @@
-export const API_DOMAIN =
-  process.env.NEXT_PUBLIC_API_URL || "https://thunderstore.io";
+export const API_DOMAIN = process.env.VITE_API_URL || "https://thunderstore.io";
 
 export const ROOT_DOMAIN =
-  process.env.NEXT_PUBLIC_SITE_URL || "https://thunderstore.io";
+  process.env.VITE_SITE_URL || "https://thunderstore.io";

--- a/tools/visual-diff-ci/run_ci_script.py
+++ b/tools/visual-diff-ci/run_ci_script.py
@@ -137,8 +137,10 @@ def setup_frontend():
 
 def start_frontend() -> BgProcess:
     configs = {
-        "PUBLIC_SITE_URL": "http://127.0.0.1:8000",
-        "PUBLIC_API_URL": "http://127.0.0.1:8000",
+        "VITE_SITE_URL": "http://127.0.0.1:8000",
+        "VITE_API_URL": "http://127.0.0.1:8000",
+        "VITE_AUTH_BASE_URL": "http://127.0.0.1:8000",
+        "VITE_AUTH_RETURN_URL": "http://127.0.0.1:8000",
     }
     process = BgProcess(
         [YARN_PATH, "workspace", "@thunderstore/cyberstorm-remix", "start", "--host", "0.0.0.0", "--port", "3000"],


### PR DESCRIPTION
Apparently the Vite env variables are not available in loaders or SSR in
general. So we have to use the process instead on server side code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified server/client domain resolution to avoid incorrect links and removed hardcoded fallback.
  * Fixed API host sourcing for server-side contexts to reduce connection issues.
  * Improved authentication redirect behavior with SSR-aware return URLs.

* **Chores**
  * Standardized environment variable names (VITE_*) across app loaders, workflows, storybook, and CI tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->