### PR TITLE
Update package.json's engine requirements

### DIFF
--- a/apps/cyberstorm-remix/package.json
+++ b/apps/cyberstorm-remix/package.json
@@ -45,7 +45,7 @@
     "vite-tsconfig-paths": "^5.0.1"
   },
   "engines": {
-    "node": ">=20.17.0"
+    "node": ">=24.1.0"
   },
   "repository": "https://github.com/thunderstore-io/thunderstore-ui/tree/master/apps/cyberstorm-remix"
 }

--- a/apps/cyberstorm-storybook/package.json
+++ b/apps/cyberstorm-storybook/package.json
@@ -24,7 +24,7 @@
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "engines": {
-    "node": ">=20.17.0"
+    "node": ">=24.1.0"
   },
   "devDependencies": {
     "@storybook/addon-webpack5-compiler-babel": "3.0.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "plop": "plop"
   },
   "engines": {
-    "node": ">=20.17.0"
+    "node": ">=24.1.0"
   },
   "dependencies": {
     "@babel/core": "7.25.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Raised the minimum required Node.js version to 24.1.0 across the project and related apps.
  - Ensures compatibility with the latest runtime and ecosystem improvements.

- Impact
  - You must use Node.js 24.1.0 or newer to install and run the project.
  - Update your local environment and CI configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->