### PR TITLE
Remove old Breadcrumbs from settings pages

### DIFF
--- a/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
@@ -4,7 +4,6 @@ import { useOutletContext, useRevalidator } from "react-router";
 import {
   Heading,
   Modal,
-  NewBreadCrumbs,
   NewButton,
   NewIcon,
   NewLink,
@@ -65,11 +64,6 @@ export default function Teams() {
 
   return (
     <>
-      <NewBreadCrumbs>
-        <span>
-          <span>Teams</span>
-        </span>
-      </NewBreadCrumbs>
       <PageHeader headingLevel="1" headingSize="2">
         Teams
       </PageHeader>

--- a/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
@@ -70,18 +70,6 @@ export default function Community() {
 
   return (
     <>
-      <NewBreadCrumbs>
-        <NewBreadCrumbsLink
-          primitiveType="cyberstormLink"
-          linkId="Teams"
-          csVariant="cyber"
-        >
-          Teams
-        </NewBreadCrumbsLink>
-        <span>
-          <span>{team.name}</span>
-        </span>
-      </NewBreadCrumbs>
       <PageHeader headingLevel="1" headingSize="2">
         {team.name}
       </PageHeader>

--- a/apps/cyberstorm-remix/app/settings/user/Settings.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Settings.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useLocation, useOutletContext } from "react-router";
-import { NewBreadCrumbs, NewLink, Tabs } from "@thunderstore/cyberstorm";
+import { NewLink, Tabs } from "@thunderstore/cyberstorm";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
 
 import { OutletContextShape } from "../../root";
@@ -48,11 +48,6 @@ export default function Community() {
 
   return (
     <>
-      <NewBreadCrumbs>
-        <span>
-          <span>{outletContext.currentUser.username}</span>
-        </span>
-      </NewBreadCrumbs>
       <PageHeader headingLevel="1" headingSize="2">
         Settings
       </PageHeader>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed breadcrumb navigation from Settings pages (Teams, Team Settings, User Settings) to simplify the UI.
  - Pages now show only the main header without a breadcrumb row.
  - No changes to tabs, routing, modals, or tables; existing functionality remains intact.
  - Aims to reduce visual clutter and improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->