### PR TITLE
Add forced currentUser update to settings and teams pages

### DIFF
--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -43,7 +43,7 @@ import {
   getSessionContext,
   getSessionStale,
   SESSION_STORAGE_KEY,
-  sessionValid,
+  runSessionValidationCheck,
 } from "@thunderstore/ts-api-react/src/SessionContext";
 import {
   getPublicEnvVariables,
@@ -152,12 +152,12 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   } else {
     // In all other cases check if actually need to fetch
     // current-user data. Ideally we shouldn't need to do
-    // this sessionValid check again, but for some reason
+    // this runSessionValidationCheck check again, but for some reason
     // we need to run this here too in addition to the,
     // shouldRevalidate function, cause for some reason
     // the commits to localStorage are not done before
     // the clientLoader is run.
-    sessionTools.sessionValid(
+    sessionTools.runSessionValidationCheck(
       publicEnvVariables.VITE_API_URL,
       publicEnvVariables.VITE_COOKIE_DOMAIN
     );
@@ -191,7 +191,7 @@ export function shouldRevalidate({
     nextUrl.pathname.startsWith("/settings")
   )
     return true;
-  sessionValid(
+  runSessionValidationCheck(
     new StorageManager(SESSION_STORAGE_KEY),
     publicEnvVariables.VITE_API_URL || "",
     publicEnvVariables.VITE_COOKIE_DOMAIN || ""

--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -26,7 +26,7 @@ export interface ContextInterface {
   /** Get RequestConfig for Dapper usage */
   getConfig: (domain?: string) => RequestConfig;
   /** Check if session is valid and try to repair if not */
-  sessionValid: (apiHost: string, cookieDomain: string) => boolean;
+  runSessionValidationCheck: (apiHost: string, cookieDomain: string) => boolean;
   /** apiHost of the session */
   apiHost?: string;
   /** Async function to update currentUser */
@@ -120,7 +120,7 @@ function parseCurrentUser(currentUser: unknown): User {
   }
 }
 
-export const sessionValid = (
+export const runSessionValidationCheck = (
   _storage: StorageManager,
   apiHost: string,
   cookieDomain: string
@@ -252,8 +252,11 @@ export const getSessionContext = (
   };
 
   // Check current session and try to fix it if cookies are not the same as storage
-  const _sessionValid = (apiHost: string, cookieDomain: string): boolean => {
-    return sessionValid(_storage, apiHost, cookieDomain);
+  const _runSessionValidationCheck = (
+    apiHost: string,
+    cookieDomain: string
+  ): boolean => {
+    return runSessionValidationCheck(_storage, apiHost, cookieDomain);
   };
 
   const _storeCurrentUser = (currentUser: User) => {
@@ -279,7 +282,7 @@ export const getSessionContext = (
       });
     } else {
       _storage.setValue(API_HOST_KEY, apiHost);
-      _sessionValid(apiHost, cookieDomain);
+      _runSessionValidationCheck(apiHost, cookieDomain);
     }
   }
 
@@ -287,7 +290,7 @@ export const getSessionContext = (
     clearSession: _clearSession,
     clearCookies: _clearCookies,
     getConfig: _getConfig,
-    sessionValid: _sessionValid,
+    runSessionValidationCheck: _runSessionValidationCheck,
     updateCurrentUser: _updateCurrentUser,
     storeCurrentUser: _storeCurrentUser,
     getSessionCurrentUser: _getSessionCurrentUser,

--- a/packages/ts-api-react/src/index.ts
+++ b/packages/ts-api-react/src/index.ts
@@ -4,7 +4,7 @@ export {
   setSession,
   clearSession,
   getConfig,
-  sessionValid,
+  runSessionValidationCheck,
   storeCurrentUser,
   updateCurrentUser,
   getSessionCurrentUser,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Settings is now available with Connections and Account views.
  - Teams section added, including team pages with tabs: Profile, Members, Service Accounts, and Settings.
  - Mobile user menu now includes the Settings option.

- Refactor
  - Unified internal navigation to use app-native links for Settings, Teams, and Upload across header, desktop dropdown, and mobile menus for more consistent routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->