### PR TITLE
Fix Team Settings pages breadcrumb linkId

### DIFF
--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -358,7 +358,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                         {teamSettingsPage ? (
                           <NewBreadCrumbsLink
                             primitiveType="cyberstormLink"
-                            linkId="Team"
+                            linkId="TeamSettings"
                             csVariant="cyber"
                             team={teamSettingsPage.params.namespaceId}
                           >


### PR DESCRIPTION
oops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the breadcrumb label in Team settings to display “Team Settings” for improved accuracy and consistency across navigation.
  * Ensures the breadcrumb trail reflects the correct destination when browsing Team settings, reducing confusion for users.
  * No changes to functionality or navigation flow—only the displayed label is updated for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->