### PR TITLE
Fix setSsion stale value set

### DIFF
--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -72,7 +72,7 @@ export const setSession = (
 ) => {
   _storage.setValue(API_HOST_KEY, sessionData.apiHost);
   _storage.setValue(COOKIE_DOMAIN_KEY, sessionData.cookieDomain);
-  _storage.setValue(STALE_KEY, sessionData.stale ? "yes" : "no");
+  _storage.setValue(STALE_KEY, sessionData.stale);
 };
 
 export const setSessionStale = (_storage: StorageManager, isStale: boolean) => {


### PR DESCRIPTION
Herp derp, it's not a boolean so we should not check for a boolean, but
just set the value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session staleness handling to store the exact “yes”/“no” value, preventing sessions from being incorrectly marked as stale.
  * Users should see more consistent session behavior, avoiding unexpected stale-state prompts or refreshes.
  * No changes to the public API; no action required by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->