### PR TITLE
Fix session revalidation corner case

### DIFF
--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -142,6 +142,7 @@ export const sessionValid = (
     // sessionid present but no currentUser, session is stale
     if (storedCurrentUser === null) {
       _storage.setValue(STALE_KEY, "yes");
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
When Session.currentUser was missing from localStorage and there was a
sessionid cookie, the currentUser wouldn't be fetched, because
sessionValid returned true.