### PR TITLE
Disable coverage run in CI pipelines until a decision has been made o…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,10 +196,11 @@ jobs:
         run: |
           cd tools/test-ci/
           poetry run python run_ci_script.py
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # TODO: Enable when decision has been made on testing strategy/policy regarding e2e tests
+      # - name: Upload results to Codecov
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
 
   chromatic-deployment:
     runs-on: ubuntu-latest

--- a/tools/test-ci/run_ci_script.py
+++ b/tools/test-ci/run_ci_script.py
@@ -121,7 +121,9 @@ def stop_backend():
 
 
 def run_tests():
-    run_command([YARN_PATH, "coverage"], cwd=REPO_ROOT)
+    # TODO: Enable tests with coverage run when decision has been made on testing strategy/policy regarding e2e tests
+    # run_command([YARN_PATH, "coverage"], cwd=REPO_ROOT)
+    run_command([YARN_PATH, "test"], cwd=REPO_ROOT)
 
 
 def main():


### PR DESCRIPTION
…n the current issues

As the tests and coverage checks rely on the Thunderstore repositorys tags to boot up the Django backend, that has endpoints for the test runners to use; a situation can occure where the Thunderstore repository master has commits that are not available because a new tag hasn't been made.

First occurence of this issue surfaced when adding the Package Source Tab

New PRs should preferably have tests in them, but commented out until further notice.