### PR TITLE
Improve API error reporting and surface session/auth guidance

### DIFF
--- a/packages/thunderstore-api/src/__tests__/errors.test.ts
+++ b/packages/thunderstore-api/src/__tests__/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../errors";
+
+describe("ApiError", () => {
+  it("includes stale session guidance for unauthorized responses", async () => {
+    const response = new Response(
+      JSON.stringify({ detail: "Session token is no longer valid." }),
+      {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const error = await ApiError.createFromResponse(response, {
+      sessionWasUsed: true,
+    });
+
+    expect(error.message).toContain(
+      "Your session has expired. Please sign in again."
+    );
+    expect(error.message).toContain("Session token is no longer valid.");
+    expect(error.message).toContain("(401 Unauthorized)");
+  });
+
+  it("surfaces validation issue details when available", async () => {
+    const response = new Response(
+      JSON.stringify({ errors: { field: ["Missing value", "Invalid state"] } }),
+      {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const error = await ApiError.createFromResponse(response);
+
+    expect(error.message).toContain(
+      "The server could not process the request due to validation errors."
+    );
+    expect(error.message).toContain("Missing value");
+    expect(error.message).toContain("(422 Unprocessable Entity)");
+  });
+});

--- a/packages/thunderstore-api/src/apiFetch.ts
+++ b/packages/thunderstore-api/src/apiFetch.ts
@@ -81,12 +81,14 @@ export async function apiFetch(props: {
   }
 
   const { config, path, request, queryParams, useSession = false } = args;
+  const configSnapshot = config();
   const usedConfig: RequestConfig = useSession
-    ? config()
+    ? configSnapshot
     : {
-        apiHost: config().apiHost,
+        apiHost: configSnapshot.apiHost,
         sessionId: undefined,
       };
+  const sessionWasUsed = Boolean(usedConfig.sessionId);
   // TODO: Query params have stronger types, but they are not just shown here.
   // Look into furthering the ensuring of passing proper query params.
   const url = getUrl(usedConfig, path, queryParams);
@@ -100,7 +102,9 @@ export async function apiFetch(props: {
   });
 
   if (!response.ok) {
-    throw await ApiError.createFromResponse(response);
+    throw await ApiError.createFromResponse(response, {
+      sessionWasUsed,
+    });
   }
 
   if (responseSchema === undefined) return undefined;

--- a/packages/thunderstore-api/src/errors.ts
+++ b/packages/thunderstore-api/src/errors.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { formatErrorMessage } from "./utils";
 
 type JSONValue =
   | string
@@ -6,6 +7,35 @@ type JSONValue =
   | boolean
   | { [x: string]: JSONValue }
   | JSONValue[];
+
+type ApiErrorContext = {
+  sessionWasUsed?: boolean;
+};
+
+const HTTP_STATUS_TITLES: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  409: "Conflict",
+  422: "Unprocessable Entity",
+  429: "Too Many Requests",
+  500: "Internal Server Error",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+  504: "Gateway Timeout",
+};
+
+const JSON_MESSAGE_PRIORITY_KEYS = [
+  "detail",
+  "message",
+  "error",
+  "errors",
+  "non_field_errors",
+  "root",
+  "__all__",
+  "title",
+];
 
 export function isApiError(e: Error | ApiError | unknown): e is ApiError {
   return e instanceof ApiError;
@@ -25,7 +55,10 @@ export class ApiError extends Error {
     this.response = args.response;
   }
 
-  static async createFromResponse(response: Response): Promise<ApiError> {
+  static async createFromResponse(
+    response: Response,
+    context: ApiErrorContext = {}
+  ): Promise<ApiError> {
     let responseJson: JSONValue | undefined;
     try {
       responseJson = await response.json();
@@ -35,7 +68,7 @@ export class ApiError extends Error {
     }
 
     return new ApiError({
-      message: `${response.status}: ${response.statusText}`,
+      message: buildApiErrorMessage({ response, responseJson, context }),
       response: response,
       responseJson: responseJson,
     });
@@ -65,18 +98,140 @@ export class ApiError extends Error {
 
 export class RequestBodyParseError extends Error {
   constructor(public error: z.ZodError) {
-    super(error.message);
+    super(formatErrorMessage(error));
   }
 }
 
 export class RequestQueryParamsParseError extends Error {
   constructor(public error: z.ZodError) {
-    super(error.message);
+    super(formatErrorMessage(error));
   }
 }
 
 export class ParseError extends Error {
   constructor(public error: z.ZodError) {
-    super(error.message);
+    super(formatErrorMessage(error));
   }
+}
+
+function buildApiErrorMessage(args: {
+  response: Response;
+  responseJson?: JSONValue;
+  context: ApiErrorContext;
+}): string {
+  const { response, responseJson, context } = args;
+  const statusLabel = getStatusLabel(response);
+  const baseMessage = getBaseMessage(response.status, context);
+  const detailMessage = extractMessage(responseJson);
+
+  const parts: string[] = [];
+
+  if (baseMessage) {
+    parts.push(baseMessage);
+  }
+
+  if (
+    detailMessage &&
+    (!baseMessage ||
+      detailMessage.toLowerCase().trim() !== baseMessage.toLowerCase().trim())
+  ) {
+    if (parts.length > 0) {
+      const lastIndex = parts.length - 1;
+      const trimmed = parts[lastIndex].trim();
+      const needsSeparator = !/[.!?:]$/.test(trimmed);
+      parts[lastIndex] = needsSeparator ? `${trimmed}:` : trimmed;
+    }
+    parts.push(detailMessage);
+  }
+
+  const messageBody = parts.join(" ").trim();
+
+  if (messageBody.length > 0) {
+    return `${messageBody} (${statusLabel})`;
+  }
+
+  return statusLabel;
+}
+
+function getBaseMessage(
+  status: number,
+  context: ApiErrorContext
+): string | undefined {
+  if (status === 401) {
+    if (context.sessionWasUsed) {
+      return "Your session has expired. Please sign in again.";
+    }
+    return "Authentication required. Please sign in.";
+  }
+
+  switch (status) {
+    case 400:
+      return "The request is invalid. Please review the provided data.";
+    case 403:
+      return "You do not have permission to perform this action.";
+    case 404:
+      return "The requested resource was not found.";
+    case 409:
+      return "The request conflicts with the current state.";
+    case 422:
+      return "The server could not process the request due to validation errors.";
+    case 429:
+      return "Too many requests were sent in a short time.";
+    default:
+      if (status >= 500 && status < 600) {
+        return "The server encountered an unexpected error. Please try again later.";
+      }
+  }
+
+  return undefined;
+}
+
+function extractMessage(value: JSONValue | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => extractMessage(item))
+      .filter((item): item is string => Boolean(item));
+
+    if (parts.length > 0) {
+      return parts.join(" ");
+    }
+
+    return undefined;
+  }
+
+  const objectValue = value as { [x: string]: JSONValue };
+
+  for (const key of JSON_MESSAGE_PRIORITY_KEYS) {
+    if (key in objectValue) {
+      const message = extractMessage(objectValue[key]);
+      if (message) {
+        return message;
+      }
+    }
+  }
+
+  for (const entry of Object.values(objectValue)) {
+    const message = extractMessage(entry);
+    if (message) {
+      return message;
+    }
+  }
+
+  return undefined;
+}
+
+function getStatusLabel(response: Response): string {
+  const fallback = HTTP_STATUS_TITLES[response.status] ?? "Error";
+  const statusText = response.statusText?.trim() || fallback;
+  return `${response.status} ${statusText}`.trim();
 }

--- a/packages/thunderstore-api/src/get/__tests__/teamMembers.test.ts
+++ b/packages/thunderstore-api/src/get/__tests__/teamMembers.test.ts
@@ -10,5 +10,5 @@ it("ensures accessing team members requires authentication", async () => {
       data: {},
       queryParams: {},
     })
-  ).rejects.toThrowError("401: Unauthorized");
+  ).rejects.toThrowError("Authentication required. Please sign in.");
 });

--- a/packages/thunderstore-api/src/get/__tests__/teamServiceAccounts.test.ts
+++ b/packages/thunderstore-api/src/get/__tests__/teamServiceAccounts.test.ts
@@ -10,5 +10,5 @@ it("ensures accessing team members requires authentication", async () => {
       data: {},
       queryParams: {},
     })
-  ).rejects.toThrowError("401: Unauthorized");
+  ).rejects.toThrowError("Authentication required. Please sign in.");
 });


### PR DESCRIPTION
- Refactor errors to build user-friendly messages (buildApiErrorMessage, getBaseMessage, extractMessage, getStatusLabel)
- Use formatted Zod error messages for parse errors via formatErrorMessage
- Make apiFetch snapshot config once and pass sessionWasUsed into ApiError.createFromResponse
- Add tests for ApiError (stale session guidance and validation detail extraction)
- Update existing tests to expect the new authentication guidance message