### PR TITLE
Improve API error handling and surface user-facing errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## Creating new files
+- When creating a new file and encountering an line endings related issue; stop and ask for the user to fix the line endings.
+
+## Code readibility
+- Ensure all classes and functions have up-to-date JSDoc annotations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,20 @@
 
 ## Code readibility
 - Ensure all classes and functions have up-to-date JSDoc annotations.
+
+## Audit documentation
+- Capture work in the existing docs under `docs/` (or create a new markdown file there) before making code changes.
+- Record the scope, impacted surface area, and the date so future contributors can see what was completed and why.
+- Use tables when summarizing scope, status, and follow-ups so progress stays easy to scan.
+- Default table columns: `Path`, `Current pattern`, `Risk`, `Suggested next step`.
+- Fill each row with:
+	- `Path`: the file, route, or module under review.
+	- `Current pattern`: concise description of the observed behavior or implementation.
+	- `Risk`: qualitative severity (e.g., Low/Medium/High) with optional brief rationale.
+	- `Suggested next step`: the planned action or completion note with date when done.
+- When work progresses, update the same entry instead of creating duplicates; note pending follow-ups and mark them complete once verified.
+- Update each row accordingly:
+	- `Path`: the new file, route, or module, if it has changed.
+	- `Current pattern`: concise description of the current (often new after changes) observed behavior or implementation.
+	- `Risk`: up-to-date qualitative severity (e.g., Low/Medium/High) with optional brief rationale.
+	- `Suggested next step`: the planned next action or "-" when done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
+# When in Agent or Plan mode
 ## Creating new files
 - When creating a new file and encountering an line endings related issue; stop and ask for the user to fix the line endings.
 
 ## Code readibility
 - Ensure all classes and functions have up-to-date JSDoc annotations.
 
+# When working with audit document or asked to audit
 ## Audit documentation
 - Capture work in the existing docs under `docs/` (or create a new markdown file there) before making code changes.
 - Record the scope, impacted surface area, and the date so future contributors can see what was completed and why.

--- a/apps/cyberstorm-remix/app/c/Community.css
+++ b/apps/cyberstorm-remix/app/c/Community.css
@@ -197,6 +197,19 @@
     }
   }
 
+  .community__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .community__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
+
   @media (width >= 41rem) {
     .community__background {
       height: 12.5rem;

--- a/apps/cyberstorm-remix/app/c/community.tsx
+++ b/apps/cyberstorm-remix/app/c/community.tsx
@@ -88,7 +88,11 @@ export function clientLoader({ params }: LoaderFunctionArgs) {
       };
     });
     return {
-      community: dapper.getCommunity(params.communityId),
+      community: dapper
+        .getCommunity(params.communityId)
+        .catch((error) =>
+          handleLoaderError(error, { mappings: communityErrorMappings })
+        ),
     };
   }
   throwUserFacingPayloadResponse({

--- a/apps/cyberstorm-remix/app/c/community.tsx
+++ b/apps/cyberstorm-remix/app/c/community.tsx
@@ -12,6 +12,7 @@ import {
 } from "react-router";
 import {
   Heading,
+  NewAlert,
   NewButton,
   NewIcon,
   NewLink,
@@ -28,7 +29,7 @@ import {
   getPublicEnvVariables,
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import { classnames } from "@thunderstore/cyberstorm/src/utils/utils";
 import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
 import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
@@ -78,8 +79,10 @@ export async function loader({ params }: LoaderFunctionArgs) {
   });
 }
 
-export function clientLoader({ params }: LoaderFunctionArgs) {
-  if (params.communityId) {
+export async function clientLoader({ params }: LoaderFunctionArgs) {
+  const { communityId } = params;
+
+  if (communityId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
       return {
@@ -87,12 +90,23 @@ export function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
+
+    const communityPromise = dapper.getCommunity(communityId).catch((error) => {
+      try {
+        handleLoaderError(error, { mappings: communityErrorMappings });
+      } catch (thrown) {
+        return {
+          __error: resolveRouteErrorPayload(thrown),
+        } as const;
+      }
+
+      return {
+        __error: resolveRouteErrorPayload(error),
+      } as const;
+    });
+
     return {
-      community: dapper
-        .getCommunity(params.communityId)
-        .catch((error) =>
-          handleLoaderError(error, { mappings: communityErrorMappings })
-        ),
+      community: communityPromise,
     };
   }
   throwUserFacingPayloadResponse({
@@ -112,6 +126,18 @@ export function shouldRevalidate(arg: ShouldRevalidateFunctionArgs) {
   return arg.defaultShouldRevalidate;
 }
 
+type CommunityDetails = Awaited<ReturnType<DapperTs["getCommunity"]>>;
+type CommunityError = {
+  readonly __error: ReturnType<typeof resolveRouteErrorPayload>;
+};
+type CommunityLoaderResult = CommunityDetails | CommunityError;
+
+function isCommunityError(
+  value: CommunityLoaderResult
+): value is CommunityError {
+  return typeof (value as CommunityError).__error !== "undefined";
+}
+
 export default function Community() {
   const { community } = useLoaderData<typeof loader | typeof clientLoader>();
   const location = useLocation();
@@ -121,178 +147,223 @@ export default function Community() {
     splitPath.length > 5 && splitPath[1] === "c" && splitPath[3] === "p";
 
   const outletContext = useOutletContext() as OutletContextShape;
+  const communityPromise = useMemo<Promise<CommunityLoaderResult>>(
+    () => Promise.resolve(community) as Promise<CommunityLoaderResult>,
+    [community]
+  );
 
   return (
     <>
       {isSubPath ? null : (
-        <Suspense>
-          <Await resolve={community}>
-            {(resolvedValue) => (
-              <>
-                <meta
-                  title={`Thunderstore - The ${resolvedValue.name} Mod Database`}
-                />
-                <meta
-                  name="description"
-                  content={`Mods for ${resolvedValue.name}`}
-                />
-                <meta property="og:type" content="website" />
-                <meta
-                  property="og:url"
-                  content={`${getPublicEnvVariables(["VITE_BETA_SITE_URL"])}${
-                    location.pathname
-                  }`}
-                />
-                <meta
-                  property="og:title"
-                  content={`Thunderstore - The ${resolvedValue.name} Mod Database`}
-                />
-                <meta
-                  property="og:description"
-                  content={`Thunderstore is a mod database and API for downloading ${resolvedValue.name} mods`}
-                />
-                <meta property="og:image:width" content="360" />
-                <meta property="og:image:height" content="480" />
-                <meta
-                  property="og:image"
-                  content={resolvedValue.cover_image_url ?? undefined}
-                />
-                <meta property="og:site_name" content="Thunderstore" />
-              </>
-            )}
+        <Suspense fallback={null}>
+          <Await resolve={communityPromise}>
+            {(result) => {
+              if (isCommunityError(result)) {
+                return null;
+              }
+
+              return (
+                <>
+                  <meta
+                    title={`Thunderstore - The ${result.name} Mod Database`}
+                  />
+                  <meta
+                    name="description"
+                    content={`Mods for ${result.name}`}
+                  />
+                  <meta property="og:type" content="website" />
+                  <meta
+                    property="og:url"
+                    content={`${getPublicEnvVariables(["VITE_BETA_SITE_URL"])}${
+                      location.pathname
+                    }`}
+                  />
+                  <meta
+                    property="og:title"
+                    content={`Thunderstore - The ${result.name} Mod Database`}
+                  />
+                  <meta
+                    property="og:description"
+                    content={`Thunderstore is a mod database and API for downloading ${result.name} mods`}
+                  />
+                  <meta property="og:image:width" content="360" />
+                  <meta property="og:image:height" content="480" />
+                  <meta
+                    property="og:image"
+                    content={result.cover_image_url ?? undefined}
+                  />
+                  <meta property="og:site_name" content="Thunderstore" />
+                </>
+              );
+            }}
           </Await>
         </Suspense>
       )}
 
-      <>
-        <div className="community__header">
-          <div
-            className={classnames(
-              "community__background",
-              isPackageListingSubPath
-                ? "community__background--packagePage"
-                : null
-            )}
-          >
-            <Suspense fallback={<SkeletonBox />}>
-              <Await resolve={community}>
-                {(resolvedValue) =>
-                  resolvedValue.hero_image_url ? (
-                    <img
-                      src={resolvedValue.hero_image_url}
-                      alt={resolvedValue.name}
-                    />
-                  ) : null
-                }
-              </Await>
-            </Suspense>
-          </div>
+      <Suspense fallback={<CommunitySkeleton />}>
+        <Await resolve={communityPromise}>
+          {(result) =>
+            isCommunityError(result) ? (
+              <CommunityAwaitError payload={result.__error} />
+            ) : (
+              <CommunityHeaderContent
+                community={result}
+                isPackageListingSubPath={isPackageListingSubPath}
+                isSubPath={isSubPath}
+              />
+            )
+          }
+        </Await>
+      </Suspense>
 
-          <div
-            className={classnames(
-              "community__content-header-wrapper",
-              isSubPath ? "community__content-header--hide" : null
-            )}
-          >
-            <div className="community__content-header">
-              <div className="community__game-icon">
-                <div className="community__game-icon-tinified">
-                  <Suspense fallback={<SkeletonBox />}>
-                    <Await resolve={community}>
-                      {(resolvedValue) =>
-                        resolvedValue.community_icon_url ? (
-                          <img
-                            src={resolvedValue.community_icon_url}
-                            alt={resolvedValue.name}
-                          />
-                        ) : null
-                      }
-                    </Await>
-                  </Suspense>
-                </div>
-              </div>
-              <div className="community__content-header-content">
-                <div className="community__header-info">
-                  <Suspense fallback={<SkeletonBox />}>
-                    <Await resolve={community}>
-                      {(resolvedValue) => (
-                        <Heading
-                          csLevel={"1"}
-                          csSize={"3"}
-                          csVariant="primary"
-                          mode="display"
-                        >
-                          {resolvedValue.name}
-                        </Heading>
-                      )}
-                    </Await>
-                  </Suspense>
-                </div>
-                <div className="community__header-meta">
-                  <Suspense fallback={<SkeletonBox />}>
-                    <Await resolve={community}>
-                      {(resolvedValue) =>
-                        resolvedValue.wiki_url ? (
-                          <NewLink
-                            primitiveType="link"
-                            href={resolvedValue.wiki_url}
-                            csVariant="cyber"
-                            rootClasses="community__item"
-                          >
-                            <NewIcon csMode="inline" noWrapper>
-                              <FontAwesomeIcon icon={faBook} />
-                            </NewIcon>
-                            <span>Modding Wiki</span>
-                            <NewIcon csMode="inline" noWrapper>
-                              <FontAwesomeIcon icon={faArrowUpRight} />
-                            </NewIcon>
-                          </NewLink>
-                        ) : null
-                      }
-                    </Await>
-                  </Suspense>
-                  <Suspense fallback={<SkeletonBox />}>
-                    <Await resolve={community}>
-                      {(resolvedValue) =>
-                        resolvedValue.discord_url ? (
-                          <NewLink
-                            primitiveType="link"
-                            href={resolvedValue.discord_url}
-                            csVariant="cyber"
-                            rootClasses="community__item"
-                          >
-                            <NewIcon csMode="inline" noWrapper>
-                              <FontAwesomeIcon icon={faDiscord} />
-                            </NewIcon>
-                            <span>Modding Discord</span>
-                            <NewIcon csMode="inline" noWrapper>
-                              <FontAwesomeIcon icon={faArrowUpRight} />
-                            </NewIcon>
-                          </NewLink>
-                        ) : null
-                      }
-                    </Await>
-                  </Suspense>
-                </div>
-              </div>
+      <Outlet context={outletContext} />
+    </>
+  );
+}
+
+function CommunityHeaderContent(props: {
+  community: CommunityDetails;
+  isPackageListingSubPath: boolean;
+  isSubPath: boolean;
+}) {
+  const { community, isPackageListingSubPath, isSubPath } = props;
+
+  return (
+    <div className="community__header">
+      <div
+        className={classnames(
+          "community__background",
+          isPackageListingSubPath ? "community__background--packagePage" : null
+        )}
+      >
+        {community.hero_image_url ? (
+          <img src={community.hero_image_url} alt={community.name} />
+        ) : null}
+      </div>
+
+      <div
+        className={classnames(
+          "community__content-header-wrapper",
+          isSubPath ? "community__content-header--hide" : null
+        )}
+      >
+        <div className="community__content-header">
+          <div className="community__game-icon">
+            <div className="community__game-icon-tinified">
+              {community.community_icon_url ? (
+                <img src={community.community_icon_url} alt={community.name} />
+              ) : null}
             </div>
-            <NewButton
-              csSize="big"
-              csVariant="accent"
-              primitiveType="cyberstormLink"
-              linkId="PackageUpload"
-              rootClasses="community__upload-button"
-            >
-              <NewIcon noWrapper csMode="inline">
-                <FontAwesomeIcon icon={faDownload} />
-              </NewIcon>
-              Upload package
-            </NewButton>
+          </div>
+          <div className="community__content-header-content">
+            <div className="community__header-info">
+              <Heading
+                csLevel={"1"}
+                csSize={"3"}
+                csVariant="primary"
+                mode="display"
+              >
+                {community.name}
+              </Heading>
+            </div>
+            <div className="community__header-meta">
+              {community.wiki_url ? (
+                <NewLink
+                  primitiveType="link"
+                  href={community.wiki_url}
+                  csVariant="cyber"
+                  rootClasses="community__item"
+                >
+                  <NewIcon csMode="inline" noWrapper>
+                    <FontAwesomeIcon icon={faBook} />
+                  </NewIcon>
+                  <span>Modding Wiki</span>
+                  <NewIcon csMode="inline" noWrapper>
+                    <FontAwesomeIcon icon={faArrowUpRight} />
+                  </NewIcon>
+                </NewLink>
+              ) : null}
+              {community.discord_url ? (
+                <NewLink
+                  primitiveType="link"
+                  href={community.discord_url}
+                  csVariant="cyber"
+                  rootClasses="community__item"
+                >
+                  <NewIcon csMode="inline" noWrapper>
+                    <FontAwesomeIcon icon={faDiscord} />
+                  </NewIcon>
+                  <span>Modding Discord</span>
+                  <NewIcon csMode="inline" noWrapper>
+                    <FontAwesomeIcon icon={faArrowUpRight} />
+                  </NewIcon>
+                </NewLink>
+              ) : null}
+            </div>
           </div>
         </div>
-        <Outlet context={outletContext} />
-      </>
-    </>
+        <NewButton
+          csSize="big"
+          csVariant="accent"
+          primitiveType="cyberstormLink"
+          linkId="PackageUpload"
+          rootClasses="community__upload-button"
+        >
+          <NewIcon noWrapper csMode="inline">
+            <FontAwesomeIcon icon={faDownload} />
+          </NewIcon>
+          Upload package
+        </NewButton>
+      </div>
+    </div>
+  );
+}
+
+function CommunitySkeleton() {
+  return (
+    <div className="community__header">
+      <SkeletonBox className="community__background" />
+      <div className="community__content-header-wrapper">
+        <div className="community__content-header">
+          <div className="community__game-icon">
+            <SkeletonBox className="community__game-icon-tinified" />
+          </div>
+          <div className="community__content-header-content">
+            <div className="community__header-info">
+              <div style={{ height: 48, width: 280 }}>
+                <SkeletonBox className="community__header-info-skeleton" />
+              </div>
+            </div>
+            <div className="community__header-meta" style={{ gap: "12px" }}>
+              <div style={{ height: 40, width: 180 }}>
+                <SkeletonBox className="community__header-meta-skeleton" />
+              </div>
+              <div style={{ height: 40, width: 200 }}>
+                <SkeletonBox className="community__header-meta-skeleton" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div style={{ height: 56, width: 240 }}>
+          <SkeletonBox className="community__upload-button" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CommunityAwaitError(props: {
+  payload: ReturnType<typeof resolveRouteErrorPayload>;
+}) {
+  const { payload } = props;
+
+  return (
+    <div className="container container--y container--full community__error">
+      <NewAlert csVariant="danger">
+        <strong>{payload.headline}</strong>
+        {payload.description ? ` ${payload.description}` : ""}
+      </NewAlert>
+    </div>
   );
 }
 

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -133,21 +133,29 @@ export async function clientLoader({
     });
     const query = resolvePackageSearchQuery(request);
     return {
-      filters: dapper.getCommunityFilters(params.communityId),
-      listings: dapper.getPackageListings(
-        {
-          kind: "community",
-          communityId: params.communityId,
-        },
-        query.ordering ?? "",
-        query.page,
-        query.search,
-        query.includedCategories,
-        query.excludedCategories,
-        query.section,
-        query.nsfw,
-        query.deprecated
-      ),
+      filters: dapper
+        .getCommunityFilters(params.communityId)
+        .catch((error) =>
+          handleLoaderError(error, { mappings: packageSearchErrorMappings })
+        ),
+      listings: dapper
+        .getPackageListings(
+          {
+            kind: "community",
+            communityId: params.communityId,
+          },
+          query.ordering ?? "",
+          query.page,
+          query.search,
+          query.includedCategories,
+          query.excludedCategories,
+          query.section,
+          query.nsfw,
+          query.deprecated
+        )
+        .catch((error) =>
+          handleLoaderError(error, { mappings: packageSearchErrorMappings })
+        ),
     };
   }
   throwUserFacingPayloadResponse({

--- a/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/NimbusErrorBoundary.css
+++ b/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/NimbusErrorBoundary.css
@@ -1,0 +1,43 @@
+@layer nimbus-components {
+  .nimbus-error-boundary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    align-items: flex-start;
+    padding: var(--space-20);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgb(61 78 159 / 0.35);
+    background: linear-gradient(
+      135deg,
+      rgb(29 41 95 / 0.35),
+      rgb(19 26 68 / 0.5)
+    );
+    transition:
+      background 180ms ease,
+      border-color 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  .nimbus-error-boundary:hover {
+    border-color: rgb(103 140 255 / 0.55);
+    background: linear-gradient(
+      135deg,
+      rgb(40 58 132 / 0.45),
+      rgb(24 32 86 / 0.65)
+    );
+    box-shadow: 0 0.5rem 1.25rem rgb(29 36 82 / 0.45);
+  }
+
+  .nimbus-error-boundary__actions {
+    display: flex;
+    align-self: stretch;
+    }
+
+  .nimbus-error-boundary__button {
+    flex-grow: 1;
+  }
+  
+  .nimbus-error-boundary__description {
+    display: none;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/NimbusErrorBoundary.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/NimbusErrorBoundary.tsx
@@ -1,0 +1,211 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { useCallback } from "react";
+import { NewButton } from "@thunderstore/cyberstorm";
+import { useLocation } from "react-router";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
+import "./NimbusErrorBoundary.css";
+
+interface NimbusErrorBoundaryState {
+  error: Error | null;
+}
+
+export interface NimbusErrorRetryHandlerArgs {
+  /** The error instance that triggered the boundary. */
+  error: unknown;
+  /**
+   * Clears the captured error and re-renders the child tree. Consumers should
+   * call this when attempting to recover without a full reload.
+   */
+  reset: () => void;
+}
+
+export type NimbusErrorBoundaryFallbackConfig = Omit<
+  NimbusErrorBoundaryFallbackProps,
+  "error" | "reset"
+>;
+
+export interface NimbusErrorBoundaryProps {
+  /** React subtree guarded by the error boundary. */
+  children: ReactNode;
+  /** Optional heading override for the fallback surface. */
+  title?: string;
+  /** Optional description override for the fallback surface. */
+  description?: string;
+  /**
+   * Text for the retry button. Defaults to "Retry".
+   */
+  retryLabel?: string;
+  /**
+   * Called after the boundary captures an error. Can be used for reporting.
+   */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /**
+   * Called after the boundary has been reset. Useful for clearing external
+   * state (e.g. closing modals).
+   */
+  onReset?: () => void;
+  /**
+   * Custom fallback component. Receives the captured error along with reset
+   * helpers. Defaults to {@link NimbusErrorBoundaryFallback}.
+   */
+  fallback?:
+    | React.ComponentType<NimbusErrorBoundaryFallbackProps>
+    | NimbusErrorBoundaryFallbackConfig;
+  /**
+   * Optional retry handler. When provided, the fallback's retry button will
+   * invoke this instead of the default reset behaviour.
+   */
+  onRetry?: (args: NimbusErrorRetryHandlerArgs) => void;
+}
+
+export interface NimbusErrorBoundaryFallbackProps {
+  /** The error that caused the boundary to render. */
+  error: unknown;
+  /** Clears the boundary's error state to allow a re-render. */
+  reset?: () => void;
+  /** Optional heading override passed from the boundary. */
+  title?: string;
+  /** Optional description override passed from the boundary. */
+  description?: string;
+  /** Retry button label. */
+  retryLabel?: string;
+  /** Optional retry handler. */
+  onRetry?: (args: NimbusErrorRetryHandlerArgs) => void;
+  /** Optional class name appended to the fallback container. */
+  className?: string;
+}
+
+/**
+ * NimbusErrorBoundary isolates rendering failures within a subtree and surfaces
+ * a consistent recovery UI with an optional "Retry" affordance.
+ */
+export class NimbusErrorBoundary extends Component<
+  NimbusErrorBoundaryProps,
+  NimbusErrorBoundaryState
+> {
+  public state: NimbusErrorBoundaryState = {
+    error: null,
+  };
+
+  public static getDerivedStateFromError(
+    error: Error
+  ): NimbusErrorBoundaryState {
+    return { error };
+  }
+
+  public componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  private readonly resetBoundary = () => {
+    this.setState({ error: null }, () => {
+      this.props.onReset?.();
+    });
+  };
+
+  public override render() {
+    const { error } = this.state;
+
+    if (error) {
+      const fallbackValue = this.props.fallback;
+      let fallbackConfig: NimbusErrorBoundaryFallbackConfig | undefined;
+      let FallbackComponent: React.ComponentType<NimbusErrorBoundaryFallbackProps> =
+        NimbusErrorBoundaryFallback;
+
+      if (fallbackValue) {
+        if (typeof fallbackValue === "function") {
+          FallbackComponent =
+            fallbackValue as React.ComponentType<NimbusErrorBoundaryFallbackProps>;
+        } else {
+          fallbackConfig = fallbackValue;
+        }
+      }
+
+      const fallbackTitle = this.props.title ?? fallbackConfig?.title;
+      const fallbackDescription =
+        this.props.description ?? fallbackConfig?.description;
+      const fallbackRetryLabel =
+        this.props.retryLabel ?? fallbackConfig?.retryLabel;
+      const fallbackClassName = fallbackConfig?.className;
+      const fallbackOnRetry = this.props.onRetry ?? fallbackConfig?.onRetry;
+
+      return (
+        <FallbackComponent
+          error={error}
+          reset={this.resetBoundary}
+          title={fallbackTitle}
+          description={fallbackDescription}
+          retryLabel={fallbackRetryLabel}
+          className={fallbackClassName}
+          onRetry={fallbackOnRetry}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Default fallback surface displayed by {@link NimbusErrorBoundary}. It derives
+ * user-facing messaging from the captured error when possible and offers a
+ * retry button that either resets the boundary or runs a custom handler.
+ */
+export function NimbusErrorBoundaryFallback(
+  props: NimbusErrorBoundaryFallbackProps
+) {
+  const { error, reset, onRetry, className } = props;
+  const { pathname, search, hash } = useLocation();
+
+  const payload = safeResolveRouteErrorPayload(error);
+  const title = props.title ?? payload?.headline ?? "Something went wrong";
+  const description =
+    props.description ?? payload?.description ?? "Please try again.";
+  const retryLabel = props.retryLabel ?? "Retry";
+  const currentLocation = `${pathname}${search}${hash}`;
+  const baseClassName =
+    "container container--y container--full nimbus-error-boundary";
+  const rootClassName = className
+    ? `${baseClassName} ${className}`
+    : baseClassName;
+
+  const noopReset = useCallback(() => {}, []);
+  const safeReset = reset ?? noopReset;
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry({ error, reset: safeReset });
+      return;
+    }
+
+    window.location.assign(currentLocation);
+  }, [currentLocation, error, onRetry, safeReset]);
+
+  return (
+    <div className={rootClassName}>
+      <p>{title}</p>
+      {description ? (
+        <p className="nimbus-error-boundary__description">{description}</p>
+      ) : null}
+      <div className="nimbus-error-boundary__actions">
+        <NewButton
+          csVariant="accent"
+          onClick={handleRetry}
+          csSize="medium"
+          rootClasses="nimbus-error-boundary__button"
+        >
+          {retryLabel}
+        </NewButton>
+      </div>
+    </div>
+  );
+}
+
+function safeResolveRouteErrorPayload(error: unknown) {
+  try {
+    return resolveRouteErrorPayload(error);
+  } catch (resolutionError) {
+    console.error("Failed to resolve route error payload", resolutionError);
+    return null;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/index.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/NimbusErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export * from "./NimbusErrorBoundary";

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
@@ -132,12 +132,9 @@
     flex-direction: column;
     gap: 1rem;
     align-items: flex-start;
-    padding: 3rem 0;
-  }
-
-  .package-search__error-description {
-    max-width: 40rem;
-    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+    padding: 1rem;
+    align-self: stretch;
+    align-items: center;
   }
 
   .package-search__grid {

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
@@ -127,6 +127,19 @@
     align-self: stretch;
   }
 
+  .package-search__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .package-search__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
+
   .package-search__grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));

--- a/apps/cyberstorm-remix/app/commonComponents/PaginatedDependencies/PaginatedDependencies.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PaginatedDependencies/PaginatedDependencies.tsx
@@ -97,7 +97,7 @@ export const PaginatedDependencies = memo(function PaginatedDependencies(
 
   const versionAndDependencies = useMemo(
     () => Promise.all([props.version, props.dependencies]),
-    [currentPage]
+    [currentPage, props.version, props.dependencies]
   );
 
   return (
@@ -105,12 +105,7 @@ export const PaginatedDependencies = memo(function PaginatedDependencies(
       <Suspense
         fallback={<SkeletonBox className="paginated-dependencies__skeleton" />}
       >
-        <Await
-          resolve={versionAndDependencies}
-          errorElement={
-            <div>Error occurred while loading required dependencies</div>
-          }
-        >
+        <Await resolve={versionAndDependencies}>
           {(resolvedValue) => {
             return (
               <>

--- a/apps/cyberstorm-remix/app/communities/Communities.css
+++ b/apps/cyberstorm-remix/app/communities/Communities.css
@@ -42,6 +42,19 @@
     width: 100%;
   }
 
+  .communities__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .communities__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
+
   .communities__community-skeleton {
     .communities__community-skeleton-image {
       display: flex;

--- a/apps/cyberstorm-remix/app/p/components/ReportPackage/ReportPackageForm.tsx
+++ b/apps/cyberstorm-remix/app/p/components/ReportPackage/ReportPackageForm.tsx
@@ -12,6 +12,8 @@ import {
   type RequestConfig,
   type PackageListingReportRequestData,
   packageListingReport,
+  UserFacingError,
+  formatUserFacingError,
 } from "@thunderstore/thunderstore-api";
 
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
@@ -92,7 +94,7 @@ export function ReportPackageForm(
     PackageListingReportRequestData,
     Error,
     SubmitorOutput,
-    Error,
+    UserFacingError,
     InputErrors
   >({
     inputs: formInputs,
@@ -102,11 +104,7 @@ export function ReportPackageForm(
       setError(null);
     },
     onSubmitError: (error) => {
-      let message = `Error occurred: ${error.message || "Unknown error"}`;
-      if (error.message === "401: Unauthorized") {
-        message = "You must be logged in to report a package.";
-      }
-      setError(message);
+      setError(formatUserFacingError(error));
     },
   });
 

--- a/apps/cyberstorm-remix/app/p/packageListing.css
+++ b/apps/cyberstorm-remix/app/p/packageListing.css
@@ -35,6 +35,19 @@
     align-items: center;
   }
 
+  .package-listing__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .package-listing__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
+
   .package-listing-management-tools__island {
     display: flex;
     gap: 6px;

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.css
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.css
@@ -2,4 +2,17 @@
   .package-changelog__skeleton {
     height: 500px;
   }
+
+  .package-changelog__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .package-changelog__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -1,12 +1,12 @@
 import { Await, type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   getPublicEnvVariables,
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
 import { Suspense } from "react";
-import { SkeletonBox } from "@thunderstore/cyberstorm";
+import { Heading, SkeletonBox } from "@thunderstore/cyberstorm";
 import "./Readme.css";
 import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
 import {
@@ -14,6 +14,8 @@ import {
   SIGN_IN_REQUIRED_MAPPING,
   createNotFoundMapping,
 } from "cyberstorm/utils/errors/loaderMappings";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
 
 const packageVersionReadmeMappings = [
   SIGN_IN_REQUIRED_MAPPING,
@@ -34,25 +36,28 @@ export async function loader({ params }: LoaderFunctionArgs) {
       };
     });
     try {
+      const readme = await dapper.getPackageReadme(
+        params.namespaceId,
+        params.packageId,
+        params.packageVersion
+      );
+
       return {
-        readme: await dapper.getPackageReadme(
-          params.namespaceId,
-          params.packageId,
-          params.packageVersion
-        ),
+        readme,
       };
     } catch (error) {
       handleLoaderError(error, { mappings: packageVersionReadmeMappings });
     }
   }
-  return {
-    status: "error",
-    message: "Failed to load readme",
-    readme: { html: "" },
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Readme not available.",
+    description: "We could not find a readme for this package version.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
-export async function clientLoader({ params }: LoaderFunctionArgs) {
+export function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -61,40 +66,36 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    try {
-      const readmePromise = dapper.getPackageReadme(
+    const readme = dapper
+      .getPackageReadme(
         params.namespaceId,
         params.packageId,
         params.packageVersion
+      )
+      .catch((error) =>
+        handleLoaderError(error, { mappings: packageVersionReadmeMappings })
       );
-      await readmePromise;
 
-      return {
-        readme: readmePromise,
-      };
-    } catch (error) {
-      handleLoaderError(error, { mappings: packageVersionReadmeMappings });
-    }
+    return {
+      readme,
+    };
   }
-  return {
-    status: "error",
-    message: "Failed to load readme",
-    readme: { html: "" },
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Readme not available.",
+    description: "We could not find a readme for this package version.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function PackageVersionReadme() {
-  const { status, message, readme } = useLoaderData<
+  const { readme } = useLoaderData<
     typeof loader | typeof clientLoader
   >();
 
-  if (status === "error") return <div>{message}</div>;
   return (
     <Suspense fallback={<SkeletonBox className="package-readme__skeleton" />}>
-      <Await
-        resolve={readme}
-        errorElement={<div>Error occurred while loading description</div>}
-      >
+      <Await resolve={readme}>
         {(resolvedValue) => (
           <>
             <div className="markdown-wrapper">
@@ -107,5 +108,23 @@ export default function PackageVersionReadme() {
         )}
       </Await>
     </Suspense>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const payload = resolveRouteErrorPayload(error);
+
+  return (
+    <div className="package-readme__error">
+      <Heading csLevel="3" csSize="3" csVariant="primary" mode="display">
+        {payload.headline}
+      </Heading>
+      {payload.description ? (
+        <p className="package-readme__error-description">
+          {payload.description}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
@@ -1,12 +1,12 @@
 import { Await, type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   getPublicEnvVariables,
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
 import { Suspense } from "react";
-import { SkeletonBox } from "@thunderstore/cyberstorm";
+import { Heading, SkeletonBox } from "@thunderstore/cyberstorm";
 import "./Readme.css";
 import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
 import {
@@ -14,6 +14,8 @@ import {
   SIGN_IN_REQUIRED_MAPPING,
   createNotFoundMapping,
 } from "cyberstorm/utils/errors/loaderMappings";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
 
 const packageVersionReadmeNoCommunityMappings = [
   SIGN_IN_REQUIRED_MAPPING,
@@ -34,12 +36,14 @@ export async function loader({ params }: LoaderFunctionArgs) {
       };
     });
     try {
+      const readme = await dapper.getPackageReadme(
+        params.namespaceId,
+        params.packageId,
+        params.packageVersion
+      );
+
       return {
-        readme: await dapper.getPackageReadme(
-          params.namespaceId,
-          params.packageId,
-          params.packageVersion
-        ),
+        readme,
       };
     } catch (error) {
       handleLoaderError(error, {
@@ -47,14 +51,15 @@ export async function loader({ params }: LoaderFunctionArgs) {
       });
     }
   }
-  return {
-    status: "error",
-    message: "Failed to load readme",
-    readme: { html: "" },
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Readme not available.",
+    description: "We could not find a readme for this package version.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
-export async function clientLoader({ params }: LoaderFunctionArgs) {
+export function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -63,42 +68,38 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    try {
-      const readmePromise = dapper.getPackageReadme(
+    const readme = dapper
+      .getPackageReadme(
         params.namespaceId,
         params.packageId,
         params.packageVersion
+      )
+      .catch((error) =>
+        handleLoaderError(error, {
+          mappings: packageVersionReadmeNoCommunityMappings,
+        })
       );
-      await readmePromise;
 
-      return {
-        readme: readmePromise,
-      };
-    } catch (error) {
-      handleLoaderError(error, {
-        mappings: packageVersionReadmeNoCommunityMappings,
-      });
-    }
+    return {
+      readme,
+    };
   }
-  return {
-    status: "error",
-    message: "Failed to load readme",
-    readme: { html: "" },
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Readme not available.",
+    description: "We could not find a readme for this package version.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function PackageVersionReadme() {
-  const { status, message, readme } = useLoaderData<
+  const { readme } = useLoaderData<
     typeof loader | typeof clientLoader
   >();
 
-  if (status === "error") return <div>{message}</div>;
   return (
     <Suspense fallback={<SkeletonBox className="package-readme__skeleton" />}>
-      <Await
-        resolve={readme}
-        errorElement={<div>Error occurred while loading description</div>}
-      >
+      <Await resolve={readme}>
         {(resolvedValue) => (
           <>
             <div className="markdown-wrapper">
@@ -111,5 +112,23 @@ export default function PackageVersionReadme() {
         )}
       </Await>
     </Suspense>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const payload = resolveRouteErrorPayload(error);
+
+  return (
+    <div className="package-readme__error">
+      <Heading csLevel="3" csSize="3" csVariant="primary" mode="display">
+        {payload.headline}
+      </Heading>
+      {payload.description ? (
+        <p className="package-readme__error-description">
+          {payload.description}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
@@ -8,6 +8,21 @@ import {
 import { Suspense } from "react";
 import { SkeletonBox } from "@thunderstore/cyberstorm";
 import "./Readme.css";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import {
+  FORBIDDEN_MAPPING,
+  SIGN_IN_REQUIRED_MAPPING,
+  createNotFoundMapping,
+} from "cyberstorm/utils/errors/loaderMappings";
+
+const packageVersionReadmeNoCommunityMappings = [
+  SIGN_IN_REQUIRED_MAPPING,
+  FORBIDDEN_MAPPING,
+  createNotFoundMapping(
+    "Readme not available.",
+    "We could not find a readme for this package version."
+  ),
+];
 
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
@@ -18,13 +33,19 @@ export async function loader({ params }: LoaderFunctionArgs) {
         sessionId: undefined,
       };
     });
-    return {
-      readme: await dapper.getPackageReadme(
-        params.namespaceId,
-        params.packageId,
-        params.packageVersion
-      ),
-    };
+    try {
+      return {
+        readme: await dapper.getPackageReadme(
+          params.namespaceId,
+          params.packageId,
+          params.packageVersion
+        ),
+      };
+    } catch (error) {
+      handleLoaderError(error, {
+        mappings: packageVersionReadmeNoCommunityMappings,
+      });
+    }
   }
   return {
     status: "error",
@@ -42,13 +63,22 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    return {
-      readme: dapper.getPackageReadme(
+    try {
+      const readmePromise = dapper.getPackageReadme(
         params.namespaceId,
         params.packageId,
         params.packageVersion
-      ),
-    };
+      );
+      await readmePromise;
+
+      return {
+        readme: readmePromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, {
+        mappings: packageVersionReadmeNoCommunityMappings,
+      });
+    }
   }
   return {
     status: "error",

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.css
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.css
@@ -2,4 +2,17 @@
   .package-readme__skeleton {
     height: 500px;
   }
+
+  .package-readme__error {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 3rem 0;
+  }
+
+  .package-readme__error-description {
+    max-width: 40rem;
+    color: var(--Color-text-muted, rgb(180 189 255 / 0.8));
+  }
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -8,6 +8,21 @@ import {
 import { Suspense } from "react";
 import { SkeletonBox } from "@thunderstore/cyberstorm";
 import "./Readme.css";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import {
+  FORBIDDEN_MAPPING,
+  SIGN_IN_REQUIRED_MAPPING,
+  createNotFoundMapping,
+} from "cyberstorm/utils/errors/loaderMappings";
+
+const readmeErrorMappings = [
+  SIGN_IN_REQUIRED_MAPPING,
+  FORBIDDEN_MAPPING,
+  createNotFoundMapping(
+    "Readme not available.",
+    "We could not find a readme for this package."
+  ),
+];
 
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
@@ -18,9 +33,19 @@ export async function loader({ params }: LoaderFunctionArgs) {
         sessionId: undefined,
       };
     });
-    return {
-      readme: dapper.getPackageReadme(params.namespaceId, params.packageId),
-    };
+    try {
+      const readmePromise = dapper.getPackageReadme(
+        params.namespaceId,
+        params.packageId
+      );
+      await readmePromise;
+
+      return {
+        readme: readmePromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: readmeErrorMappings });
+    }
   }
   return {
     status: "error",
@@ -38,9 +63,19 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    return {
-      readme: dapper.getPackageReadme(params.namespaceId, params.packageId),
-    };
+    try {
+      const readmePromise = dapper.getPackageReadme(
+        params.namespaceId,
+        params.packageId
+      );
+      await readmePromise;
+
+      return {
+        readme: readmePromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: readmeErrorMappings });
+    }
   }
   return {
     status: "error",

--- a/apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx
@@ -1,5 +1,5 @@
 import { type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   getPublicEnvVariables,
@@ -9,6 +9,8 @@ import { PaginatedDependencies } from "~/commonComponents/PaginatedDependencies/
 import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
 import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
 import { packageDependenciesErrorMappings } from "./Required";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
+import { Heading } from "@thunderstore/cyberstorm";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
@@ -51,7 +53,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   });
 }
 
-export async function clientLoader({ params, request }: LoaderFunctionArgs) {
+export function clientLoader({ params, request }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -63,28 +65,30 @@ export async function clientLoader({ params, request }: LoaderFunctionArgs) {
     const searchParams = new URL(request.url).searchParams;
     const page = searchParams.get("page");
 
-    try {
-      const versionPromise = dapper.getPackageVersionDetails(
+    const version = dapper
+      .getPackageVersionDetails(
         params.namespaceId,
         params.packageId,
         params.packageVersion
+      )
+      .catch((error) =>
+        handleLoaderError(error, { mappings: packageDependenciesErrorMappings })
       );
-      const dependenciesPromise = dapper.getPackageVersionDependencies(
+    const dependencies = dapper
+      .getPackageVersionDependencies(
         params.namespaceId,
         params.packageId,
         params.packageVersion,
         page === null ? undefined : Number(page)
+      )
+      .catch((error) =>
+        handleLoaderError(error, { mappings: packageDependenciesErrorMappings })
       );
 
-      await Promise.all([versionPromise, dependenciesPromise]);
-
-      return {
-        version: versionPromise,
-        dependencies: dependenciesPromise,
-      };
-    } catch (error) {
-      handleLoaderError(error, { mappings: packageDependenciesErrorMappings });
-    }
+    return {
+      version,
+      dependencies,
+    };
   }
   throwUserFacingPayloadResponse({
     headline: "Dependencies not found.",
@@ -101,5 +105,23 @@ export default function PackageVersionRequired() {
 
   return (
     <PaginatedDependencies version={version} dependencies={dependencies} />
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const payload = resolveRouteErrorPayload(error);
+
+  return (
+    <div className="package-listing__error">
+      <Heading csLevel="3" csSize="3" csVariant="primary" mode="display">
+        {payload.headline}
+      </Heading>
+      {payload.description ? (
+        <p className="package-listing__error-description">
+          {payload.description}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx
@@ -6,6 +6,9 @@ import {
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
 import { PaginatedDependencies } from "~/commonComponents/PaginatedDependencies/PaginatedDependencies";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import { packageDependenciesErrorMappings } from "./Required";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
@@ -19,21 +22,33 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     const searchParams = new URL(request.url).searchParams;
     const page = searchParams.get("page");
 
-    return {
-      version: await dapper.getPackageVersionDetails(
+    try {
+      const version = await dapper.getPackageVersionDetails(
         params.namespaceId,
         params.packageId,
         params.packageVersion
-      ),
-      dependencies: await dapper.getPackageVersionDependencies(
+      );
+      const dependencies = await dapper.getPackageVersionDependencies(
         params.namespaceId,
         params.packageId,
         params.packageVersion,
         page === null ? undefined : Number(page)
-      ),
-    };
+      );
+
+      return {
+        version,
+        dependencies,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageDependenciesErrorMappings });
+    }
   }
-  throw new Response("Package version dependencies not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Dependencies not found.",
+    description: "We could not find the requested version dependencies.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export async function clientLoader({ params, request }: LoaderFunctionArgs) {
@@ -48,21 +63,35 @@ export async function clientLoader({ params, request }: LoaderFunctionArgs) {
     const searchParams = new URL(request.url).searchParams;
     const page = searchParams.get("page");
 
-    return {
-      version: dapper.getPackageVersionDetails(
+    try {
+      const versionPromise = dapper.getPackageVersionDetails(
         params.namespaceId,
         params.packageId,
         params.packageVersion
-      ),
-      dependencies: dapper.getPackageVersionDependencies(
+      );
+      const dependenciesPromise = dapper.getPackageVersionDependencies(
         params.namespaceId,
         params.packageId,
         params.packageVersion,
         page === null ? undefined : Number(page)
-      ),
-    };
+      );
+
+      await Promise.all([versionPromise, dependenciesPromise]);
+
+      return {
+        version: versionPromise,
+        dependencies: dependenciesPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageDependenciesErrorMappings });
+    }
   }
-  throw new Response("Package version dependencies not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Dependencies not found.",
+    description: "We could not find the requested version dependencies.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function PackageVersionWithoutCommunityRequired() {

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -6,6 +6,24 @@ import {
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
 import { PaginatedDependencies } from "~/commonComponents/PaginatedDependencies/PaginatedDependencies";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import {
+  FORBIDDEN_MAPPING,
+  SIGN_IN_REQUIRED_MAPPING,
+  VALIDATION_MAPPING,
+  createNotFoundMapping,
+} from "cyberstorm/utils/errors/loaderMappings";
+
+export const packageDependenciesErrorMappings = [
+  SIGN_IN_REQUIRED_MAPPING,
+  FORBIDDEN_MAPPING,
+  VALIDATION_MAPPING,
+  createNotFoundMapping(
+    "Dependencies not found.",
+    "We could not find the requested version dependencies."
+  ),
+];
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
@@ -18,27 +36,39 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     });
     const searchParams = new URL(request.url).searchParams;
     const page = searchParams.get("page");
-    const listing = await dapper.getPackageListingDetails(
-      params.communityId,
-      params.namespaceId,
-      params.packageId
-    );
+    try {
+      const listing = await dapper.getPackageListingDetails(
+        params.communityId,
+        params.namespaceId,
+        params.packageId
+      );
 
-    return {
-      version: await dapper.getPackageVersionDetails(
+      const version = await dapper.getPackageVersionDetails(
         params.namespaceId,
         params.packageId,
         listing.latest_version_number
-      ),
-      dependencies: await dapper.getPackageVersionDependencies(
+      );
+      const dependencies = await dapper.getPackageVersionDependencies(
         params.namespaceId,
         params.packageId,
         listing.latest_version_number,
         page === null ? undefined : Number(page)
-      ),
-    };
+      );
+
+      return {
+        version,
+        dependencies,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageDependenciesErrorMappings });
+    }
   }
-  throw new Response("Package version dependencies not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Dependencies not found.",
+    description: "We could not find the requested version dependencies.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export async function clientLoader({ params, request }: LoaderFunctionArgs) {
@@ -52,27 +82,41 @@ export async function clientLoader({ params, request }: LoaderFunctionArgs) {
     });
     const searchParams = new URL(request.url).searchParams;
     const page = searchParams.get("page");
-    const listing = await dapper.getPackageListingDetails(
-      params.communityId,
-      params.namespaceId,
-      params.packageId
-    );
+    try {
+      const listing = await dapper.getPackageListingDetails(
+        params.communityId,
+        params.namespaceId,
+        params.packageId
+      );
 
-    return {
-      version: dapper.getPackageVersionDetails(
+      const versionPromise = dapper.getPackageVersionDetails(
         params.namespaceId,
         params.packageId,
         listing.latest_version_number
-      ),
-      dependencies: dapper.getPackageVersionDependencies(
+      );
+      const dependenciesPromise = dapper.getPackageVersionDependencies(
         params.namespaceId,
         params.packageId,
         listing.latest_version_number,
         page === null ? undefined : Number(page)
-      ),
-    };
+      );
+
+      await Promise.all([versionPromise, dependenciesPromise]);
+
+      return {
+        version: versionPromise,
+        dependencies: dependenciesPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageDependenciesErrorMappings });
+    }
   }
-  throw new Response("Package version dependencies not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Dependencies not found.",
+    description: "We could not find the requested version dependencies.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function PackageVersionRequired() {

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -7,7 +7,7 @@ import {
   NewLink,
 } from "@thunderstore/cyberstorm";
 import { Await, type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   getPublicEnvVariables,
@@ -18,6 +18,8 @@ import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
 import { columns, packageVersionsErrorMappings } from "./Versions";
 import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
 
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
@@ -29,30 +31,30 @@ export async function loader({ params }: LoaderFunctionArgs) {
       };
     });
     try {
-      const versionsPromise = dapper.getPackageVersions(
+      const versions = await dapper.getPackageVersions(
         params.namespaceId,
         params.packageId
       );
-      await versionsPromise;
 
       return {
         communityId: params.communityId,
         namespaceId: params.namespaceId,
         packageId: params.packageId,
-        versions: versionsPromise,
+        versions,
       };
     } catch (error) {
       handleLoaderError(error, { mappings: packageVersionsErrorMappings });
     }
   }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Package not found.",
+    description: "We could not find the requested package.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
-export async function clientLoader({ params }: LoaderFunctionArgs) {
+export function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -61,37 +63,30 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    try {
-      const versionsPromise = dapper.getPackageVersions(
-        params.namespaceId,
-        params.packageId
+    const versions = dapper
+      .getPackageVersions(params.namespaceId, params.packageId)
+      .catch((error) =>
+        handleLoaderError(error, { mappings: packageVersionsErrorMappings })
       );
-      await versionsPromise;
 
-      return {
-        communityId: params.communityId,
-        namespaceId: params.namespaceId,
-        packageId: params.packageId,
-        versions: versionsPromise,
-      };
-    } catch (error) {
-      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
-    }
+    return {
+      communityId: params.communityId,
+      namespaceId: params.namespaceId,
+      packageId: params.packageId,
+      versions,
+    };
   }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Package not found.",
+    description: "We could not find the requested package.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function Versions() {
-  const { communityId, namespaceId, packageId, status, message, versions } =
+  const { communityId, namespaceId, packageId, versions } =
     useLoaderData<typeof loader | typeof clientLoader>();
-
-  if (status === "error") {
-    return <div>{message}</div>;
-  }
 
   return (
     <Suspense fallback={<SkeletonBox className="package-versions__skeleton" />}>
@@ -151,5 +146,23 @@ export default function Versions() {
         )}
       </Await>
     </Suspense>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const payload = resolveRouteErrorPayload(error);
+
+  return (
+    <div className="package-listing__error">
+      <Heading csLevel="3" csSize="3" csVariant="primary" mode="display">
+        {payload.headline}
+      </Heading>
+      {payload.description ? (
+        <p className="package-listing__error-description">
+          {payload.description}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -16,7 +16,8 @@ import {
 import { Suspense } from "react";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
-import { columns } from "./Versions";
+import { columns, packageVersionsErrorMappings } from "./Versions";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
 
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
@@ -27,12 +28,22 @@ export async function loader({ params }: LoaderFunctionArgs) {
         sessionId: undefined,
       };
     });
-    return {
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-    };
+    try {
+      const versionsPromise = dapper.getPackageVersions(
+        params.namespaceId,
+        params.packageId
+      );
+      await versionsPromise;
+
+      return {
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: versionsPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
+    }
   }
   return {
     status: "error",
@@ -50,12 +61,22 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    return {
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-    };
+    try {
+      const versionsPromise = dapper.getPackageVersions(
+        params.namespaceId,
+        params.packageId
+      );
+      await versionsPromise;
+
+      return {
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: versionsPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
+    }
   }
   return {
     status: "error",

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
@@ -16,7 +16,8 @@ import {
 import { Suspense } from "react";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
-import { columns } from "./Versions";
+import { columns, packageVersionsErrorMappings } from "./Versions";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
 
 export async function loader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
@@ -27,11 +28,21 @@ export async function loader({ params }: LoaderFunctionArgs) {
         sessionId: undefined,
       };
     });
-    return {
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-    };
+    try {
+      const versionsPromise = dapper.getPackageVersions(
+        params.namespaceId,
+        params.packageId
+      );
+      await versionsPromise;
+
+      return {
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: versionsPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
+    }
   }
   return {
     status: "error",
@@ -49,11 +60,21 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    return {
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-    };
+    try {
+      const versionsPromise = dapper.getPackageVersions(
+        params.namespaceId,
+        params.packageId
+      );
+      await versionsPromise;
+
+      return {
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: versionsPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
+    }
   }
   return {
     status: "error",

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -8,7 +8,7 @@ import {
   NewLink,
 } from "@thunderstore/cyberstorm";
 import { Await, type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useRouteError } from "react-router";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   getPublicEnvVariables,
@@ -23,6 +23,8 @@ import {
   SIGN_IN_REQUIRED_MAPPING,
   createNotFoundMapping,
 } from "cyberstorm/utils/errors/loaderMappings";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { resolveRouteErrorPayload } from "cyberstorm/utils/errors/resolveRouteErrorPayload";
 
 export const packageVersionsErrorMappings = [
   SIGN_IN_REQUIRED_MAPPING,
@@ -43,30 +45,30 @@ export async function loader({ params }: LoaderFunctionArgs) {
       };
     });
     try {
-      const versionsPromise = dapper.getPackageVersions(
+      const versions = await dapper.getPackageVersions(
         params.namespaceId,
         params.packageId
       );
-      await versionsPromise;
 
       return {
         communityId: params.communityId,
         namespaceId: params.namespaceId,
         packageId: params.packageId,
-        versions: versionsPromise,
+        versions,
       };
     } catch (error) {
       handleLoaderError(error, { mappings: packageVersionsErrorMappings });
     }
   }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Package not found.",
+    description: "We could not find the requested package.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
-export async function clientLoader({ params }: LoaderFunctionArgs) {
+export function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -75,37 +77,31 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
         sessionId: tools?.getConfig().sessionId,
       };
     });
-    try {
-      const versionsPromise = dapper.getPackageVersions(
-        params.namespaceId,
-        params.packageId
+    const versions = dapper
+      .getPackageVersions(params.namespaceId, params.packageId)
+      .catch((error) =>
+        handleLoaderError(error, { mappings: packageVersionsErrorMappings })
       );
-      await versionsPromise;
 
-      return {
-        communityId: params.communityId,
-        namespaceId: params.namespaceId,
-        packageId: params.packageId,
-        versions: versionsPromise,
-      };
-    } catch (error) {
-      handleLoaderError(error, { mappings: packageVersionsErrorMappings });
-    }
+    return {
+      communityId: params.communityId,
+      namespaceId: params.namespaceId,
+      packageId: params.packageId,
+      versions,
+    };
   }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-  };
+  throwUserFacingPayloadResponse({
+    headline: "Package not found.",
+    description: "We could not find the requested package.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function Versions() {
-  const { communityId, namespaceId, packageId, status, message, versions } =
-    useLoaderData<typeof loader | typeof clientLoader>();
-
-  if (status === "error") {
-    return <div>{message}</div>;
-  }
+  const { communityId, namespaceId, packageId, versions } = useLoaderData<
+    typeof loader | typeof clientLoader
+  >();
 
   return (
     <Suspense fallback={<SkeletonBox className="package-versions__skeleton" />}>
@@ -165,6 +161,24 @@ export default function Versions() {
         )}
       </Await>
     </Suspense>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const payload = resolveRouteErrorPayload(error);
+
+  return (
+    <div className="package-listing__error">
+      <Heading csLevel="3" csSize="3" csVariant="primary" mode="display">
+        {payload.headline}
+      </Heading>
+      {payload.description ? (
+        <p className="package-listing__error-description">
+          {payload.description}
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -10,6 +10,29 @@ import {
   getSessionTools,
 } from "cyberstorm/security/publicEnvVariables";
 import type { Route } from "./+types/Team";
+import { throwUserFacingPayloadResponse } from "cyberstorm/utils/errors/userFacingErrorResponse";
+import { handleLoaderError } from "cyberstorm/utils/errors/handleLoaderError";
+import {
+  FORBIDDEN_MAPPING,
+  RATE_LIMIT_MAPPING,
+  SIGN_IN_REQUIRED_MAPPING,
+  VALIDATION_MAPPING,
+  createNotFoundMapping,
+  createServerErrorMapping,
+} from "cyberstorm/utils/errors/loaderMappings";
+
+const teamErrorMappings = [
+  SIGN_IN_REQUIRED_MAPPING,
+  FORBIDDEN_MAPPING,
+  VALIDATION_MAPPING,
+  RATE_LIMIT_MAPPING,
+  createNotFoundMapping(
+    "Team not found.",
+    "We could not find the requested team.",
+    404
+  ),
+  createServerErrorMapping(),
+];
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   if (params.communityId && params.namespaceId) {
@@ -30,12 +53,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     const section = searchParams.get("section");
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-
-    return {
-      teamId: params.namespaceId,
-      filters: filters,
-      listings: await dapper.getPackageListings(
+    try {
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const listings = await dapper.getPackageListings(
         {
           kind: "namespace",
           communityId: params.communityId,
@@ -47,12 +67,25 @@ export async function loader({ params, request }: Route.LoaderArgs) {
         includedCategories?.split(",") ?? undefined,
         excludedCategories?.split(",") ?? undefined,
         section ? (section === "all" ? "" : section) : "",
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-    };
+        nsfw === "true",
+        deprecated === "true"
+      );
+
+      return {
+        teamId: params.namespaceId,
+        filters,
+        listings,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: teamErrorMappings });
+    }
   }
-  throw new Response("Community not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Community not found.",
+    description: "We could not find the requested community.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export async function clientLoader({
@@ -77,28 +110,41 @@ export async function clientLoader({
     const section = searchParams.get("section");
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
-    const filters = dapper.getCommunityFilters(params.communityId);
-    return {
-      teamId: params.namespaceId,
-      filters: filters,
-      listings: dapper.getPackageListings(
-        {
-          kind: "namespace",
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        section ? (section === "all" ? "" : section) : "",
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-    };
+    const filtersPromise = dapper.getCommunityFilters(params.communityId);
+    const listingsPromise = dapper.getPackageListings(
+      {
+        kind: "namespace",
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+      },
+      ordering ?? "",
+      page === null ? undefined : Number(page),
+      search ?? "",
+      includedCategories?.split(",") ?? undefined,
+      excludedCategories?.split(",") ?? undefined,
+      section ? (section === "all" ? "" : section) : "",
+      nsfw === "true",
+      deprecated === "true"
+    );
+
+    try {
+      await Promise.all([filtersPromise, listingsPromise]);
+
+      return {
+        teamId: params.namespaceId,
+        filters: filtersPromise,
+        listings: listingsPromise,
+      };
+    } catch (error) {
+      handleLoaderError(error, { mappings: teamErrorMappings });
+    }
   }
-  throw new Response("Community not found", { status: 404 });
+  throwUserFacingPayloadResponse({
+    headline: "Community not found.",
+    description: "We could not find the requested community.",
+    category: "not_found",
+    status: 404,
+  });
 }
 
 export default function Team() {

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -293,15 +293,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
     (m) => m.id === "tools/markdown-preview/markdownPreview"
   );
 
-  const shouldShowAds = location.pathname.startsWith("/teams")
-    ? false
-    : location.pathname.startsWith("/settings")
-      ? false
-      : location.pathname.startsWith("/package/create")
-        ? false
-        : location.pathname.startsWith("/tools")
-          ? false
-          : true;
+  // const shouldShowAds = location.pathname.startsWith("/teams")
+  //   ? false
+  //   : location.pathname.startsWith("/settings")
+  //     ? false
+  //     : location.pathname.startsWith("/package/create")
+  //       ? false
+  //       : location.pathname.startsWith("/tools")
+  //         ? false
+  //         : true;
+  const shouldShowAds = false;
 
   return (
     <html lang="en">

--- a/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
@@ -19,6 +19,8 @@ import {
   type RequestConfig,
   teamCreate,
   type TeamCreateRequestData,
+  UserFacingError,
+  formatUserFacingError,
 } from "@thunderstore/thunderstore-api";
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { postTeamCreate } from "@thunderstore/dapper-ts/src/methods/team";
@@ -159,7 +161,7 @@ function CreateTeamForm(props: { config: () => RequestConfig }) {
     TeamCreateRequestData,
     Error,
     SubmitorOutput,
-    Error,
+    UserFacingError,
     InputErrors
   >({
     inputs: formInputs,
@@ -176,7 +178,7 @@ function CreateTeamForm(props: { config: () => RequestConfig }) {
     onSubmitError: (error) => {
       toast.addToast({
         csVariant: "danger",
-        children: `Error occurred: ${error.message || "Unknown error"}`,
+        children: formatUserFacingError(error),
         duration: 8000,
       });
     },

--- a/apps/cyberstorm-remix/app/settings/teams/team/tabs/Settings/Settings.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/team/tabs/Settings/Settings.tsx
@@ -18,6 +18,8 @@ import {
   teamDisband,
   type TeamDisbandRequestData,
   teamRemoveMember,
+  UserFacingError,
+  formatUserFacingError,
 } from "@thunderstore/thunderstore-api";
 import { ApiAction } from "@thunderstore/ts-api-react-actions";
 import { NotLoggedIn } from "~/commonComponents/NotLoggedIn/NotLoggedIn";
@@ -128,7 +130,7 @@ function LeaveTeamForm(props: {
     onSubmitError: (error) => {
       toast.addToast({
         csVariant: "danger",
-        children: `Error occurred: ${error.message || "Unknown error"}`,
+        children: formatUserFacingError(error),
         duration: 8000,
       });
     },
@@ -233,7 +235,7 @@ function DisbandTeamForm(props: {
     TeamDisbandRequestData,
     Error,
     SubmitorOutput,
-    Error,
+    UserFacingError,
     InputErrors
   >({
     inputs: formInputs,
@@ -250,7 +252,7 @@ function DisbandTeamForm(props: {
     onSubmitError: (error) => {
       toast.addToast({
         csVariant: "danger",
-        children: `Error occurred: ${error.message || "Unknown error"}`,
+        children: formatUserFacingError(error),
         duration: 8000,
       });
     },

--- a/apps/cyberstorm-remix/app/settings/user/Account/Account.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Account/Account.tsx
@@ -13,7 +13,11 @@ import { NotLoggedIn } from "~/commonComponents/NotLoggedIn/NotLoggedIn";
 import { type OutletContextShape } from "~/root";
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { useReducer } from "react";
-import { userDelete } from "@thunderstore/thunderstore-api";
+import {
+  userDelete,
+  UserFacingError,
+  formatUserFacingError,
+} from "@thunderstore/thunderstore-api";
 
 export default function Account() {
   const outletContext = useOutletContext() as OutletContextShape;
@@ -114,7 +118,7 @@ function DeleteAccountForm(props: {
     UserAccountDeleteRequestData,
     Error,
     SubmitorOutput,
-    Error,
+    UserFacingError,
     InputErrors
   >({
     inputs: formInputs,
@@ -129,7 +133,7 @@ function DeleteAccountForm(props: {
     onSubmitError: (error) => {
       toast.addToast({
         csVariant: "danger",
-        children: `Error occurred: ${error.message || "Unknown error"}`,
+        children: formatUserFacingError(error),
         duration: 8000,
       });
     },

--- a/apps/cyberstorm-remix/cyberstorm/utils/StrongForm/useStrongForm.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/StrongForm/useStrongForm.ts
@@ -3,31 +3,52 @@ import {
   ParseError,
   RequestBodyParseError,
   RequestQueryParamsParseError,
+  UserFacingError,
+  mapApiErrorToUserFacingError,
 } from "../../../../../packages/thunderstore-api/src";
 
 interface UseStrongFormProps<
   Inputs,
-  SubmissionDataShape,
-  RefinerError,
-  SubmissionOutput,
-  SubmissionError,
+  SubmissionDataShape = Inputs,
+  RefinerError extends Error = Error,
+  SubmissionOutput = unknown,
+  SubmissionError extends Error = UserFacingError,
 > {
   inputs: Inputs;
-  refiner?: (inputs: Inputs) => Promise<SubmissionDataShape>;
-  onRefineSuccess?: (output: SubmissionDataShape) => void;
-  onRefineError?: (error: RefinerError) => void;
   submitor: (data: SubmissionDataShape) => Promise<SubmissionOutput>;
+  refiner?: (inputs: Inputs) => Promise<SubmissionDataShape>;
+  onRefineSuccess?: (data: SubmissionDataShape) => void;
+  onRefineError?: (error: RefinerError) => void;
   onSubmitSuccess?: (output: SubmissionOutput) => void;
   onSubmitError?: (error: SubmissionError) => void;
+  errorMapper?: (error: unknown) => SubmissionError;
+}
+
+interface UseStrongFormReturn<
+  Inputs,
+  SubmissionDataShape = Inputs,
+  RefinerError extends Error = Error,
+  SubmissionOutput = unknown,
+  SubmissionError extends Error = UserFacingError,
+  InputErrors = Record<string, unknown>,
+> {
+  submit: () => Promise<SubmissionOutput>;
+  submitting: boolean;
+  submitOutput?: SubmissionOutput;
+  submitError?: SubmissionError;
+  submissionData?: SubmissionDataShape;
+  refining: boolean;
+  refineError?: RefinerError;
+  inputErrors?: InputErrors;
 }
 
 export function useStrongForm<
   Inputs,
-  SubmissionDataShape,
-  RefinerError,
-  SubmissionOutput,
-  SubmissionError,
-  InputErrors,
+  SubmissionDataShape = Inputs,
+  RefinerError extends Error = Error,
+  SubmissionOutput = unknown,
+  SubmissionError extends Error = UserFacingError,
+  InputErrors = Record<string, unknown>,
 >(
   props: UseStrongFormProps<
     Inputs,
@@ -36,7 +57,14 @@ export function useStrongForm<
     SubmissionOutput,
     SubmissionError
   >
-) {
+): UseStrongFormReturn<
+  Inputs,
+  SubmissionDataShape,
+  RefinerError,
+  SubmissionOutput,
+  SubmissionError,
+  InputErrors
+> {
   const [refining, setRefining] = useState(false);
   const [submissionData, setSubmissionData] = useState<SubmissionDataShape>();
   const [refineError, setRefineError] = useState<RefinerError>();
@@ -45,112 +73,137 @@ export function useStrongForm<
   const [submitError, setSubmitError] = useState<SubmissionError>();
   const [inputErrors, setInputErrors] = useState<InputErrors>();
 
+  const defaultErrorMapper = (error: unknown): SubmissionError => {
+    return mapApiErrorToUserFacingError(error) as unknown as SubmissionError;
+  };
+
+  const mapError = props.errorMapper ?? defaultErrorMapper;
+
   useEffect(() => {
-    if (refining || submitting) {
-      return;
-    }
+    let cancelled = false;
+
     setSubmitOutput(undefined);
     setSubmitError(undefined);
     setInputErrors(undefined);
-    if (props.refiner) {
-      setSubmissionData(undefined);
-      setRefineError(undefined);
-      setRefining(true);
-      props
-        .refiner(props.inputs)
-        .then((refiningOutput) => {
-          if (props.onRefineSuccess) {
-            props.onRefineSuccess(refiningOutput);
-          }
-          setSubmissionData(refiningOutput);
-          setRefining(false);
-        })
-        .catch((error) => {
-          setRefineError(error);
-          if (props.onRefineError) {
-            props.onRefineError(error);
-          }
-          setRefining(false);
-        });
-    } else {
-      // A quick hack to allow the form to work without a refiner.
-      setSubmissionData(props.inputs as unknown as SubmissionDataShape);
-    }
-  }, [props.inputs]);
 
-  const submit = async () => {
+    if (!props.refiner) {
+      setSubmissionData(props.inputs as unknown as SubmissionDataShape);
+      setRefining(false);
+      setRefineError(undefined);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setSubmissionData(undefined);
+    setRefineError(undefined);
+    setRefining(true);
+
+    props
+      .refiner(props.inputs)
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+
+        setSubmissionData(result);
+        if (props.onRefineSuccess) {
+          props.onRefineSuccess(result);
+        }
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+
+        const castError = error as RefinerError;
+        setRefineError(castError);
+        if (props.onRefineError) {
+          props.onRefineError(castError);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setRefining(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [props.inputs, props.refiner, props.onRefineSuccess, props.onRefineError]);
+
+  const toSubmissionError = (error: unknown): SubmissionError => {
+    if (error instanceof UserFacingError) {
+      return error as unknown as SubmissionError;
+    }
+    return mapError(error);
+  };
+
+  const emitSubmissionError = (error: SubmissionError): never => {
+    setSubmitError(error);
+    if (props.onSubmitError) {
+      props.onSubmitError(error);
+    }
+    throw error;
+  };
+
+  const createGuardSubmissionError = (message: string): SubmissionError => {
+    return toSubmissionError(
+      new UserFacingError({
+        category: "validation",
+        headline: message,
+        description: undefined,
+        originalError: new Error(message),
+      })
+    );
+  };
+
+  const submit = async (): Promise<SubmissionOutput> => {
     if (submitting) {
-      const error = new Error("Form is already submitting!");
-      if (props.onSubmitError) {
-        props.onSubmitError(error as SubmissionError);
-      }
-      throw error;
+      return emitSubmissionError(
+        createGuardSubmissionError("Form is already submitting.")
+      );
     }
+
     if (refining) {
-      const error = new Error("Form is still refining!");
-      if (props.onSubmitError) {
-        props.onSubmitError(error as SubmissionError);
-      }
-      throw error;
+      return emitSubmissionError(
+        createGuardSubmissionError("Form is still refining.")
+      );
     }
+
     if (refineError) {
-      const error = new Error("Form refinement failed!");
-      if (props.onSubmitError) {
-        props.onSubmitError(error as SubmissionError);
-      }
-      throw refineError;
+      return emitSubmissionError(toSubmissionError(refineError));
     }
+
     if (!submissionData) {
-      const error = new Error("Form has not been refined yet!");
-      if (props.onSubmitError) {
-        props.onSubmitError(error as SubmissionError);
-      }
-      throw error;
+      return emitSubmissionError(
+        createGuardSubmissionError("Form has not been refined yet.")
+      );
     }
 
     setSubmitting(true);
+    setSubmitError(undefined);
+    setInputErrors(undefined);
+
     try {
-      await props
-        .submitor(submissionData)
-        .then((output) => {
-          setSubmitOutput(output);
-          if (props.onSubmitSuccess) {
-            props.onSubmitSuccess(output);
-          }
-        })
-        .catch((error) => {
-          if (error instanceof RequestBodyParseError) {
-            setSubmitError(
-              new Error(
-                "Some of the field values are invalid"
-              ) as SubmissionError
-            );
-            setInputErrors(error.error.formErrors as InputErrors);
-          } else if (error instanceof RequestQueryParamsParseError) {
-            setSubmitError(
-              new Error(
-                "Some of the query parameters are invalid"
-              ) as SubmissionError
-            );
-            setInputErrors(error.error.formErrors as InputErrors);
-          } else if (error instanceof ParseError) {
-            setSubmitError(
-              new Error(
-                "Request succeeded, but the response was invalid"
-              ) as SubmissionError
-            );
-            setInputErrors(error.error.formErrors as InputErrors);
-            throw error;
-          } else {
-            throw error;
-          }
-        });
-      return submitOutput;
-    } catch (error) {
-      if (props.onSubmitError) {
-        props.onSubmitError(error as SubmissionError);
+      const output = await props.submitor(submissionData);
+      setSubmitOutput(output);
+      if (props.onSubmitSuccess) {
+        props.onSubmitSuccess(output);
       }
-      throw error;
+      return output;
+    } catch (error) {
+      if (error instanceof RequestBodyParseError) {
+        setInputErrors(error.error.formErrors as InputErrors);
+      } else if (error instanceof RequestQueryParamsParseError) {
+        setInputErrors(error.error.formErrors as InputErrors);
+      } else if (error instanceof ParseError) {
+        setInputErrors(error.error.formErrors as InputErrors);
+      }
+
+      const mappedError = toSubmissionError(error);
+      return emitSubmissionError(mappedError);
     } finally {
       setSubmitting(false);
     }

--- a/apps/cyberstorm-remix/cyberstorm/utils/errors/handleLoaderError.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/errors/handleLoaderError.ts
@@ -1,0 +1,68 @@
+import {
+  throwUserFacingErrorResponse,
+  throwUserFacingPayloadResponse,
+  type CreateUserFacingErrorResponseOptions,
+  type UserFacingErrorPayload,
+} from "./userFacingErrorResponse";
+import {
+  ApiError,
+  mapApiErrorToUserFacingError,
+  type UserFacingErrorCategory,
+} from "@thunderstore/thunderstore-api";
+
+export interface LoaderErrorMapping {
+  status: number | readonly number[];
+  headline: string;
+  description?: string;
+  category?: UserFacingErrorCategory;
+  includeContext?: boolean;
+  statusOverride?: number;
+}
+
+export interface HandleLoaderErrorOptions
+  extends CreateUserFacingErrorResponseOptions {
+  mappings?: LoaderErrorMapping[];
+}
+
+export function handleLoaderError(
+  error: unknown,
+  options: HandleLoaderErrorOptions = {}
+): never {
+  if (error instanceof Response) {
+    throw error;
+  }
+
+  if (error instanceof ApiError && options.mappings?.length) {
+    const mapping = options.mappings.find((candidate) => {
+      const statuses = Array.isArray(candidate.status)
+        ? candidate.status
+        : [candidate.status];
+      return statuses.includes(error.statusCode);
+    });
+
+    if (mapping) {
+      const base = mapApiErrorToUserFacingError(error, options.mapOptions);
+      const includeContextValue =
+        mapping.includeContext ?? options.includeContext ?? false;
+      const payload: UserFacingErrorPayload = {
+        headline: mapping.headline,
+        description:
+          mapping.description !== undefined
+            ? mapping.description
+            : base.description,
+        category: mapping.category ?? base.category,
+        status: mapping.statusOverride ?? error.statusCode,
+      };
+
+      if (includeContextValue && base.context) {
+        payload.context = base.context;
+      }
+
+      throwUserFacingPayloadResponse(payload, {
+        statusOverride: mapping.statusOverride ?? options.statusOverride,
+      });
+    }
+  }
+
+  throwUserFacingErrorResponse(error, options);
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/errors/loaderMappings.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/errors/loaderMappings.ts
@@ -1,0 +1,62 @@
+import type { LoaderErrorMapping } from "./handleLoaderError";
+
+export const SIGN_IN_REQUIRED_MAPPING: LoaderErrorMapping = {
+  status: 401,
+  headline: "Sign in required.",
+  description: "Please sign in to continue.",
+  category: "auth",
+};
+
+export const FORBIDDEN_MAPPING: LoaderErrorMapping = {
+  status: 403,
+  headline: "You do not have permission to perform this action.",
+  description: "Contact a team administrator to request access.",
+  category: "auth",
+};
+
+export const VALIDATION_MAPPING: LoaderErrorMapping = {
+  status: 422,
+  headline: "Invalid request.",
+  description: "Please review the provided data and try again.",
+  category: "validation",
+};
+
+export const CONFLICT_MAPPING: LoaderErrorMapping = {
+  status: 409,
+  headline: "Action could not be completed.",
+  description: "Another change was made at the same time. Refresh and try again.",
+  category: "server",
+};
+
+export const RATE_LIMIT_MAPPING: LoaderErrorMapping = {
+  status: 429,
+  headline: "Too many requests.",
+  description: "Please wait a moment and try again.",
+  category: "rate_limit",
+};
+
+export function createServerErrorMapping(
+  headline = "Something went wrong.",
+  description = "Please try again in a moment.",
+  status = 500
+): LoaderErrorMapping {
+  return {
+    status,
+    headline,
+    description,
+    category: "server",
+  };
+}
+
+export function createNotFoundMapping(
+  headline: string,
+  description: string,
+  status = 404
+): LoaderErrorMapping {
+  return {
+    status,
+    headline,
+    description,
+    category: "not_found",
+  };
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/errors/loaderResult.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/errors/loaderResult.ts
@@ -1,0 +1,50 @@
+import { handleLoaderError } from "./handleLoaderError";
+import { resolveRouteErrorPayload } from "./resolveRouteErrorPayload";
+
+export type ResolveLoaderPromiseOptions = Parameters<
+  typeof handleLoaderError
+>[1];
+
+export type LoaderErrorPayload = ReturnType<typeof resolveRouteErrorPayload>;
+
+export type LoaderError = {
+  readonly __error: LoaderErrorPayload;
+};
+
+export type LoaderResult<T> = T | LoaderError;
+
+/**
+ * Type guard that narrows a loader result to its error branch.
+ */
+export function isLoaderError<T>(value: LoaderResult<T>): value is LoaderError {
+  return typeof (value as LoaderError)?.__error !== "undefined";
+}
+
+/**
+ * Maps thrown loader values to the standard loader error payload wrapper.
+ */
+export function toLoaderError(error: unknown): LoaderError {
+  return {
+    __error: resolveRouteErrorPayload(error),
+  };
+}
+
+/**
+ * Resolves a loader promise and converts thrown errors into the standard loader error payload.
+ */
+export async function resolveLoaderPromise<T>(
+  promise: Promise<T>,
+  options?: ResolveLoaderPromiseOptions
+): Promise<LoaderResult<T>> {
+  try {
+    return await promise;
+  } catch (error) {
+    try {
+      handleLoaderError(error, options);
+    } catch (thrown) {
+      return toLoaderError(thrown);
+    }
+
+    return toLoaderError(error);
+  }
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/errors/resolveRouteErrorPayload.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/errors/resolveRouteErrorPayload.ts
@@ -1,0 +1,69 @@
+import { isRouteErrorResponse } from "react-router";
+import {
+  ApiError,
+  mapApiErrorToUserFacingError,
+  type UserFacingError,
+} from "@thunderstore/thunderstore-api";
+import {
+  parseUserFacingErrorPayload,
+  type UserFacingErrorPayload,
+} from "./userFacingErrorResponse";
+
+function toPayloadFromUserFacing(
+  error: UserFacingError
+): UserFacingErrorPayload {
+  return {
+    headline: error.headline,
+    description: error.description,
+    category: error.category,
+    status: error.status,
+    context: error.context,
+  };
+}
+
+/**
+ * Normalizes various error shapes thrown during routing into a consistent payload
+ * that components can render without duplicating mapping logic.
+ */
+export function resolveRouteErrorPayload(
+  error: unknown
+): UserFacingErrorPayload {
+  if (isRouteErrorResponse(error)) {
+    const parsed = parseUserFacingErrorPayload(error.data);
+    if (parsed) {
+      return parsed;
+    }
+
+    return {
+      headline: error.statusText || "Something went wrong.",
+      description: typeof error.data === "string" ? error.data : undefined,
+      category: "server",
+      status: error.status,
+    };
+  }
+
+  if (error instanceof ApiError) {
+    return toPayloadFromUserFacing(mapApiErrorToUserFacingError(error));
+  }
+
+  const parsed = parseUserFacingErrorPayload(error);
+  if (parsed) {
+    return parsed;
+  }
+
+  if (error instanceof Error) {
+    return {
+      headline: error.message || "Something went wrong.",
+      description: undefined,
+      category: "server",
+      status: 500,
+    };
+  }
+
+  return {
+    headline: "Something went wrong.",
+    description: undefined,
+    category: "server",
+    status: 500,
+  };
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/errors/userFacingErrorResponse.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/errors/userFacingErrorResponse.ts
@@ -1,0 +1,116 @@
+import {
+  type MapUserFacingErrorOptions,
+  type UserFacingError,
+  type UserFacingErrorCategory,
+  mapApiErrorToUserFacingError,
+} from "@thunderstore/thunderstore-api";
+
+export interface UserFacingErrorPayload {
+  headline: string;
+  description?: string;
+  category: UserFacingErrorCategory;
+  status?: number;
+  context?: Record<string, unknown>;
+}
+
+export interface UserFacingPayloadOptions {
+  includeContext?: boolean;
+}
+
+export interface CreateUserFacingErrorResponseOptions {
+  mapOptions?: MapUserFacingErrorOptions;
+  statusOverride?: number;
+  includeContext?: boolean;
+}
+
+export function createUserFacingErrorPayload(
+  error: unknown,
+  mapOptions: MapUserFacingErrorOptions = {},
+  payloadOptions: UserFacingPayloadOptions = {}
+): UserFacingErrorPayload {
+  const userFacing = mapApiErrorToUserFacingError(error, mapOptions);
+  return toPayload(userFacing, payloadOptions);
+}
+
+export function throwUserFacingErrorResponse(
+  error: unknown,
+  options: CreateUserFacingErrorResponseOptions = {}
+): never {
+  const userFacing = mapApiErrorToUserFacingError(error, options.mapOptions);
+  const payload = toPayload(userFacing, {
+    includeContext: options.includeContext ?? false,
+  });
+
+  throwUserFacingPayloadResponse(payload, {
+    statusOverride: options.statusOverride,
+  });
+}
+
+export function throwUserFacingPayloadResponse(
+  payload: UserFacingErrorPayload,
+  options: { statusOverride?: number } = {}
+): never {
+  const status = options.statusOverride ?? payload.status ?? 500;
+  throw new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function parseUserFacingErrorPayload(
+  value: unknown
+): UserFacingErrorPayload | null {
+  if (isUserFacingErrorPayload(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (isUserFacingErrorPayload(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function isUserFacingErrorPayload(
+  value: unknown
+): value is UserFacingErrorPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const maybePayload = value as Partial<UserFacingErrorPayload>;
+  return (
+    typeof maybePayload.headline === "string" &&
+    typeof maybePayload.category === "string"
+  );
+}
+
+function toPayload(
+  error: UserFacingError,
+  options: UserFacingPayloadOptions = {}
+): UserFacingErrorPayload {
+  const includeContext = options.includeContext ?? false;
+
+  const payload: UserFacingErrorPayload = {
+    headline: error.headline,
+    description: error.description,
+    category: error.category,
+    status: error.status,
+  };
+
+  if (includeContext && error.context) {
+    payload.context = error.context;
+  }
+
+  return payload;
+}

--- a/docs/error-handling-improvement-plan.md
+++ b/docs/error-handling-improvement-plan.md
@@ -1,0 +1,38 @@
+# Error Handling Improvement Plan
+
+This document outlines two core issues with the current error handling strategy and proposes solutions to improve UI stability and user experience.
+
+## 1. Unhandled `clientLoader` Promise Rejections
+
+### Issue
+When a server-side rendering (SSR) loader fails, any subsequent promise rejections within `clientLoader` are caught by the top-level route error boundary. This causes the entire page to be replaced by a generic error message, leading to a poor user experience. The caught error is often difficult to parse, resulting in a vague error message.
+
+### Proposed Solution
+Implement a "Retry" button within the error boundary that performs a hard navigation to the current page. This will force a full page reload, re-triggering the SSR loader.
+
+### Risks & Considerations
+- **Traffic Spikes:** If a failing SSR response is cached, multiple clients will receive the error and then perform a hard reload. This could lead to a sudden increase in server traffic.
+- **Further Investigation:** This behavior may indicate a deeper issue. A long-term solution could involve replacing route-level error boundaries with a custom error boundary that wraps each route's output, providing more granular control.
+
+## 2. Lack of Granular Error Boundaries
+
+### Issue
+React Router does not provide out-of-the-box support for component or layout-level error boundaries. As a result, an error thrown by a single component can cascade and replace the entire page with an error message. While the `Suspense`/`Await` pattern is effective for handling promise-based errors, it does not cover non-promise-related errors (e.g., a bug in component logic).
+
+### Proposed Solution
+Create a reusable `NimbusErrorBoundary` component that can be used to wrap individual components or sections of a layout. This approach offers several advantages:
+- **Improved UX:** Prevents a single component failure from crashing the entire page.
+- **Better Error Reporting:** Enables more specific and useful error messages for users.
+- **Easier Debugging:** Provides better context for developers to identify and fix the root cause of an error.
+
+### Risks & Considerations
+- **Boilerplate Code:** This will introduce some boilerplate, as components will need to be explicitly wrapped with `NimbusErrorBoundary`. However, this is a necessary trade-off for achieving granular error handling.
+- **React Limitations:** [React Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) have some limitations, but these generally encourage better component design by promoting smaller, more isolated components.
+
+## Audit Log (2025-11-04)
+
+| Path | Current pattern | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/c/community.tsx | Nimbus boundary wraps the community header and all loader errors render a retry surface that triggers a full reload. | Low — localized failures retry without collapsing the entire route. | - (2025-11-04) Completed. |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | Await and route errors render Nimbus fallbacks with retry navigation, keeping results scoped to the tab. | Low — promise rejections now recover without wiping the page. | - (2025-11-04) Completed. |
+| apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx | Component is exported through a Nimbus boundary with a reusable fallback to contain synchronous UI failures. | Low — component-level issues stay isolated and offer retriable UX. | - (2025-11-04) Completed. |

--- a/docs/error-handling-plan.md
+++ b/docs/error-handling-plan.md
@@ -1,0 +1,72 @@
+# Thunderstore Error Experience Improvement Plan
+
+## Context & Current Flow
+- **User action**: Components such as `ReportPackageForm` call `useStrongForm`, which wraps submission via `packageListingReport`.
+- **Form handler (`useStrongForm`)**: On failure, it forwards the raw `Error` to `onSubmitError` without categorisation.
+- **API call chain**: `packageListingReport` → `apiFetch` → `fetchRetry`. When the server returns a failing HTTP status, `ApiError.createFromResponse` builds a message like `"Authentication required. Please sign in."` and attaches the `Response`.
+- **UI message**: Many forms (including `ReportPackageForm`) build a toast string the pattern `Error occurred: ${error.message}` and only override specific strings (e.g. legacy `"401: Unauthorized"`). After recent improvements, the comparison misses, so the fallback verbose message reaches the user.
+- **Global patterns**: The same fallback string appears across forms, `ApiAction` callbacks, React Router loaders, and Dapper data hooks.
+
+## Pain Points Discovered
+- **String matching brittleness**: Dozens of components compare `error.message` against hard-coded values, making UX copy tightly coupled to backend text.
+- **No user-facing classification**: We lack a canonical way to indicate "auth required", "validation problem", or "server down"; each surface invents its own text.
+- **Duplicated copy & inconsistent tone**: Toasts, inline alerts, and error boundaries all render different language for the same scenario.
+
+## Target Experience
+1. **Consistent semantics**: Every client-visible error is described by a `UserFacingError` contract containing status, category, primary message, optional resolution hint, and telemetry context.
+2. **Layered handling**:
+   - `thunderstore-api`: exposes raw error metadata plus a helper for converting to `UserFacingError`.
+   - `ts-api-react` & `ts-api-react-actions`: normalise thrown errors before reaching React components.
+   - `useStrongForm`/`useFormToaster`: consume `UserFacingError` and render context-appropriate copy.
+   - Route loaders/actions & Dapper wrappers: convert server failures to `UserFacingError` and throw/return structured payloads consumable by error boundaries.
+3. **Copy centralisation**: Provide map of default strings while still allowing views to override.
+
+## Proposed Interfaces
+- **`UserFacingError`** (new shared type, e.g. under `packages/thunderstore-api/src/errors/UserFacingError.ts`):
+  ```ts
+  type UserFacingErrorCategory = "auth" | "validation" | "not_found" | "rate_limit" | "server" | "network" | "unknown";
+  interface UserFacingError {
+    category: UserFacingErrorCategory;
+    status?: number;
+      headline: string;      // Short CTA-friendly message
+      description?: string;  // Optional detail for modals or alerts
+    originalError: Error;  // Preserves stack/message for logging
+    context?: Record<string, unknown>;
+  }
+  ```
+- **Error translator**: `mapApiErrorToUserFacingError(error: unknown, options)` that inspects `ApiError`, `TypeError` (network), `RequestBodyParseError`, etc., returning a populated `UserFacingError`. Options allow callers to specify surface (toast/inline) and customise copy as needed.
+- **Presenter hooks**: `useErrorPresenter` in `cyberstorm-forms` that accepts `UserFacingError` and selects toast vs inline copy.
+
+## Execution Plan
+1. **Shared Translator Audits**: Validate that `packages/thunderstore-api/src/errors` (including `sanitizeServerDetail`, `mapApiErrorToUserFacingError`, and `formatUserFacingError`) expose everything cyberstorm-remix and Dapper consumers require, with safe defaults.
+2. **Hook Layer Consistency**: Ensure `useApiCall`, `ApiAction`, `useStrongForm`, and `useFormToaster` always surface `UserFacingError` objects, respect the formatter, and continue to capture validation metadata.
+3. **Remix Surface Sweep**: Update `apps/cyberstorm-remix/app/**` forms/actions to consume the formatter, remove legacy `error.message` strings, and wire `inputErrors` for validation paths.
+4. **Loader & Boundary Integration**: Propagate translation through Dapper wrappers and Remix loaders/actions so route-level failures deliver structured payloads that the root error boundary can present cleanly.
+5. **Docs & Tests**: Expand unit/integration coverage plus contributor guidance (`docs/error-handling-plan.md`, Vitest suites) to lock behaviour and keep package consumers aligned.
+
+## Delivery Phases
+1. **Foundations**: Implement translator, `UserFacingError`, and updated error classes in `thunderstore-api`. Add unit tests mirroring scenarios: stale session, malformed payload, rate limit, server crash.
+2. **Shared Hooks**: Update `ts-api-react`, `ts-api-react-actions`, `useStrongForm`, `useFormToaster`. Provide migration docs for teams adopting new contract.
+3. **Surface Rollout**: Migrate high-impact flows (package reporting, uploads, team management) to the new error presenter. Remove string equality logic and rely on categories.
+4. **Route & Loader Consistency**: Update loaders/actions and error boundaries to emit/present `UserFacingError` shapes. Ensure Dapper consumers adopt the translator.
+5. **Cleanup**: Search for legacy `"Error occurred:"` or direct `error.message` comparisons and replace with category-based handling. Document best practices in the developer guide.
+
+## Progress Log
+- **2025-10-23**
+   - *Foundations*: `packages/thunderstore-api` now ships `sanitizeServerDetail`, the `UserFacingError` class, and `mapApiErrorToUserFacingError`; associated unit tests cover translator behaviour.
+   - *Shared Hooks*: `ts-api-react` / `ts-api-react-actions` now normalise errors to `UserFacingError`; `useStrongForm` rewritten to consume the mapper, capture validation errors, and surface `headline`/`description` to callers.
+   - *Surface Rollout*: `ReportPackageForm`, `packageEdit`, and initial toaster helpers now display friendly copy; additional forms (e.g. uploads, team settings) still use legacy messages pending follow-up.
+- **2025-10-29**
+   - *Shared Hooks*: Introduced `formatUserFacingError` and updated `useFormToaster` to consume it, consolidating toast copy generation around `headline`/`description` semantics.
+   - *Surface Rollout*: Migrated upload, account deletion, and team creation flows to rely on `UserFacingError` plus the formatter; removed remaining `"Error occurred"` fallbacks across Remix app forms.
+
+## Testing & Verification
+- **Unit**: Cover translators, `ApiError` metadata, and presenter helpers.
+- **Integration**: Vitest tests around `useStrongForm` to ensure UI receives correct `headline`/`description` given mocked errors.
+
+## Open Questions
+None at this time; UX-specific CTAs and cross-package adoption will be revisited after the core rollout.
+
+---
+
+**New file**: `docs/error-handling-plan.md`

--- a/docs/loader-client-loader-audit.md
+++ b/docs/loader-client-loader-audit.md
@@ -1,0 +1,79 @@
+# Loader & Client Loader Error-Handling Audit
+
+## Overview
+- Audited every `loader` and `clientLoader` export under `apps/cyberstorm-remix`.
+- Most high-traffic community and package flows now wrap Dapper calls with `handleLoaderError` plus shared status mappings (401/403/404/422) while preserving Suspense semantics on the client.
+- Completed wiki child routes, team management, upload flows, and community package search tabs.
+- Recommendation: continue standardising on `handleLoaderError` (with per-route copy via shared mappings) and expand reusable mappings for less common statuses (409 conflicts, 429 rate limits, etc.).
+
+## Server loaders (`export async function loader`)
+| Path | Current handling | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/c/community.tsx | ✅ Uses `handleLoaderError` with shared auth/not-found/429/server mappings | Low | Consider adding copy if community fetch introduces additional status codes. |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | ✅ Uses `handleLoaderError` with shared auth/validation/429/server mappings while preserving community filters | Low | Monitor for additional status codes if search introduces new failure modes. |
+| apps/cyberstorm-remix/app/communities/communities.tsx | ✅ Uses `handleLoaderError` with auth mappings | Low; unmapped statuses fall back to default handler copy | Monitor for additional status-specific copy needs. |
+| apps/cyberstorm-remix/app/healthz.tsx | Returns JSON for `/healthz`, no external calls | Low risk | None required. |
+| apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | ✅ Wrapped Dapper calls; shared mappings for 401/403/404/422 | Low; listings fallback handled | Revisit copy once dependants adds 409/500 copy requirements. |
+| apps/cyberstorm-remix/app/p/packageEdit.tsx | Uses `handleLoaderError` with 404 override | ✅ Handles 404 and delegates others | Consider adding map options for 401/403 (session expired) if needed, but baseline is sound. |
+| apps/cyberstorm-remix/app/p/packageListing.tsx | ✅ Loader & client use mappings, keep Suspense promises | Low; permissions promise still optional | Consider adding 409 handling for moderation workflows. |
+| apps/cyberstorm-remix/app/p/packageVersion.tsx | ✅ Wrapped with shared mappings, preserves Suspense usage | Low | Add 409 mapping if version lock exposed later. |
+| apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx | ✅ Wrapped with shared mappings; client awaits for error surfacing | Low | Same as above. |
+| apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx | ✅ Uses `handleLoaderError` with auth/not-found copy | Low | None. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx | ✅ Loader catches and maps 401/403/404 | Low | Consider 409 copy when edit conflicts exposed. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx | ✅ Same mapping pattern applied | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx | ✅ Shared mappings for auth/not-found | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx | ✅ Uses shared dependency mappings (401/403/404/422) | Low | Add 429/500 copy if rate limits appear. |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx | ✅ Same shared mappings applied | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx | ✅ Loader wraps listing/version/dependencies in mapping-aware handler | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx | ✅ Uses shared mappings; preserves Suspense | Low | Watch for 409 copy (locked source). |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx | ✅ Applies exported versions mapping | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx | ✅ Same mapping usage | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx | ✅ Loader/client catch & map 401/403/404 | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx | ✅ Wraps wiki + permissions with shared mappings | Low | Child routes now share the same mappings; monitor for new status codes as wiki grows. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx | ✅ Uses `handleLoaderError` with shared wiki/409/429/server mappings; 404 returns empty wiki | Low | Monitor for additional copy requirements as wiki evolves. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx | ✅ Uses `handleLoaderError` with shared wiki/409/429/server mappings while validating wiki existence | Low | Consider adding permission-based copy if future UX requires it. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx | ✅ Uses `handleLoaderError` with shared wiki/409/429/server mappings; 404 returns empty result | Low | Monitor for additional copy requirements as wiki evolves. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx | ✅ Uses `handleLoaderError` with shared wiki/409/429/server mappings; missing slug returns 404 payload | Low | Monitor for additional copy requirements as wiki evolves. |
+| apps/cyberstorm-remix/app/p/team/Team.tsx | ✅ Uses `handleLoaderError` with shared auth/not-found/validation/429/server mappings; preserves listing filters | Low | Monitor copy needs for future status codes. |
+| apps/cyberstorm-remix/app/root.tsx | Loads env only | Low risk | None. |
+| apps/cyberstorm-remix/app/upload/upload.tsx | ✅ Uses `handleLoaderError` with shared auth/validation/conflict/429/server mappings when fetching communities | Low | Monitor for additional status-specific copy once upload APIs evolve. |
+
+## Client loaders (`export async function clientLoader`)
+| Path | Current handling | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/c/community.tsx | ✅ Awaited community fetch with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | ✅ Awaited filters/listings with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/communities/communities.tsx | ✅ Await + mappings before returning Suspense promise | Low | Monitor additional codes. |
+| apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | ✅ Await Promises + shared mappings | Low | — |
+| apps/cyberstorm-remix/app/p/packageEdit.tsx | Uses `handleLoaderError` + 404 override | ✅ Good | Consider mapping additional codes via options if needed. |
+| apps/cyberstorm-remix/app/p/packageListing.tsx | ✅ Wraps all promises; keeps Suspense semantics | Low | Consider 409 copy for moderation actions. |
+| apps/cyberstorm-remix/app/p/packageVersion.tsx | ✅ Uses shared mappings with awaited promises | Low | — |
+| apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx | ✅ Same pattern | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx | ✅ Await + mappings | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx | ✅ Uses shared mappings | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx | ✅ Awaited promises w/ mappings | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx | ✅ Same | Low | — |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx | ✅ Same | Low | Child routes now share the same mappings; monitor for new status codes as wiki grows. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx | ✅ Awaited calls with shared mappings; keeps Suspense promises | Low | None. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx | ✅ Awaited wiki check with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx | ✅ Awaited wiki/page/permissions promises with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx | ✅ Awaited wiki/page promises with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/p/team/Team.tsx | ✅ Awaited filters/listings promises with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/root.tsx | Reads env + session; throws explicit Errors; acceptable | Low risk (explicit `Error` for missing env) | Optional: convert to `throwUserFacingPayloadResponse` with auth signage if desired. |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/Members/Members.tsx | Uses `handleLoaderError` + 404 override | ✅ Good | None. |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/Profile/Profile.tsx | ✅ Good | None | — |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/ServiceAccounts/ServiceAccounts.tsx | ✅ Good | None | — |
+| apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx | ✅ Good | None | — |
+| apps/cyberstorm-remix/app/upload/upload.tsx | ✅ Awaited communities call with shared mappings | Low | None. |
+
+## Additional notes
+- Remaining work: none.
+- Expand shared mappings for less common statuses (409 conflicts, 429 rate limits, 5xx fallbacks) so future routes can reference them without bespoke copy.
+- Continue preferring awaited promises inside client loaders to guarantee `handleLoaderError` can translate failures before Remix resolves Suspense.

--- a/docs/loader-client-loader-audit.md
+++ b/docs/loader-client-loader-audit.md
@@ -41,7 +41,7 @@
 ## Client loaders (`export async function clientLoader`)
 | Path | Current handling | Risk | Suggested next step |
 | --- | --- | --- | --- |
-| apps/cyberstorm-remix/app/c/community.tsx | ✅ Awaited community fetch with shared mappings | Low | None. |
+| apps/cyberstorm-remix/app/c/community.tsx | Suspense promise wraps `DapperTs.getCommunity` with shared mappings on rejection | Low | Completed 2025-10-31; monitor for new status codes. |
 | apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | ✅ Awaited filters/listings with shared mappings | Low | None. |
 | apps/cyberstorm-remix/app/communities/communities.tsx | ✅ Await + mappings before returning Suspense promise | Low | Monitor additional codes. |
 | apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | ✅ Await Promises + shared mappings | Low | — |

--- a/docs/loader-error-handling-plan.md
+++ b/docs/loader-error-handling-plan.md
@@ -1,0 +1,19 @@
+# Loader Error Handling Plan
+
+## Goals
+- Deliver consistent, user-friendly messaging for loader and action failures across the cyberstorm Remix app.
+- Reuse shared utilities so future routes automatically benefit from structured `UserFacingError` payloads.
+- Ensure API client helpers provide contextual not-found errors that can be surfaced directly in the UI.
+
+## Implementation Steps
+1. **API error helpers**: Extend `packages/thunderstore-api/src/errors/userFacingError.ts` with `createResourceNotFoundError` so 404 responses emit predictable headlines, descriptions, and context.
+2. **Team API fetchers**: Update `fetchTeamDetails`, `fetchTeamMembers`, and `fetchTeamServiceAccounts` to wrap 404 responses with `createResourceNotFoundError`, preserving team identifiers for the UI.
+3. **Shared loader handling**: Add `handleLoaderError` under `apps/cyberstorm-remix/cyberstorm/utils/errors/` to funnel both `ApiError` and `UserFacingError` instances through `throwUserFacingErrorResponse` while leaving native `Response` objects untouched.
+4. **Route loaders**: Refactor Remix loaders (team settings tabs, package edit flows, and other routes previously using inline `ApiError` checks) to call `handleLoaderError`, while leaving bespoke `throwUserFacingPayloadResponse` cases for explicit copy.
+5. **Error boundary polish**: Adjust the root ErrorBoundary so payload descriptions always win and fallback text is deduplicated against the headline, preventing repeated “Not found” messaging.
+6. **Documentation**: Maintain this plan within `docs/loader-error-handling-plan.md` for quick onboarding and future expansion (e.g., auditing remaining loaders, adding automated tests).
+
+## Follow-Up Ideas
+- Broaden the loader audit to cover all Remix routes (communities, upload) and migrate them to `handleLoaderError`.
+- Add Vitest coverage for `handleLoaderError` and the new API error helper to guard against regressions.
+- Consider centralized logging/Sentry hooks before `handleLoaderError` rethrows so production diagnostics retain full context.

--- a/docs/promise-rejection-handling-audit.md
+++ b/docs/promise-rejection-handling-audit.md
@@ -1,0 +1,28 @@
+# Promise Rejection Handling Audit
+
+_Date:_ 2025-11-07
+_Scope:_ Audit of Cyberstorm Remix UI promise handling, tracking migration to guarded async flows and remaining follow-ups.
+
+## Requirements
+- Client loaders that hand promises to Suspense must surface failures via `{ __error }` payloads (or equivalent user-facing envelope) and downstream views must branch on that union, suppressing meta tags or metadata when errors occur.
+
+| Path | Current pattern | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx | Filters promise now resolved via `async/await` with cancellation guard and console logging | Low – residual risk limited to toast visibility gaps if fetch fails silently | Monitor for UX regressions; consider user-facing error toast if repeated failures observed (2025-11-15) |
+| apps/cyberstorm-remix/app/upload/upload.tsx | Loader returns `LoaderResult` union; Await consumer renders inline alert when `__error` present | Low – pattern now consistent with other guarded loaders | - |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | Combined filters/listings loader resolves through union helper; layout branches on `isLoaderError` with contextual alert | Low – Suspense now provides user-facing copy and prevents meta mismatches | - |
+| apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx | Loader wraps promise via `resolveLoaderPromise`; Await suppresses meta/header when union payload signals failure | Low – union guard keeps settings chrome in sync with data availability | - |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/Profile/Profile.tsx | Profile loader surfaces `{ __error }` payload and component renders alert with helper | Low – inline alert gives actionable copy; no further follow-up needed | - |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/Members/Members.tsx | Members loader resolves through union helper; Suspense branch renders payload-aware alert | Low – table only renders on success, preventing stale state | - |
+| apps/cyberstorm-remix/app/settings/teams/team/tabs/ServiceAccounts/ServiceAccounts.tsx | Service accounts loader now returns union and branches Await rendering to payload-aware alert | Low – inline alert communicates failure and avoids Suspense rejection loop | - |
+| apps/cyberstorm-remix/app/p/packageListing.tsx | Rated-pack fetch and hydration metadata handled via cancellable `async/await` flow with toast on failure | Low – console logging only during hydration | Add metrics hook if failures spike (2025-11-30) |
+| apps/cyberstorm-remix/app/c/community.tsx | Client loader now returns community data or `{ __error }`; Suspense branch guards union and shows inline `NewAlert` while suppressing meta tags on failure | Low – meta tags stay blank when errors occur, which is acceptable but should be revisited if SEO demands alternate copy | - |
+| apps/cyberstorm-remix/app/communities/communities.tsx | Loader resolves through union helper; grid await branches to payload-aware alert | Low – communicates failures inline while keeping Suspense stable | - |
+| apps/cyberstorm-remix/app/p/team/Team.tsx | Loader now returns LoaderResult unions for filters/listings; view gates Suspense sections with `isLoaderError` and shows inline alert | Low – guarded alerts keep page content stable when fetches fail | - |
+| apps/cyberstorm-remix/app/p/packageEdit.tsx | Loader promises wrapped with `resolveLoaderPromise`; Await components branch on `isLoaderError` and reuse alert component | Low – alert messaging keeps editor usable during API failures | - |
+| apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | Listing/filters/community results now use LoaderResult unions with payload-aware alerts in the tab content | Low – inline alert replaces skeletons when data fails to load | - |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/ | Client loaders (Wiki.tsx, WikiFirstPage.tsx, WikiPage.tsx, WikiNewPage.tsx, WikiPageEdit.tsx) stream promises without error unions; navigation assumes data | Medium – wiki navigation and editors fail silently until boundary renders, causing inconsistent controls | Standardize on union payloads per loader and adjust nav/content components to branch on error payload (2025-12-05) |
+| apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx | Loader returns LoaderResult unions for version/team; component branches meta/header/actions rendering and reuses payload alert | Low – union guard prevents Suspense rejections and keeps UX consistent | - |
+| apps/cyberstorm-remix/app/p/packageVersion.tsx | Version metadata effect handles promise rejection and avoids unmounted updates | Low – console log only | Explore user-visible fallback copy if hydrations routinely fail (2025-11-30) |
+
+_Pending follow-ups:_ Implement the union-based client loader pattern for the medium-risk rows above (upload, community package search, team settings tabs, team/package edit, dependants, wiki module) and continue scanning sibling apps (storybook app, uploader react package) for remaining promise chains; update the table as statuses evolve.

--- a/docs/suspense-await-loader-audit.md
+++ b/docs/suspense-await-loader-audit.md
@@ -1,0 +1,76 @@
+# Suspense & Await Loader Audit
+
+## Overview
+- Reviewed every `loader` and `clientLoader` under `apps/cyberstorm-remix` with a focus on Remix Suspense/Await integration.
+- Goal: loaders should continue to return resolved data for SSR when possible, while client loaders should hand back the original promises so UI-level `Suspense` components can present fallbacks during client transitions.
+- Presently, most loaders still provide SSR-friendly resolved data, but nearly every client loader resolves its data before returning. This prevents Suspense fallbacks from appearing and forces duplicate error handling inside the loader.
+- A handful of server loaders also bubble promises (after awaiting for error handling) instead of returning concrete values, making SSR less predictable.
+
+## Server loaders (`export async function loader`)
+| Path | Current pattern | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/c/community.tsx | Returns resolved community object (SSR-friendly). | Low | No change needed once client side is updated. |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | Resolves filters/listings before return. | Low | No action required; just ensure layout Suspense owns client errors. |
+| apps/cyberstorm-remix/app/communities/communities.tsx | Returns resolved listings; SSR works today. | Low | Keep as-is after client loader shift. |
+| apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | Resolves filters but returns other promises that were awaited only for errors. | Medium | Convert return shape to plain data (or explicit `{value, promise}` split) so SSR has concrete values. |
+| apps/cyberstorm-remix/app/p/packageEdit.tsx | Returns fully awaited data. | Low | No change required. |
+| apps/cyberstorm-remix/app/p/packageListing.tsx | Returns awaited data across all fields. | Low | Nothing to do. |
+| apps/cyberstorm-remix/app/p/packageVersion.tsx | Returns promises after `Promise.all`, leaving layout to unwrap. | Medium | Return concrete objects for SSR; move promise handing to client loader/layout combo. |
+| apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx | Returns resolved data. | Low | No change needed. |
+| apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx | Returns resolved promise object (already awaited). | Medium | Return the markdown payload rather than the promise. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx | Same: returns promise after awaiting. | Medium | Return resolved readme HTML for SSR, shift promise handling to client loader. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx | Returns promise after awaiting. | Medium | Same recommendation as above. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx | Returns promise after awaiting. | Medium | Return resolved value, keep Suspense only on client path. |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx | Returns promises post-`Promise.all`. | Medium | Replace with resolved arrays/objects for SSR clarity. |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx | Returns promises after awaiting. | Medium | Same fix as other dependency tabs. |
+| apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx | Mix of resolved data and promises. | Medium | Normalize to resolved data. |
+| apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx | Returns promise after awaiting the fetch. | Medium | Provide final source payload to SSR, leave streaming to client. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx | Returns promise after awaiting. | Medium | Return resolved version list, keep Suspense usage for client transitions only. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx | Returns promise after awaiting. | Medium | Same update as above. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx | Returns promise after awaiting. | Medium | Return resolved versions. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx | Returns resolved wiki object + primitive IDs. | Low | Already SSR friendly; no change. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx | Returns resolved wiki/page objects (plus IDs). | Low | Fine as-is. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx | Returns resolved metadata (no wiki promise). | Low | No change required. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx | Returns resolved wiki/page. | Low | No change required. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx | Returns resolved page struct. | Low | Good for SSR. |
+| apps/cyberstorm-remix/app/p/team/Team.tsx | Returns resolved filters/listings. | Low | Already SSR friendly. |
+| apps/cyberstorm-remix/app/root.tsx | Returns env/session data synchronously. | Low | No change needed. |
+| apps/cyberstorm-remix/app/upload/upload.tsx | Returns resolved community list. | Low | No change needed. |
+
+## Client loaders (`export async function clientLoader`)
+| Path | Current pattern | Risk | Suggested next step |
+| --- | --- | --- | --- |
+| apps/cyberstorm-remix/app/c/community.tsx | Awaits community before returning, so Suspense gets an already-resolved value. | High | Stop awaiting; return the raw promise and let layout handle errors via Suspense/ErrorBoundary. |
+| apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx | Uses `await Promise.all` then returns resolved values. | High | Return the original promises (or re-wrap) and surface errors in layout. |
+| apps/cyberstorm-remix/app/communities/communities.tsx | Awaits `getCommunities` before returning. | High | ✅ Completed Oct 29 2025 — client loader returns the original promise and the route-level ErrorBoundary surfaces `resolveRouteErrorPayload`. |
+| apps/cyberstorm-remix/app/p/dependants/Dependants.tsx | Awaits all data; returns a mix of resolved values/promises. | High | Return promises for listings/community and relocate error handling + boundaries. |
+| apps/cyberstorm-remix/app/p/packageEdit.tsx | Fully awaits everything prior to return. | High | Return deferred promises (especially listing/filters) and surface permission errors via boundary. |
+| apps/cyberstorm-remix/app/p/packageListing.tsx | Awaits all resources (Promise.all) before returning. | High | Return the original promises to preserve Suspense UX. |
+| apps/cyberstorm-remix/app/p/packageVersion.tsx | Awaits each fetch, handing back resolved objects. | High | Return raw promises; relocate error management to layout-level boundaries. |
+| apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx | Awaits via `Promise.all`, then returns resolved promises. | High | Return unresolved promises so Suspense fallback renders. |
+| apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx | Awaits changelog promise before returning. | High | Return `changelogPromise`; move error handling to component boundary. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx | Awaits readme before returning. | High | Return promise and catch errors in layout. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx | Same as above. | High | Same fix. |
+| apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx | Awaits readme before returning. | High | Return promise and handle errors higher up. |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionRequired.tsx | Awaits via `Promise.all`, returning resolved promises. | High | Stop awaiting; let Suspense manage loading states. |
+| apps/cyberstorm-remix/app/p/tabs/Required/PackageVersionWithoutCommunityRequired.tsx | Same pattern. | High | Same update. |
+| apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx | Awaits dependencies before return. | High | Return raw promises & elevate error handling. |
+| apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx | Awaits source payload before returning. | High | Return promise and add boundary in layout. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx | Awaits versions before returning. | High | Return promise; move error handling to Suspense boundary. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx | Same. | High | Same fix. |
+| apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx | Same. | High | Same fix. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx | Awaits both wiki & permissions before returning promises. | High | Return promises without awaiting; relocate error handling to wiki layout component. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx | Awaits wiki/page/permissions before returning (mix of resolved/promise). | High | Return raw promises; add route-level Suspense/ErrorBoundary. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx | Awaits wiki existence before returning. | Medium | Consider returning promise if metadata fetch should show skeleton; ensure layout can render boundary copy. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx | Awaits wiki/page before returning promises. | High | Return promises untouched; surface errors via layout boundary. |
+| apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx | Awaits wiki/page before returning. | High | Return promises, introduce Suspense boundary for editor. |
+| apps/cyberstorm-remix/app/p/team/Team.tsx | Awaits filters/listings prior to return. | High | Return promises so team tab skeleton renders; move error handling to route-level boundary. |
+| apps/cyberstorm-remix/app/root.tsx | Returns env/session synchronously. | Low | No Suspense usage; unchanged. |
+| apps/cyberstorm-remix/app/upload/upload.tsx | Awaits community list before returning. | High | Return promise to allow upload page skeleton; move errors to boundary. |
+
+## Additional notes
+- Nearly all client loaders still resolve data and map errors before returning, which defeats Suspense fallbacks. Refactor client loaders to return raw promises and relocate error handling to the components that call `Await`.
+- Communities route now confirmed working with promise-based client loader and shared ErrorBoundary pattern (Oct 29 2025).
+- Several loaders (notably changelog/readme/versions/dependant flows) return promise objects after awaiting; switch those to resolved values to maximize SSR benefit.
+- Introducing route-level `ErrorBoundary` components for Suspense-driven layouts will allow graceful rendering when client promises reject.
+- When refactoring, prefer a consistent shape (e.g., `{ value, promise }`) if both SSR data and client streaming are required, and document the contract for downstream components.

--- a/docs/user-facing-error-review-findings.md
+++ b/docs/user-facing-error-review-findings.md
@@ -1,0 +1,13 @@
+# User-Facing Error Handling Review – Findings
+
+## 1. StrongForm guardrails return plain `Error`
+- **Files affected:** `apps/cyberstorm-remix/app/p/components/ReportPackage/ReportPackageForm.tsx`, `apps/cyberstorm-remix/app/p/packageEdit.tsx`, `apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx`, `apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx`, `apps/cyberstorm-remix/app/settings/teams/**`, `apps/cyberstorm-remix/app/settings/user/Account/Account.tsx`, and any other consumer formatting `UserFacingError` via `formatUserFacingError`.
+- **What happens:** `useStrongForm` (`apps/cyberstorm-remix/cyberstorm/utils/StrongForm/useStrongForm.ts`) still throws vanilla `Error` objects for local guard conditions (double submits, refining state, refine errors) before mapping remote failures to `UserFacingError`. When these reach `formatUserFacingError`, both `headline` and `description` are undefined, so toasts/modals display blank messages.
+- **Consequence:** User-visible regression whenever a form hits those guard rails (e.g., double-clicking “Save”) because the helper now expects a `UserFacingError`.
+- **Resolution:** `useStrongForm` now converts internal guardrail failures into `UserFacingError` instances before emitting them, so downstream toasts receive human-readable headlines.
+
+## 2. `handleLoaderError` loses bespoke not-found copy
+- **Files affected:** `apps/cyberstorm-remix/app/p/packageEdit.tsx`, `apps/cyberstorm-remix/app/settings/teams/team/tabs/{Members,Profile,ServiceAccounts,Settings}/Members.tsx`, `apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx`, and similar loaders that replaced explicit `ApiError` checks with `handleLoaderError`.
+- **What happens:** Legacy code threw `new Response("Package not found", { status: 404 })` (or team-specific messages). After refactoring, these catch blocks call `handleLoaderError`, which maps an `ApiError` via `mapApiErrorToUserFacingError` and rethrows immediately. The route-specific `throwUserFacingPayloadResponse({ headline: "Package not found.", ... })` that follows is now unreachable for API-driven 404s.
+- **Consequence:** UI no longer shows the tailored copy we added; it falls back to sanitized API text (“The requested resource was not found.”) without category-specific context.
+- **Resolution:** Each affected loader now checks for `ApiError` 404 responses and rethrows the tailored `throwUserFacingPayloadResponse` payload before delegating unexpected errors to `handleLoaderError`.

--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -22,7 +22,7 @@ export async function getCommunities(
   ) {
     supportedOrdering = ordering as CommunityListOrderingEnum;
   }
-  const data = await fetchCommunityList({
+  return fetchCommunityList({
     config: this.config,
     queryParams: [
       { key: "page", value: page, impotent: 1 },
@@ -37,23 +37,18 @@ export async function getCommunities(
     data: {},
   });
 
-  return {
-    count: data.count,
-    hasMore: Boolean(data.next),
-    results: data.results,
-  };
+  // return {
+  //   count: data.count,
+  //   hasMore: Boolean(data.next),
+  //   results: data.results,
+  // };
 }
 
-export async function getCommunity(
-  this: DapperTsInterface,
-  communityId: string
-) {
-  const data = await fetchCommunity({
+export function getCommunity(this: DapperTsInterface, communityId: string) {
+  return fetchCommunity({
     config: this.config,
     params: { community_id: communityId },
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -6,12 +6,10 @@ export async function getCommunityFilters(
   this: DapperTsInterface,
   communityId: string
 ) {
-  const data = await fetchCommunityFilters({
+  return fetchCommunityFilters({
     config: this.config,
     params: { community_id: communityId },
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -10,7 +10,7 @@ import {
 
 import { DapperTsInterface } from "../index";
 
-export async function getPackageListings(
+export function getPackageListings(
   this: DapperTsInterface,
   type: PackageListingType,
   ordering?: string,
@@ -75,7 +75,7 @@ export async function getPackageListings(
   let data;
 
   if (type.kind === "community") {
-    data = await fetchCommunityPackageListings({
+    data = fetchCommunityPackageListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -84,7 +84,7 @@ export async function getPackageListings(
       queryParams: options,
     });
   } else if (type.kind === "namespace") {
-    data = await fetchNamespacePackageListings({
+    data = fetchNamespacePackageListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -94,7 +94,7 @@ export async function getPackageListings(
       queryParams: options,
     });
   } else if (type.kind === "package-dependants") {
-    data = await fetchPackageDependantsListings({
+    data = fetchPackageDependantsListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -110,11 +110,7 @@ export async function getPackageListings(
     );
   }
 
-  return {
-    count: data.count,
-    hasMore: Boolean(data.next),
-    results: data.results,
-  };
+  return data;
 }
 
 export async function getPackageListingDetails(

--- a/packages/dapper/src/types/shared.ts
+++ b/packages/dapper/src/types/shared.ts
@@ -19,6 +19,7 @@ export interface PackageCategory {
 
 export type PaginatedList<T> = {
   count: number;
-  hasMore: boolean;
+  next: string | null;
+  previous: string | null;
   results: T[];
 };

--- a/packages/thunderstore-api/src/__tests__/userFacingError.test.ts
+++ b/packages/thunderstore-api/src/__tests__/userFacingError.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  ApiError,
+  RequestBodyParseError,
+  createResourceNotFoundError,
+  mapApiErrorToUserFacingError,
+  UserFacingError,
+} from "../index";
+
+describe("mapApiErrorToUserFacingError", () => {
+  it("categorises stale session responses as auth errors", async () => {
+    const response = new Response(
+      JSON.stringify({ detail: "Session token is no longer valid." }),
+      {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const apiError = await ApiError.createFromResponse(response, {
+      sessionWasUsed: true,
+    });
+
+    const userFacing = mapApiErrorToUserFacingError(apiError);
+
+    expect(userFacing).toBeInstanceOf(UserFacingError);
+    expect(userFacing.category).toBe("auth");
+    expect(userFacing.status).toBe(401);
+    expect(userFacing.headline).toContain("session has expired");
+    expect(userFacing.description).toContain(
+      "Session token is no longer valid."
+    );
+    expect(userFacing.context?.sessionWasUsed).toBe(true);
+  });
+
+  it("maps request validation issues to validation category", () => {
+    const schema = z.object({ field: z.string().min(1) });
+    const result = schema.safeParse({ field: "" });
+
+    expect(result.success).toBe(false);
+
+    const zodError = result.success ? undefined : result.error;
+    const validationError = new RequestBodyParseError(zodError!);
+
+    const userFacing = mapApiErrorToUserFacingError(validationError);
+
+    expect(userFacing.category).toBe("validation");
+    expect(userFacing.headline).toContain("Invalid request data");
+  });
+
+  it("falls back to network category for fetch issues", () => {
+    const networkError = new TypeError("Failed to fetch");
+
+    const userFacing = mapApiErrorToUserFacingError(networkError, {
+      fallbackHeadline: "Network issue detected.",
+      fallbackDescription: "Check your connection and retry.",
+    });
+
+    expect(userFacing.category).toBe("network");
+    expect(userFacing.headline).toBe("Network issue detected.");
+    expect(userFacing.description).toBe("Check your connection and retry.");
+  });
+
+  it("creates a consistent not found user-facing error", async () => {
+    const response = new Response(
+      JSON.stringify({ detail: "Not found." }),
+      {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
+    const apiError = await ApiError.createFromResponse(response);
+
+    const userFacing = createResourceNotFoundError({
+      resourceName: "team",
+      identifier: "alpha",
+      originalError: apiError,
+    });
+
+    expect(userFacing).toBeInstanceOf(UserFacingError);
+    expect(userFacing.headline).toBe("Team not found.");
+    expect(userFacing.description).toBe(
+      'We could not find the team "alpha".'
+    );
+    expect(userFacing.status).toBe(404);
+    expect(userFacing.category).toBe("not_found");
+    expect(userFacing.context?.resource).toBe("team");
+    expect(userFacing.context?.identifier).toBe("alpha");
+  });
+
+  it("falls back to generic copy when identifier absent", async () => {
+    const response = new Response("Not found.", {
+      status: 404,
+      statusText: "Not Found",
+    });
+
+    const apiError = await ApiError.createFromResponse(response);
+
+    const userFacing = createResourceNotFoundError({
+      resourceName: "team",
+      originalError: apiError,
+    });
+
+    expect(userFacing.description).toBe(
+      "We could not find the requested team."
+    );
+    expect(userFacing.context?.identifier).toBeUndefined();
+  });
+});

--- a/packages/thunderstore-api/src/errors/sanitizeServerDetail.ts
+++ b/packages/thunderstore-api/src/errors/sanitizeServerDetail.ts
@@ -1,0 +1,22 @@
+const MAX_LENGTH = 400;
+
+function stripControlCharacters(value: string): string {
+  return value.replace(/[\x00-\x1F\x7F]/g, " ");
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function sanitizeServerDetail(value: string): string {
+  if (!value) return "";
+
+  const cleaned = collapseWhitespace(stripControlCharacters(value));
+  if (!cleaned) return "";
+
+  if (cleaned.length <= MAX_LENGTH) {
+    return cleaned;
+  }
+
+  return `${cleaned.slice(0, MAX_LENGTH).trim()}…`;
+}

--- a/packages/thunderstore-api/src/errors/userFacingError.ts
+++ b/packages/thunderstore-api/src/errors/userFacingError.ts
@@ -1,0 +1,239 @@
+import {
+  ApiError,
+  ParseError,
+  RequestBodyParseError,
+  RequestQueryParamsParseError,
+} from "../errors";
+import { sanitizeServerDetail } from "./sanitizeServerDetail";
+
+export type UserFacingErrorCategory =
+  | "auth"
+  | "validation"
+  | "not_found"
+  | "rate_limit"
+  | "server"
+  | "network"
+  | "unknown";
+
+export interface MapUserFacingErrorOptions {
+  fallbackHeadline?: string;
+  fallbackDescription?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface CreateResourceNotFoundErrorArgs {
+  resourceName: string;
+  identifier?: string;
+  description?: string;
+  originalError: Error;
+  context?: Record<string, unknown>;
+}
+
+interface UserFacingErrorArgs {
+  category: UserFacingErrorCategory;
+  status?: number;
+  headline: string;
+  description?: string;
+  originalError: Error;
+  context?: Record<string, unknown>;
+}
+
+export class UserFacingError extends Error {
+  readonly category: UserFacingErrorCategory;
+  readonly status?: number;
+  readonly headline: string;
+  readonly description?: string;
+  readonly originalError: Error;
+  readonly context?: Record<string, unknown>;
+
+  constructor(args: UserFacingErrorArgs) {
+    super(args.headline);
+    this.category = args.category;
+    this.status = args.status;
+    this.headline = args.headline;
+    this.description = args.description;
+    this.originalError = args.originalError;
+    this.context = args.context;
+    this.name = "UserFacingError";
+  }
+}
+
+const RESOURCE_FALLBACK_LABEL = "resource";
+
+const DEFAULT_HEADLINE = "Something went wrong.";
+const DEFAULT_DESCRIPTION = "Please try again.";
+
+export interface FormatUserFacingErrorOptions {
+  fallback?: string;
+}
+
+export function formatUserFacingError(
+  error: UserFacingError,
+  options: FormatUserFacingErrorOptions = {}
+): string {
+  if (error.description) {
+    return `${error.headline} ${error.description}`;
+  }
+  if (options.fallback) {
+    return options.fallback;
+  }
+  return error.headline;
+}
+
+export function mapApiErrorToUserFacingError(
+  error: unknown,
+  options: MapUserFacingErrorOptions = {}
+): UserFacingError {
+  if (error instanceof UserFacingError) {
+    return error;
+  }
+
+  const fallbackHeadline = options.fallbackHeadline ?? DEFAULT_HEADLINE;
+  const fallbackDescription =
+    options.fallbackDescription ?? DEFAULT_DESCRIPTION;
+
+  if (error instanceof ApiError) {
+    const category = categorizeStatus(error.statusCode);
+    const headline = ensureHeadline(error.message, fallbackHeadline);
+    const sanitizedServerDetail = ensureDescription(error.serverMessage ?? "");
+    const sanitizedFallback = ensureDescription(fallbackDescription);
+    const descriptionCandidate = sanitizedServerDetail || sanitizedFallback;
+
+    return new UserFacingError({
+      category,
+      status: error.statusCode,
+      headline,
+      description: descriptionCandidate,
+      originalError: error,
+      context: {
+        ...options.context,
+        statusText: error.statusText,
+        sessionWasUsed: error.context?.sessionWasUsed ?? false,
+      },
+    });
+  }
+
+  if (
+    error instanceof RequestBodyParseError ||
+    error instanceof RequestQueryParamsParseError ||
+    error instanceof ParseError
+  ) {
+    const message = ensureHeadline(error.message, "Invalid request data.");
+    return new UserFacingError({
+      category: "validation",
+      headline: message,
+      description: sanitizeServerDetail(error.message),
+      originalError: error,
+      context: options.context,
+    });
+  }
+
+  if (isNetworkError(error)) {
+    const err = toError(error);
+    return new UserFacingError({
+      category: "network",
+      headline: fallbackHeadline,
+      description: fallbackDescription,
+      originalError: err,
+      context: options.context,
+    });
+  }
+
+  const err = toError(error);
+  return new UserFacingError({
+    category: "unknown",
+    headline: fallbackHeadline,
+    description: fallbackDescription,
+    originalError: err,
+    context: options.context,
+  });
+}
+
+export function createResourceNotFoundError(
+  args: CreateResourceNotFoundErrorArgs
+): UserFacingError {
+  const resourceName = sanitizeLabel(args.resourceName);
+  const identifier = sanitizeOptional(args.identifier);
+  const headline = `${capitalize(resourceName)} not found.`;
+  const description =
+    sanitizeOptional(args.description) ??
+    (identifier
+      ? `We could not find the ${resourceName} "${identifier}".`
+      : `We could not find the requested ${resourceName}.`);
+
+  return new UserFacingError({
+    category: "not_found",
+    status: 404,
+    headline,
+    description,
+    originalError: args.originalError,
+    context: {
+      ...args.context,
+      resource: resourceName,
+      ...(identifier ? { identifier } : {}),
+    },
+  });
+}
+
+function ensureHeadline(value: string, fallback: string): string {
+  const sanitized = sanitizeServerDetail(value);
+  return sanitized || fallback;
+}
+
+function ensureDescription(value: string): string {
+  return sanitizeServerDetail(value);
+}
+
+function categorizeStatus(status: number): UserFacingErrorCategory {
+  if (status === 401 || status === 403) {
+    return "auth";
+  }
+  if (status === 404) {
+    return "not_found";
+  }
+  if (status === 422 || status === 400) {
+    return "validation";
+  }
+  if (status === 429) {
+    return "rate_limit";
+  }
+  if (status >= 500) {
+    return "server";
+  }
+  return "unknown";
+}
+
+function sanitizeLabel(value: string): string {
+  const sanitized = sanitizeServerDetail(value);
+  return sanitized || RESOURCE_FALLBACK_LABEL;
+}
+
+function sanitizeOptional(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const sanitized = sanitizeServerDetail(value);
+  return sanitized || undefined;
+}
+
+function capitalize(value: string): string {
+  if (!value) return RESOURCE_FALLBACK_LABEL;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+  if (error instanceof Error && error.name === "AbortError") {
+    return true;
+  }
+  return false;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+}

--- a/packages/thunderstore-api/src/get/community.ts
+++ b/packages/thunderstore-api/src/get/community.ts
@@ -6,13 +6,13 @@ import {
 } from "../schemas/responseSchemas";
 import { CommunityRequestParams } from "../schemas/requestSchemas";
 
-export async function fetchCommunity(
+export function fetchCommunity(
   props: ApiEndpointProps<CommunityRequestParams, object, object>
 ): Promise<CommunityResponseData> {
   const { config, params } = props;
   const path = `api/cyberstorm/community/${params.community_id}/`;
 
-  return await apiFetch({
+  return apiFetch({
     args: {
       config,
       path,

--- a/packages/thunderstore-api/src/get/communityFilters.ts
+++ b/packages/thunderstore-api/src/get/communityFilters.ts
@@ -9,13 +9,13 @@ import {
   CommunityFiltersResponseData,
 } from "../schemas/responseSchemas";
 
-export async function fetchCommunityFilters(
+export function fetchCommunityFilters(
   props: ApiEndpointProps<CommunityFiltersRequestParams, object, object>
 ): Promise<CommunityFiltersResponseData> {
   const { config, params } = props;
   const path = `api/cyberstorm/community/${params.community_id}/filters/`;
 
-  return await apiFetch({
+  return apiFetch({
     args: {
       config,
       path,

--- a/packages/thunderstore-api/src/get/communityList.ts
+++ b/packages/thunderstore-api/src/get/communityList.ts
@@ -10,7 +10,7 @@ import {
   CommunityListResponseData,
 } from "../schemas/responseSchemas";
 
-export async function fetchCommunityList(
+export function fetchCommunityList(
   props: ApiEndpointProps<object, CommunityListRequestQueryParams, object>
 ): Promise<CommunityListResponseData> {
   const {
@@ -27,7 +27,7 @@ export async function fetchCommunityList(
   } = props;
   const path = "api/cyberstorm/community/";
 
-  return await apiFetch({
+  return apiFetch({
     args: {
       config,
       path,

--- a/packages/thunderstore-api/src/get/communityPackageListings.ts
+++ b/packages/thunderstore-api/src/get/communityPackageListings.ts
@@ -12,7 +12,7 @@ import {
   packageListingsResponseDataSchema,
 } from "../schemas/responseSchemas";
 
-export async function fetchCommunityPackageListings(
+export function fetchCommunityPackageListings(
   props: ApiEndpointProps<
     CommunityPackageListingsRequestParams,
     PackageListingsRequestQueryParams,
@@ -37,7 +37,7 @@ export async function fetchCommunityPackageListings(
       { key: "deprecated", value: false, impotent: false },
     ],
   } = props;
-  return await apiFetch({
+  return apiFetch({
     args: {
       config,
       path: `api/cyberstorm/listing/${params.community_id.toLowerCase()}/`,

--- a/packages/thunderstore-api/src/get/teamDetails.ts
+++ b/packages/thunderstore-api/src/get/teamDetails.ts
@@ -1,4 +1,8 @@
-import { ApiEndpointProps } from "../index";
+import {
+  ApiEndpointProps,
+  ApiError,
+  createResourceNotFoundError,
+} from "../index";
 import { apiFetch } from "../apiFetch";
 import {
   TeamDetailsResponseData,
@@ -12,13 +16,29 @@ export async function fetchTeamDetails(
   const { config, params } = props;
   const path = `api/cyberstorm/team/${params.team_name}/`;
 
-  return await apiFetch({
-    args: {
-      config: config,
-      path: path,
-    },
-    requestSchema: undefined,
-    queryParamsSchema: undefined,
-    responseSchema: teamDetailsResponseDataSchema,
-  });
+  try {
+    return await apiFetch({
+      args: {
+        config: config,
+        path: path,
+      },
+      requestSchema: undefined,
+      queryParamsSchema: undefined,
+      responseSchema: teamDetailsResponseDataSchema,
+    });
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 404) {
+      throw createResourceNotFoundError({
+        resourceName: "team",
+        identifier: params.team_name,
+        description: "We could not find the requested team.",
+        originalError: error,
+        context: {
+          ...error.context,
+          statusText: error.statusText,
+        },
+      });
+    }
+    throw error;
+  }
 }

--- a/packages/thunderstore-api/src/get/teamMembers.ts
+++ b/packages/thunderstore-api/src/get/teamMembers.ts
@@ -1,4 +1,8 @@
-import { ApiEndpointProps } from "../index";
+import {
+  ApiEndpointProps,
+  ApiError,
+  createResourceNotFoundError,
+} from "../index";
 import { apiFetch } from "../apiFetch";
 import {
   TeamMembersResponseData,
@@ -12,14 +16,30 @@ export async function fetchTeamMembers(
   const { config, params } = props;
   const path = `api/cyberstorm/team/${params.team_name}/member/`;
 
-  return await apiFetch({
-    args: {
-      config: config,
-      path: path,
-      useSession: true,
-    },
-    requestSchema: undefined,
-    queryParamsSchema: undefined,
-    responseSchema: teamMembersResponseDataSchema,
-  });
+  try {
+    return await apiFetch({
+      args: {
+        config: config,
+        path: path,
+        useSession: true,
+      },
+      requestSchema: undefined,
+      queryParamsSchema: undefined,
+      responseSchema: teamMembersResponseDataSchema,
+    });
+  } catch (error) {
+    if (error instanceof ApiError && error.statusCode === 404) {
+      throw createResourceNotFoundError({
+        resourceName: "team",
+        identifier: params.team_name,
+        description: "We could not find the requested team.",
+        originalError: error,
+        context: {
+          ...error.context,
+          statusText: error.statusText,
+        },
+      });
+    }
+    throw error;
+  }
 }

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -54,6 +54,7 @@ export * from "./post/teamAddServiceAccount";
 export * from "./post/teamMember";
 export * from "./post/usermedia";
 export * from "./errors";
+export * from "./errors/userFacingError";
 export * from "./schemas/requestSchemas";
 export * from "./schemas/responseSchemas";
 export * from "./schemas/objectSchemas";

--- a/packages/ts-api-react-actions/src/useApiAction.ts
+++ b/packages/ts-api-react-actions/src/useApiAction.ts
@@ -1,14 +1,22 @@
-import { ApiEndpoint, useApiCall } from "@thunderstore/ts-api-react";
+import {
+  ApiEndpoint,
+  UseApiCallOptions,
+  useApiCall,
+} from "@thunderstore/ts-api-react";
 import { ApiEndpointProps } from "@thunderstore/thunderstore-api";
 
 export type UseApiActionArgs<Params, QueryParams, Data, Return> = {
   endpoint: ApiEndpoint<Params, QueryParams, Data, Return>;
+  apiCallOptions?: UseApiCallOptions;
 };
 
 export function useApiAction<Params, QueryParams, Data, Return>(
   args: UseApiActionArgs<Params, QueryParams, Data, Return>
 ) {
-  const apiCall = useApiCall<Params, QueryParams, Data, Return>(args.endpoint);
+  const apiCall = useApiCall<Params, QueryParams, Data, Return>(
+    args.endpoint,
+    args.apiCallOptions
+  );
 
   const submitHandler = async (
     props: ApiEndpointProps<Params, QueryParams, Data>

--- a/packages/ts-api-react/src/index.ts
+++ b/packages/ts-api-react/src/index.ts
@@ -12,4 +12,4 @@ export {
 export type { ContextInterface } from "./SessionContext";
 export { StorageManager as NamespacedStorageManager } from "./storage";
 export { useApiCall } from "./useApiCall";
-export type { ApiEndpoint } from "./useApiCall";
+export type { ApiEndpoint, UseApiCallOptions } from "./useApiCall";

--- a/packages/ts-api-react/src/useApiCall.ts
+++ b/packages/ts-api-react/src/useApiCall.ts
@@ -1,13 +1,52 @@
-import { ApiEndpointProps } from "@thunderstore/thunderstore-api";
+import {
+  ApiEndpointProps,
+  MapUserFacingErrorOptions,
+  mapApiErrorToUserFacingError,
+} from "@thunderstore/thunderstore-api";
 
 export type ApiEndpoint<Params, QueryParams, Data, Return> = (
   props: ApiEndpointProps<Params, QueryParams, Data>
 ) => Return;
 
+export type UseApiCallOptions = {
+  mapErrors?: boolean;
+  errorOptions?: MapUserFacingErrorOptions;
+};
+
 export function useApiCall<Params, QueryParams, Data, Return>(
-  endpoint: ApiEndpoint<Params, QueryParams, Data, Return>
+  endpoint: ApiEndpoint<Params, QueryParams, Data, Return>,
+  options: UseApiCallOptions = {}
 ): (props: ApiEndpointProps<Params, QueryParams, Data>) => Return {
+  const shouldMapErrors = options.mapErrors ?? true;
+
   return (props: ApiEndpointProps<Params, QueryParams, Data>) => {
-    return endpoint(props);
+    try {
+      const result = endpoint(props);
+
+      if (!shouldMapErrors) {
+        return result;
+      }
+
+      if (isPromise(result)) {
+        return result.catch((error) => {
+          throw mapApiErrorToUserFacingError(error, options.errorOptions);
+        }) as Return;
+      }
+
+      return result;
+    } catch (error) {
+      if (!shouldMapErrors) {
+        throw error;
+      }
+      throw mapApiErrorToUserFacingError(error, options.errorOptions);
+    }
   };
+}
+
+function isPromise(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Promise<unknown>).then === "function"
+  );
 }


### PR DESCRIPTION
- Introduce UserFacingError and mapApiErrorToUserFacingError in thunderstore-api
  (with sanitizeServerDetail) to provide consistent, safe, and localisable
  error semantics for UI consumption.
- Export new error types from package index and add unit tests for mapping logic.
- Rewrite useStrongForm to map/return UserFacingError, surface validation
  form errors, and accept an errorMapper (defaults to the API mapper).
- Update useFormToaster to resolve and display UserFacingError headline/description
  and respect custom overrides.
- Make ts-api-react's useApiCall map API errors to UserFacingError by default and
  accept mapping options; expose UseApiCallOptions from its index.
- Update ts-api-react-actions ApiAction and useApiAction to propagate mapped
  UserFacingError instances and accept UseApiCallOptions.
- Replace ad-hoc error.message string checks in UI flows (ReportPackageForm,
  packageEdit) to display headline/description from UserFacingError.
- Add documentation: docs/error-handling-plan.md describing intended error UX
  and rollout plan.

This change centralises error translation and improves UX consistency across
forms, toasts, API actions, and loaders.