### PR TITLE
Refactor API methods to remove unnecessary async/await and improve return handling

### DIFF
--- a/packages/dapper-fake/src/fakers/community.ts
+++ b/packages/dapper-fake/src/fakers/community.ts
@@ -83,11 +83,28 @@ export const getFakeCommunities: GetCommunities = async (
   }
 
   const count = communities.length;
-  const pageCommunities = communities.splice((page - 1) * pageSize, pageSize);
+  const currentPage = Math.max(page, 1);
+  const startIndex = (currentPage - 1) * pageSize;
+  const pageCommunities = communities.slice(startIndex, startIndex + pageSize);
+  const hasNext = startIndex + pageSize < count;
+  const buildPageUrl = (targetPage: number) => {
+    const params = new URLSearchParams();
+    params.set("page", String(targetPage));
+    if (ordering) {
+      params.set("ordering", ordering);
+    }
+    if (typeof search === "string" && search.trim().length > 0) {
+      params.set("search", search);
+    }
+    return `https://thunderstore.io/api/cyberstorm/community/?${params.toString()}`;
+  };
+  const next = hasNext ? buildPageUrl(currentPage + 1) : null;
+  const previous = currentPage > 1 ? buildPageUrl(currentPage - 1) : null;
 
   return {
     count,
-    hasMore: page > fullPages + 1,
+    next,
+    previous,
     results: pageCommunities,
   };
 };

--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -36,25 +36,93 @@ const getFakePackageListing = (
 // here that's done for community listing, but getting all the filters
 // to work properly might not be worth the effort.
 export const getFakePackageListings = async (
-  type: PackageListingType
-  // ordering = "last-updated",
-  // page = 1,
-  // q = "",
-  // includedCategories = [],
-  // excludedCategories = [],
-  // section = "",
-  // nsfw = false,
-  // deprecated = false
-) => ({
-  count: 200,
-  hasMore: true,
-  results: range(20).map(() =>
-    getFakePackageListing(
-      type.communityId,
-      type.kind === "namespace" ? type.namespaceId : faker.word.sample()
-    )
-  ),
-});
+  type: PackageListingType,
+  ordering = "last-updated",
+  page = 1,
+  q = "",
+  includedCategories: string[] = [],
+  excludedCategories: string[] = [],
+  section = "",
+  nsfw = false,
+  deprecated = false
+) => {
+  const pageSize = 20;
+  const count = 200;
+  const normalizedPage = Number.isFinite(page)
+    ? Math.max(1, Math.trunc(page))
+    : 1;
+  const currentPage = normalizedPage;
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, count);
+  const pageLength = Math.max(endIndex - startIndex, 0);
+
+  const collectionPath = (() => {
+    switch (type.kind) {
+      case "community":
+        return `api/cyberstorm/listing/${type.communityId.toLowerCase()}/`;
+      case "namespace":
+        return `api/cyberstorm/listing/${type.communityId.toLowerCase()}/${type.namespaceId.toLowerCase()}/`;
+      case "package-dependants":
+        return `api/cyberstorm/listing/${type.communityId.toLowerCase()}/${type.namespaceId.toLowerCase()}/${type.packageName.toLowerCase()}/dependants/`;
+      default:
+        return "api/cyberstorm/listing/";
+    }
+  })();
+
+  const buildQueryString = (targetPage: number) => {
+    const params = new URLSearchParams();
+    params.set("page", String(targetPage));
+    if (ordering) {
+      params.set("ordering", ordering);
+    }
+    if (q) {
+      params.set("q", q);
+    }
+    includedCategories?.forEach((value) => {
+      params.append("included_categories", value);
+    });
+    excludedCategories?.forEach((value) => {
+      params.append("excluded_categories", value);
+    });
+    if (section) {
+      params.set("section", section);
+    }
+    if (nsfw) {
+      params.set("nsfw", "true");
+    }
+    if (deprecated) {
+      params.set("deprecated", "true");
+    }
+    return params.toString();
+  };
+
+  const buildPageUrl = (targetPage: number) =>
+    `https://thunderstore.io/${collectionPath}?${buildQueryString(targetPage)}`;
+
+  const hasNext = endIndex < count;
+  const next = hasNext ? buildPageUrl(currentPage + 1) : null;
+  const previous = currentPage > 1 ? buildPageUrl(currentPage - 1) : null;
+
+  const results = range(pageLength).map((index) => {
+    const namespaceId =
+      type.kind === "namespace" || type.kind === "package-dependants"
+        ? type.namespaceId
+        : `${type.communityId}-namespace-${currentPage}-${index}`;
+    const packageName =
+      type.kind === "package-dependants"
+        ? `${type.packageName.toLowerCase()}-dependant-${currentPage}-${index}`
+        : `${namespaceId}-package-${currentPage}-${index}`;
+
+    return getFakePackageListing(type.communityId, namespaceId, packageName);
+  });
+
+  return {
+    count,
+    next,
+    previous,
+    results,
+  };
+};
 
 const getFakeDependencies = async (
   community: string,
@@ -274,11 +342,14 @@ export const getFakePackageVersionDependencies = async (
   page?: number
 ) => {
   setSeed(`${namespace}-${name}-${version}`);
-  page = page ?? 1;
+  const normalizedPage =
+    typeof page === "number" && Number.isFinite(page)
+      ? Math.max(1, Math.trunc(page))
+      : 1;
 
   // Split the fake data into pages of 10 items each.
 
-  const start = (page - 1) * 10;
+  const start = (normalizedPage - 1) * 10;
   const end = start + 10;
   const items = fakePackageVersionDependencies.slice(start, end);
 
@@ -287,13 +358,13 @@ export const getFakePackageVersionDependencies = async (
     next:
       end < fakePackageVersionDependencies.length
         ? `https://thunderstore.io/api/cyberstorm/package/${namespace}/${name}/v/${version}/dependencies/?page=${
-            page + 1
+            normalizedPage + 1
           }`
         : null,
     previous:
-      page > 1
+      normalizedPage > 1
         ? `https://thunderstore.io/api/cyberstorm/package/${namespace}/${name}/v/${version}/dependencies/?page=${
-            page - 1
+            normalizedPage - 1
           }`
         : null,
     results: items,

--- a/packages/dapper-ts/src/methods/communities.ts
+++ b/packages/dapper-ts/src/methods/communities.ts
@@ -6,7 +6,7 @@ import {
 
 import { type DapperTsInterface } from "../index";
 
-export async function getCommunities(
+export function getCommunities(
   this: DapperTsInterface,
   page?: number,
   ordering?: string,
@@ -22,7 +22,7 @@ export async function getCommunities(
   ) {
     supportedOrdering = ordering as CommunityListOrderingEnum;
   }
-  const data = await fetchCommunityList({
+  return fetchCommunityList({
     config: this.config,
     queryParams: [
       { key: "page", value: page, impotent: 1 },
@@ -36,24 +36,13 @@ export async function getCommunities(
     params: {},
     data: {},
   });
-
-  return {
-    count: data.count,
-    hasMore: Boolean(data.next),
-    results: data.results,
-  };
 }
 
-export async function getCommunity(
-  this: DapperTsInterface,
-  communityId: string
-) {
-  const data = await fetchCommunity({
+export function getCommunity(this: DapperTsInterface, communityId: string) {
+  return fetchCommunity({
     config: this.config,
     params: { community_id: communityId },
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/communityFilters.ts
+++ b/packages/dapper-ts/src/methods/communityFilters.ts
@@ -6,12 +6,10 @@ export async function getCommunityFilters(
   this: DapperTsInterface,
   communityId: string
 ) {
-  const data = await fetchCommunityFilters({
+  return fetchCommunityFilters({
     config: this.config,
     params: { community_id: communityId },
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/dynamicHTML.ts
+++ b/packages/dapper-ts/src/methods/dynamicHTML.ts
@@ -6,12 +6,10 @@ export async function getDynamicHTML(
   this: DapperTsInterface,
   placement: string
 ) {
-  const data = await fetchDynamicHTML({
+  return fetchDynamicHTML({
     config: this.config,
     params: { placement },
     data: {},
     queryParams: {},
   });
-
-  return data.dynamic_htmls;
 }

--- a/packages/dapper-ts/src/methods/package.ts
+++ b/packages/dapper-ts/src/methods/package.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import {
-  ApiError,
   type PackageVersionDependenciesRequestQueryParams,
   fetchPackageChangelog,
   fetchPackagePermissions,
@@ -23,7 +22,7 @@ export async function getPackageChangelog(
   packageName: string,
   versionNumber?: string
 ) {
-  const data = await fetchPackageChangelog({
+  return fetchPackageChangelog({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -33,8 +32,6 @@ export async function getPackageChangelog(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
 export async function getPackageReadme(
@@ -43,7 +40,7 @@ export async function getPackageReadme(
   packageName: string,
   versionNumber?: string
 ) {
-  const data = await fetchPackageReadme({
+  return fetchPackageReadme({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -53,8 +50,6 @@ export async function getPackageReadme(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
 export async function getPackageSource(
@@ -63,7 +58,7 @@ export async function getPackageSource(
   packageName: string,
   versionNumber?: string
 ) {
-  const data = await fetchPackageSource({
+  return fetchPackageSource({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -73,8 +68,6 @@ export async function getPackageSource(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
 export const versionsSchema = z
@@ -92,7 +85,7 @@ export async function getPackageVersions(
   namespaceId: string,
   packageName: string
 ) {
-  const data = await fetchPackageVersions({
+  return fetchPackageVersions({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -101,8 +94,6 @@ export async function getPackageVersions(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 export async function getPackageVersionDependencies(
   this: DapperTsInterface,
@@ -119,7 +110,7 @@ export async function getPackageVersionDependencies(
     },
   ];
 
-  const data = await fetchPackageVersionDependencies({
+  return fetchPackageVersionDependencies({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -129,8 +120,6 @@ export async function getPackageVersionDependencies(
     data: {},
     queryParams: options,
   });
-
-  return data;
 }
 
 export async function getPackageWiki(
@@ -138,7 +127,7 @@ export async function getPackageWiki(
   namespaceId: string,
   packageName: string
 ) {
-  const data = await fetchPackageWiki({
+  return fetchPackageWiki({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -147,12 +136,10 @@ export async function getPackageWiki(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
 export async function getPackageWikiPage(this: DapperTsInterface, id: string) {
-  const data = await fetchPackageWikiPage({
+  return fetchPackageWikiPage({
     config: this.config,
     params: {
       id,
@@ -160,8 +147,6 @@ export async function getPackageWikiPage(this: DapperTsInterface, id: string) {
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
 export async function postPackageSubmissionMetadata(
@@ -173,7 +158,7 @@ export async function postPackageSubmissionMetadata(
   categories?: string[],
   community_categories?: { [key: string]: string[] }
 ) {
-  const data = await postPackageSubmission({
+  return postPackageSubmission({
     config: this.config,
     params: {},
     data: {
@@ -186,15 +171,13 @@ export async function postPackageSubmissionMetadata(
     },
     queryParams: {},
   });
-
-  return data;
 }
 
 export async function getPackageSubmissionStatus(
   this: DapperTsInterface,
   submissionId: string
 ) {
-  const response = await fetchPackageSubmissionStatus({
+  return fetchPackageSubmissionStatus({
     config: this.config,
     params: {
       submission_id: submissionId,
@@ -202,8 +185,6 @@ export async function getPackageSubmissionStatus(
     data: {},
     queryParams: {},
   });
-
-  return response;
 }
 
 export async function getPackagePermissions(
@@ -212,24 +193,14 @@ export async function getPackagePermissions(
   namespaceId: string,
   packageName: string
 ) {
-  try {
-    const response = await fetchPackagePermissions({
-      config: this.config,
-      params: {
-        community_id: communityId,
-        namespace_id: namespaceId,
-        package_name: packageName,
-      },
-      data: {},
-      queryParams: {},
-    });
-    return response;
-  } catch (error) {
-    // In case of user not being logged in or stale session
-    if (error instanceof ApiError && error.response.status === 401) {
-      return undefined;
-    } else {
-      throw error;
-    }
-  }
+  return fetchPackagePermissions({
+    config: this.config,
+    params: {
+      community_id: communityId,
+      namespace_id: namespaceId,
+      package_name: packageName,
+    },
+    data: {},
+    queryParams: {},
+  });
 }

--- a/packages/dapper-ts/src/methods/packageListings.ts
+++ b/packages/dapper-ts/src/methods/packageListings.ts
@@ -10,7 +10,7 @@ import {
 
 import { type DapperTsInterface } from "../index";
 
-export async function getPackageListings(
+export function getPackageListings(
   this: DapperTsInterface,
   type: PackageListingType,
   ordering?: string,
@@ -75,7 +75,7 @@ export async function getPackageListings(
   let data;
 
   if (type.kind === "community") {
-    data = await fetchCommunityPackageListings({
+    data = fetchCommunityPackageListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -84,7 +84,7 @@ export async function getPackageListings(
       queryParams: options,
     });
   } else if (type.kind === "namespace") {
-    data = await fetchNamespacePackageListings({
+    data = fetchNamespacePackageListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -94,7 +94,7 @@ export async function getPackageListings(
       queryParams: options,
     });
   } else if (type.kind === "package-dependants") {
-    data = await fetchPackageDependantsListings({
+    data = fetchPackageDependantsListings({
       config: this.config,
       params: {
         community_id: type.communityId,
@@ -110,11 +110,7 @@ export async function getPackageListings(
     );
   }
 
-  return {
-    count: data.count,
-    hasMore: Boolean(data.next),
-    results: data.results,
-  };
+  return data;
 }
 
 export async function getPackageListingDetails(
@@ -123,7 +119,7 @@ export async function getPackageListingDetails(
   namespaceId: string,
   packageName: string
 ) {
-  const data = await fetchPackageListingDetails({
+  return fetchPackageListingDetails({
     config: this.config,
     params: {
       community_id: communityId,
@@ -133,6 +129,4 @@ export async function getPackageListingDetails(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/packageVersion.ts
+++ b/packages/dapper-ts/src/methods/packageVersion.ts
@@ -8,7 +8,7 @@ export async function getPackageVersionDetails(
   packageName: string,
   packageVersion: string
 ) {
-  const data = await fetchPackageVersionDetails({
+  return fetchPackageVersionDetails({
     config: this.config,
     params: {
       namespace_id: namespaceId,
@@ -18,6 +18,4 @@ export async function getPackageVersionDetails(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/ratedPackages.ts
+++ b/packages/dapper-ts/src/methods/ratedPackages.ts
@@ -1,14 +1,17 @@
-import { fetchRatedPackages } from "@thunderstore/thunderstore-api";
+import {
+  RatedPackagesResponseData,
+  fetchRatedPackages,
+} from "@thunderstore/thunderstore-api";
 
 import { type DapperTsInterface } from "../index";
 
-export async function getRatedPackages(this: DapperTsInterface) {
-  const data = await fetchRatedPackages({
+export function getRatedPackages(
+  this: DapperTsInterface
+): Promise<RatedPackagesResponseData> {
+  return fetchRatedPackages({
     config: this.config,
     params: {},
     data: {},
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper-ts/src/methods/ratedPackages.ts
+++ b/packages/dapper-ts/src/methods/ratedPackages.ts
@@ -1,5 +1,5 @@
 import {
-  RatedPackagesResponseData,
+  type RatedPackagesResponseData,
   fetchRatedPackages,
 } from "@thunderstore/thunderstore-api";
 

--- a/packages/dapper-ts/src/methods/team.ts
+++ b/packages/dapper-ts/src/methods/team.ts
@@ -7,11 +7,8 @@ import {
 
 import { type DapperTsInterface } from "../index";
 
-export async function getTeamDetails(
-  this: DapperTsInterface,
-  teamName: string
-) {
-  const data = await fetchTeamDetails({
+export function getTeamDetails(this: DapperTsInterface, teamName: string) {
+  return fetchTeamDetails({
     config: this.config,
     params: {
       team_name: teamName,
@@ -19,15 +16,10 @@ export async function getTeamDetails(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
-export async function getTeamMembers(
-  this: DapperTsInterface,
-  teamName: string
-) {
-  const data = await fetchTeamMembers({
+export function getTeamMembers(this: DapperTsInterface, teamName: string) {
+  return fetchTeamMembers({
     config: this.config,
     params: {
       team_name: teamName,
@@ -35,15 +27,13 @@ export async function getTeamMembers(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
-export async function getTeamServiceAccounts(
+export function getTeamServiceAccounts(
   this: DapperTsInterface,
   teamName: string
 ) {
-  const data = await fetchTeamServiceAccounts({
+  return fetchTeamServiceAccounts({
     config: this.config,
     params: {
       team_name: teamName,
@@ -51,17 +41,13 @@ export async function getTeamServiceAccounts(
     data: {},
     queryParams: {},
   });
-
-  return data;
 }
 
-export async function postTeamCreate(this: DapperTsInterface, name: string) {
-  const data = await teamCreate({
+export function postTeamCreate(this: DapperTsInterface, name: string) {
+  return teamCreate({
     config: this.config,
     params: {},
     data: { name },
     queryParams: {},
   });
-
-  return data;
 }

--- a/packages/dapper/src/types/shared.ts
+++ b/packages/dapper/src/types/shared.ts
@@ -19,6 +19,7 @@ export interface PackageCategory {
 
 export type PaginatedList<T> = {
   count: number;
-  hasMore: boolean;
+  next: string | null;
+  previous: string | null;
   results: T[];
 };


### PR DESCRIPTION
Refactor API methods to remove unnecessary async/await and improve return handling

Note: Some of the functions return shapes differ as of this commit, so the places that use these functions should change in future commits

Update dapper-fake functions to match the changed dapper methods return shapes (pagination)