### PR TITLE
Use ssrLoader HoF with all server side loader() funcs

### DIFF
--- a/apps/cyberstorm-remix/app/c/community.tsx
+++ b/apps/cyberstorm-remix/app/c/community.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 import {
@@ -29,39 +30,41 @@ import { type OutletContextShape } from "../root";
 import type { Route } from "./+types/community";
 import "./Community.css";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const community = await dapper.getCommunity(params.communityId);
+      const url = new URL(request.url);
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        community: community,
+        seo: createSeo({
+          descriptors: [
+            { title: `The ${community.name} Mod Database` },
+            { name: "description", content: `Mods for ${community.name}` },
+            { property: "og:image", content: community.cover_image_url ?? "" },
+            {
+              property: "og:url",
+              content: `${url.origin}${url.pathname}`,
+            },
+            {
+              property: "og:description",
+              content: `Thunderstore is a mod database and API for downloading ${community.name} mods`,
+            },
+            { property: "og:image:width", content: "360" },
+            { property: "og:image:height", content: "480" },
+          ],
+        }),
       };
-    });
-    const community = await dapper.getCommunity(params.communityId);
-    const url = new URL(request.url);
-    return {
-      community: community,
-      seo: createSeo({
-        descriptors: [
-          { title: `The ${community.name} Mod Database` },
-          { name: "description", content: `Mods for ${community.name}` },
-          { property: "og:image", content: community.cover_image_url ?? "" },
-          {
-            property: "og:url",
-            content: `${url.origin}${url.pathname}`,
-          },
-          {
-            property: "og:description",
-            content: `Thunderstore is a mod database and API for downloading ${community.name} mods`,
-          },
-          { property: "og:image:width", content: "360" },
-          { property: "og:image:height", content: "480" },
-        ],
-      }),
-    };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
 import { PackageOrderOptions } from "~/commonComponents/PackageSearch/components/PackageOrder";
@@ -10,56 +11,58 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 
 import type { Route } from "./+types/PackageSearch";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId) {
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
-      };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const community = await dapper.getCommunity(params.communityId);
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const community = await dapper.getCommunity(params.communityId);
 
-    return {
-      filters: filters,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "community",
-          communityId: params.communityId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        section ? (section === "all" ? "" : section) : "",
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
-          { title: `Packages for ${community.name} | Thunderstore` },
+      return {
+        filters: filters,
+        listings: await dapper.getPackageListings(
           {
-            name: "description",
-            content: `Browse packages for ${community.name}`,
+            kind: "community",
+            communityId: params.communityId,
           },
-        ],
-      }),
-    };
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          section ? (section === "all" ? "" : section) : "",
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            { title: `Packages for ${community.name} | Thunderstore` },
+            {
+              name: "description",
+              content: `Browse packages for ${community.name}`,
+            },
+          ],
+        }),
+      };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense, memo, useEffect, useRef, useState } from "react";
 import {
   Await,
@@ -56,7 +57,7 @@ const selectOptions = [
   },
 ];
 
-export async function loader({ request }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   const searchParams = url.searchParams;
   const order = searchParams.get("order") ?? SortOptions.Popular;
@@ -95,7 +96,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/healthz.tsx
+++ b/apps/cyberstorm-remix/app/healthz.tsx
@@ -1,8 +1,10 @@
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
+
 import type { Route } from "./+types/healthz";
 
-export async function loader({ request }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   if (url.pathname === "/healthz") {
     return Response.json({ message: "ok" }, { status: 200 });
   }
-}
+});

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
@@ -18,92 +19,94 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Dependants";
 import "./Dependants.css";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId && params.packageId && params.namespaceId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId && params.packageId && params.namespaceId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const listing = await dapper.getPackageListingDetails(
+        params.communityId,
+        params.namespaceId,
+        params.packageId
+      );
+
+      if (!listing) {
+        throw new Response("Package not found", { status: 404 });
+      }
+
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        community: dapper.getCommunity(params.communityId),
+        listing,
+        filters: filters,
+        listings: await dapper.getPackageListings(
+          {
+            kind: "package-dependants",
+            communityId: params.communityId,
+            namespaceId: params.namespaceId,
+            packageName: params.packageId,
+          },
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          section ? (section === "all" ? "" : section) : "",
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `Dependants of ${formatToDisplayName(
+                listing.name
+              )} | Thunderstore`,
+            },
+            {
+              name: "description",
+              content: `Mods that depend on ${listing.name}`,
+            },
+            { property: "og:type", content: "website" },
+            { property: "og:url", content: request.url },
+            {
+              property: "og:title",
+              content: `Dependants of ${formatToDisplayName(
+                listing.name
+              )} | Thunderstore`,
+            },
+            {
+              property: "og:description",
+              content: `Mods that depend on ${listing.name}`,
+            },
+            ...(listing.icon_url
+              ? [
+                  { property: "og:image", content: listing.icon_url },
+                  { property: "og:image:width", content: "256" },
+                  { property: "og:image:height", content: "256" },
+                ]
+              : []),
+            { property: "og:site_name", content: "Thunderstore" },
+          ],
+        }),
       };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const listing = await dapper.getPackageListingDetails(
-      params.communityId,
-      params.namespaceId,
-      params.packageId
-    );
-
-    if (!listing) {
-      throw new Response("Package not found", { status: 404 });
     }
-
-    return {
-      community: dapper.getCommunity(params.communityId),
-      listing,
-      filters: filters,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "package-dependants",
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-          packageName: params.packageId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        section ? (section === "all" ? "" : section) : "",
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `Dependants of ${formatToDisplayName(
-              listing.name
-            )} | Thunderstore`,
-          },
-          {
-            name: "description",
-            content: `Mods that depend on ${listing.name}`,
-          },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: request.url },
-          {
-            property: "og:title",
-            content: `Dependants of ${formatToDisplayName(
-              listing.name
-            )} | Thunderstore`,
-          },
-          {
-            property: "og:description",
-            content: `Mods that depend on ${listing.name}`,
-          },
-          ...(listing.icon_url
-            ? [
-                { property: "og:image", content: listing.icon_url },
-                { property: "og:image:width", content: "256" },
-                { property: "og:image:height", content: "256" },
-              ]
-            : []),
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
-    };
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/p/packageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/packageEdit.tsx
@@ -4,6 +4,7 @@ import { getPrivateListing } from "app/p/listingUtils";
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useReducer } from "react";
 import { useLoaderData, useOutletContext, useRevalidator } from "react-router";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
@@ -32,7 +33,7 @@ import "./packageEdit.css";
 
 const package404 = new Response("Package not found", { status: 404 });
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   return {
     listing: undefined,
     permissions: undefined,
@@ -44,7 +45,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -13,6 +13,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import {
   type ReactElement,
   Suspense,
@@ -66,70 +67,72 @@ type PackageListingOutletContext = OutletContextShape & {
   packageDownloadUrl?: string;
 };
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId } = params;
 
-  if (!communityId || !namespaceId || !packageId) {
-    throw new Response("Package not found", { status: 404 });
+    if (!communityId || !namespaceId || !packageId) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
+
+    const listing = await getPublicListing(dapper, {
+      communityId,
+      namespaceId,
+      packageId,
+    });
+
+    if (!listing) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const community = await dapper.getCommunity(communityId);
+    const url = new URL(request.url);
+
+    return {
+      community,
+      communityFilters: await dapper.getCommunityFilters(communityId),
+      listing: listing,
+      listingStatus: undefined,
+      team: await dapper.getTeamDetails(namespaceId),
+      permissions: undefined,
+      community_identifier: communityId,
+      namespace_id: namespaceId,
+      package_id: packageId,
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${formatToDisplayName(listing.name)} | Thunderstore - The ${
+              community.name
+            } Mod Database`,
+          },
+          { name: "description", content: listing.description },
+          { property: "og:type", content: "website" },
+          { property: "og:url", content: url.href },
+          {
+            property: "og:title",
+            content: `${formatToDisplayName(listing.name)} by ${
+              listing.namespace
+            }`,
+          },
+          { property: "og:description", content: listing.description },
+          ...(listing.icon_url
+            ? [
+                { property: "og:image", content: listing.icon_url },
+                { property: "og:image:width", content: "256" },
+                { property: "og:image:height", content: "256" },
+              ]
+            : []),
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
+    };
   }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  const listing = await getPublicListing(dapper, {
-    communityId,
-    namespaceId,
-    packageId,
-  });
-
-  if (!listing) {
-    throw new Response("Package not found", { status: 404 });
-  }
-
-  const community = await dapper.getCommunity(communityId);
-  const url = new URL(request.url);
-
-  return {
-    community,
-    communityFilters: await dapper.getCommunityFilters(communityId),
-    listing: listing,
-    listingStatus: undefined,
-    team: await dapper.getTeamDetails(namespaceId),
-    permissions: undefined,
-    community_identifier: communityId,
-    namespace_id: namespaceId,
-    package_id: packageId,
-    seo: createSeo({
-      descriptors: [
-        {
-          title: `${formatToDisplayName(listing.name)} | Thunderstore - The ${
-            community.name
-          } Mod Database`,
-        },
-        { name: "description", content: listing.description },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: url.href },
-        {
-          property: "og:title",
-          content: `${formatToDisplayName(listing.name)} by ${
-            listing.namespace
-          }`,
-        },
-        { property: "og:description", content: listing.description },
-        ...(listing.icon_url
-          ? [
-              { property: "og:image", content: listing.icon_url },
-              { property: "og:image:width", content: "256" },
-              { property: "og:image:height", content: "256" },
-            ]
-          : []),
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 import {
@@ -37,66 +38,68 @@ import { PackageActions } from "./components/PackageListing/PackageActions";
 import { getPrivateListing, getPublicListing } from "./listingUtils";
 import "./packageListing.css";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId, packageVersion } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId, packageVersion } = params;
 
-  if (!communityId || !namespaceId || !packageId || !packageVersion) {
-    throw new Response("Package not found", { status: 404 });
+    if (!communityId || !namespaceId || !packageId || !packageVersion) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
+
+    const listing = await getPublicListing(dapper, {
+      communityId,
+      namespaceId,
+      packageId,
+      packageVersion,
+    });
+
+    if (!listing) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const community = await dapper.getCommunity(communityId);
+    const url = new URL(request.url);
+
+    return {
+      community,
+      listing,
+      packageVersion,
+      team: await dapper.getTeamDetails(namespaceId),
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${formatToDisplayName(listing.name)} v${packageVersion} | ${
+              community.name
+            } Mod Database`,
+          },
+          { name: "description", content: listing.description },
+          { property: "og:type", content: "website" },
+          { property: "og:url", content: url.href },
+          {
+            property: "og:title",
+            content: `${formatToDisplayName(
+              listing.name
+            )} v${packageVersion} by ${listing.namespace}`,
+          },
+          { property: "og:description", content: listing.description },
+          ...(listing.icon_url
+            ? [
+                { property: "og:image", content: listing.icon_url },
+                { property: "og:image:width", content: "256" },
+                { property: "og:image:height", content: "256" },
+              ]
+            : []),
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
+    };
   }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  const listing = await getPublicListing(dapper, {
-    communityId,
-    namespaceId,
-    packageId,
-    packageVersion,
-  });
-
-  if (!listing) {
-    throw new Response("Package not found", { status: 404 });
-  }
-
-  const community = await dapper.getCommunity(communityId);
-  const url = new URL(request.url);
-
-  return {
-    community,
-    listing,
-    packageVersion,
-    team: await dapper.getTeamDetails(namespaceId),
-    seo: createSeo({
-      descriptors: [
-        {
-          title: `${formatToDisplayName(listing.name)} v${packageVersion} | ${
-            community.name
-          } Mod Database`,
-        },
-        { name: "description", content: listing.description },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: url.href },
-        {
-          property: "og:title",
-          content: `${formatToDisplayName(
-            listing.name
-          )} v${packageVersion} by ${listing.namespace}`,
-        },
-        { property: "og:description", content: listing.description },
-        ...(listing.icon_url
-          ? [
-              { property: "og:image", content: listing.icon_url },
-              { property: "og:image:width", content: "256" },
-              { property: "og:image:height", content: "256" },
-            ]
-          : []),
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
+++ b/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { isPromise } from "cyberstorm/utils/typeChecks";
 import {
   type ReactElement,
@@ -49,51 +50,53 @@ import { PackageActions } from "./components/PackageListing/PackageActions";
 // import type { Route } from "./+types/packageVersionWithoutCommunity";
 import "./packageListing.css";
 
-export async function loader({ params, request }: LoaderFunctionArgs) {
-  if (params.namespaceId && params.packageId && params.packageVersion) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: LoaderFunctionArgs) => {
+    if (params.namespaceId && params.packageId && params.packageVersion) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+
+      const version = await dapper.getPackageVersionDetails(
+        params.namespaceId,
+        params.packageId,
+        params.packageVersion
+      );
+      const team = await dapper.getTeamDetails(params.namespaceId);
+      const url = new URL(request.url);
+
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        version: version,
+        team: team,
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `${formatToDisplayName(version.full_version_name)} | ${
+                team.name
+              }`,
+            },
+            { name: "description", content: version.description },
+            { property: "og:type", content: "website" },
+            { property: "og:url", content: url.href },
+            {
+              property: "og:title",
+              content: `${formatToDisplayName(version.full_version_name)} | ${
+                team.name
+              }`,
+            },
+            { property: "og:description", content: version.description },
+            { property: "og:image", content: version.icon_url },
+            { property: "og:site_name", content: "Thunderstore" },
+          ],
+        }),
       };
-    });
-
-    const version = await dapper.getPackageVersionDetails(
-      params.namespaceId,
-      params.packageId,
-      params.packageVersion
-    );
-    const team = await dapper.getTeamDetails(params.namespaceId);
-    const url = new URL(request.url);
-
-    return {
-      version: version,
-      team: team,
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${formatToDisplayName(version.full_version_name)} | ${
-              team.name
-            }`,
-          },
-          { name: "description", content: version.description },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: url.href },
-          {
-            property: "og:title",
-            content: `${formatToDisplayName(version.full_version_name)} | ${
-              team.name
-            }`,
-          },
-          { property: "og:description", content: version.description },
-          { property: "og:image", content: version.icon_url },
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
-    };
+    }
+    throw new Response("Package not found", { status: 404 });
   }
-  throw new Response("Package not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData } from "react-router";
 
@@ -26,7 +27,7 @@ async function fetchChangelogSafe(
   }
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -51,7 +52,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -11,7 +12,7 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 import type { Route } from "./+types/PackageVersionReadme";
 import "./Readme.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const dapper = new DapperTs(() => {
       return {
@@ -46,7 +47,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       descriptors: [{ title: "Readme Not Found | Thunderstore" }],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, type LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
@@ -11,7 +12,7 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 // import type { Route } from "./+types/PackageVersionWithoutCommunityReadme";
 import "./Readme.css";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export const loader = ssrLoader(async ({ params }: LoaderFunctionArgs) => {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const dapper = new DapperTs(() => {
       return {
@@ -46,7 +47,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       descriptors: [{ title: "Readme Not Found | Thunderstore" }],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -27,7 +28,7 @@ async function fetchReadmeSafe(
   }
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -53,7 +54,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -3,6 +3,7 @@ import { getPrivateListing, getPublicListing } from "app/p/listingUtils";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData } from "react-router";
 
@@ -21,58 +22,60 @@ const getPageFromUrl = (url: string): number | undefined => {
   return maybePage ? Number(maybePage) : undefined;
 };
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId, packageVersion } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId, packageVersion } = params;
 
-  // Either communityId or packageVersion is required depending on route.
-  if (!namespaceId || !packageId || (!communityId && !packageVersion)) {
-    throw Dependency404;
-  }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  let version: string;
-
-  if (packageVersion) {
-    version = packageVersion;
-  } else if (communityId) {
-    const listingArgs = { communityId, namespaceId, packageId };
-    const listing = await getPublicListing(dapper, listingArgs);
-
-    // Listing that's not available on unauthenticated SSR request
-    // might be available for authenticated user on client. Return
-    // undefined rather than throw error to allow refetch on client.
-    if (!listing) {
-      return { dependencies: undefined, seo: createSeo({ descriptors: [] }) };
+    // Either communityId or packageVersion is required depending on route.
+    if (!namespaceId || !packageId || (!communityId && !packageVersion)) {
+      throw Dependency404;
     }
 
-    version = listing.latest_version_number;
-  } else {
-    throw Dependency404; // Can't happen, satisfies TypeScript
-  }
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
 
-  return {
-    communityId: communityId,
-    dependencies: await dapper.getPackageVersionDependencies(
-      namespaceId,
-      packageId,
-      version,
-      getPageFromUrl(request.url)
-    ),
-    seo: createSeo({
-      descriptors: [
-        { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
-        {
-          name: "description",
-          content: `Dependencies for ${namespaceId}-${packageId}`,
-        },
-      ],
-    }),
-  };
-}
+    let version: string;
+
+    if (packageVersion) {
+      version = packageVersion;
+    } else if (communityId) {
+      const listingArgs = { communityId, namespaceId, packageId };
+      const listing = await getPublicListing(dapper, listingArgs);
+
+      // Listing that's not available on unauthenticated SSR request
+      // might be available for authenticated user on client. Return
+      // undefined rather than throw error to allow refetch on client.
+      if (!listing) {
+        return { dependencies: undefined, seo: createSeo({ descriptors: [] }) };
+      }
+
+      version = listing.latest_version_number;
+    } else {
+      throw Dependency404; // Can't happen, satisfies TypeScript
+    }
+
+    return {
+      communityId: communityId,
+      dependencies: await dapper.getPackageVersionDependencies(
+        namespaceId,
+        packageId,
+        version,
+        getPageFromUrl(request.url)
+      ),
+      seo: createSeo({
+        descriptors: [
+          { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
+          {
+            name: "description",
+            content: `Dependencies for ${namespaceId}-${packageId}`,
+          },
+        ],
+      }),
+    };
+  }
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { type SeoReturn, createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useOutletContext } from "react-router";
 import { useLoaderData } from "react-router";
@@ -37,7 +38,7 @@ type ResultType = {
   seo?: SeoReturn;
 };
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -95,7 +96,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     source: undefined,
     seo: createSeo({ descriptors: [{ title: "Source Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -20,7 +21,7 @@ import { columns } from "./Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -55,7 +56,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     versions: [],
     seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, type LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
@@ -19,7 +20,7 @@ import { columns } from "./Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export const loader = ssrLoader(async ({ params }: LoaderFunctionArgs) => {
   if (params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -53,7 +54,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     versions: [],
     seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -20,7 +21,7 @@ import type { Route } from "./+types/Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -55,7 +56,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     versions: [],
     seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import {
   Await,
@@ -22,7 +23,7 @@ import { isApiError } from "@thunderstore/thunderstore-api";
 import type { Route } from "./+types/Wiki";
 import "./Wiki.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -68,7 +69,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useState } from "react";
 import { useLoaderData, useRouteLoaderData } from "react-router";
 
@@ -25,7 +26,7 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -102,7 +103,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     return result;
   }
   throw new Error("Namespace ID or Package ID is missing");
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
@@ -1,5 +1,6 @@
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useReducer, useState } from "react";
 import { useNavigate, useOutletContext, useRevalidator } from "react-router";
 import { useLoaderData } from "react-router";
@@ -22,7 +23,7 @@ import {
 import type { Route } from "./+types/WikiNewPage";
 import "./Wiki.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     return {
       communityId: params.communityId,
@@ -35,7 +36,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useState } from "react";
 import { useLoaderData, useRouteLoaderData } from "react-router";
 
@@ -25,7 +26,7 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (
     params.communityId &&
     params.namespaceId &&
@@ -112,7 +113,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useReducer, useState } from "react";
 import { useNavigate, useOutletContext, useRevalidator } from "react-router";
 import { useLoaderData } from "react-router";
@@ -31,7 +32,7 @@ import { ApiAction } from "@thunderstore/ts-api-react-actions";
 import type { Route } from "./+types/WikiPageEdit";
 import "./Wiki.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (
     params.communityId &&
     params.namespaceId &&
@@ -74,7 +75,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -1,6 +1,7 @@
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
@@ -12,73 +13,75 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Team";
 import "./Team.css";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId && params.namespaceId) {
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
-      };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const community = await dapper.getCommunity(params.communityId);
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const community = await dapper.getCommunity(params.communityId);
 
-    return {
-      teamId: params.namespaceId,
-      filters: filters,
-      // Community is required for the breadcrumbs in the root layout
-      community: community,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "namespace",
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        section ? (section === "all" ? "" : section) : "",
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
+      return {
+        teamId: params.namespaceId,
+        filters: filters,
+        // Community is required for the breadcrumbs in the root layout
+        community: community,
+        listings: await dapper.getPackageListings(
           {
-            title: `Mods uploaded by ${params.namespaceId} | Thunderstore - The ${community.name} Mod Database`,
+            kind: "namespace",
+            communityId: params.communityId,
+            namespaceId: params.namespaceId,
           },
-          {
-            name: "description",
-            content: `Browse mods uploaded by ${params.namespaceId}`,
-          },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: request.url },
-          {
-            property: "og:title",
-            content: `Mods by ${params.namespaceId} | Thunderstore`,
-          },
-          {
-            property: "og:description",
-            content: `Browse mods uploaded by ${params.namespaceId}`,
-          },
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
-    };
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          section ? (section === "all" ? "" : section) : "",
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `Mods uploaded by ${params.namespaceId} | Thunderstore - The ${community.name} Mod Database`,
+            },
+            {
+              name: "description",
+              content: `Browse mods uploaded by ${params.namespaceId}`,
+            },
+            { property: "og:type", content: "website" },
+            { property: "og:url", content: request.url },
+            {
+              property: "og:title",
+              content: `Mods by ${params.namespaceId} | Thunderstore`,
+            },
+            {
+              property: "og:description",
+              content: `Browse mods uploaded by ${params.namespaceId}`,
+            },
+            { property: "og:site_name", content: "Thunderstore" },
+          ],
+        }),
+      };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -13,6 +13,7 @@ import {
 import { LinkLibrary } from "cyberstorm/utils/LinkLibrary";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { type ReactNode, memo, useEffect, useRef, useState } from "react";
 import {
   Links,
@@ -88,7 +89,7 @@ export type OutletContextShape = {
   dapper: DapperTs;
 };
 
-export async function loader() {
+export const loader = ssrLoader(async () => {
   return {
     publicEnvVariables: getPublicEnvVariables([
       "VITE_SITE_URL",
@@ -118,7 +119,7 @@ export async function loader() {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
@@ -1,4 +1,5 @@
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Outlet, useLocation, useOutletContext, useParams } from "react-router";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
 import { type OutletContextShape } from "~/root";
@@ -8,30 +9,32 @@ import { NewLink, Tabs } from "@thunderstore/cyberstorm";
 import type { Route } from "./+types/teamSettings";
 import "./teamSettings.css";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const teamName = params.namespaceId ?? "";
-  const url = new URL(request.url);
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const teamName = params.namespaceId ?? "";
+    const url = new URL(request.url);
 
-  return {
-    seo: createSeo({
-      descriptors: [
-        { title: `Team ${teamName} settings | Thunderstore` },
-        { name: "description", content: `Manage ${teamName} team settings` },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: url.href },
-        {
-          property: "og:title",
-          content: `Team ${teamName} settings | Thunderstore`,
-        },
-        {
-          property: "og:description",
-          content: `Manage ${teamName} team settings`,
-        },
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-}
+    return {
+      seo: createSeo({
+        descriptors: [
+          { title: `Team ${teamName} settings | Thunderstore` },
+          { name: "description", content: `Manage ${teamName} team settings` },
+          { property: "og:type", content: "website" },
+          { property: "og:url", content: url.href },
+          {
+            property: "og:title",
+            content: `Team ${teamName} settings | Thunderstore`,
+          },
+          {
+            property: "og:description",
+            content: `Manage ${teamName} team settings`,
+          },
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
+    };
+  }
+);
 
 export default function TeamSettings() {
   const teamName = useParams().namespaceId ?? "";

--- a/apps/cyberstorm-remix/app/settings/user/Settings.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Settings.tsx
@@ -1,4 +1,5 @@
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Outlet, useLocation, useOutletContext } from "react-router";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
 
@@ -8,7 +9,7 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Settings";
 import "./Settings.css";
 
-export async function loader({ request }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   return {
     seo: createSeo({
@@ -29,7 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export default function UserSettings() {
   const context = useOutletContext<OutletContextShape>();

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useLoaderData, useOutletContext } from "react-router";
 
@@ -56,7 +57,7 @@ interface CategoryOption {
   label: string;
 }
 
-export async function loader() {
+export const loader = ssrLoader(async () => {
   const dapper = new DapperTs(() => {
     return {
       apiHost: getApiHostForSsr(),
@@ -76,7 +77,7 @@ export async function loader() {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
   const communities = await serverLoader();


### PR DESCRIPTION
Technically this provides no benefits in loaders that don't use Dapper as that's the only source expected source for ApiErrors. It was decided to use it in all loaders for consistency's sake, and to avoid situations where it ends up missing when a developer adds Dapper calls to an existing loader.