### PR TITLE
Fix TextInput clear button causing focus styles to flash

### DIFF
--- a/packages/cyberstorm/src/newComponents/TextInput/TextInput.tsx
+++ b/packages/cyberstorm/src/newComponents/TextInput/TextInput.tsx
@@ -113,6 +113,11 @@ export const TextInput = memo(function TextInput(props: TextInputProps) {
       {clearValue && fProps.value !== "" ? (
         <Actionable
           primitiveType="button"
+          type="button"
+          onPointerDown={(e) => {
+            // Prevent input from losing focus on click/touch
+            e.preventDefault();
+          }}
           onClick={() => clearValue()}
           rootClasses={classnames(
             "text-input__clear-value-button",


### PR DESCRIPTION
When the user clicks the clear button, the styles will flash to
non-focused as the clear button will be focused. Fix that.