### PR TITLE
Fix ReactMarkdown import and usage in Markdown component

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.tsx
@@ -1,4 +1,4 @@
-import { MarkdownHooks } from "react-markdown";
+import ReactMarkdown from "react-markdown";
 import gfm from "remark-gfm";
 
 import { nimbusSanitize } from "./Sanitize";
@@ -28,13 +28,9 @@ export function Markdown(props: MarkdownProps) {
   return (
     <div className="markdown-wrapper">
       <div className="markdown">
-        <MarkdownHooks
-          remarkPlugins={[gfm]}
-          rehypePlugins={[nimbusSanitize]}
-          fallback={"Loading markdown..."}
-        >
+        <ReactMarkdown remarkPlugins={[gfm]} rehypePlugins={[nimbusSanitize]}>
           {input && input !== "" ? input : placeholder ? placeholder : ""}
-        </MarkdownHooks>
+        </ReactMarkdown>
       </div>
     </div>
   );


### PR DESCRIPTION
Replaced the incorrect `MarkdownHooks` named import with the correct default `ReactMarkdown` import from `react-markdown`. We must use the synchronous component if we want SSR to display the markdown.