### PR TITLE
Improve community header layout, package search drawer breakpoint, an…

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.css
+++ b/apps/cyberstorm-remix/app/c/Community.css
@@ -3,101 +3,36 @@
     --nimbus-layout-content-max-width: 120rem;
 
     z-index: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    align-items: flex-start;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: var(--gap-md);
+    align-items: start;
     align-self: stretch;
-    padding: 1rem 3rem 2rem;
+    padding: var(--gap-md) var(--gap-7xl) var(--gap-3xl);
+  }
+
+  .community--packageListingSubpath {
+    gap: var(--gap-xl);
+  }
+
+  @media (width <= 41rem) {
+    .community {
+      padding: var(--gap-md) 0 var(--gap-3xl);
+    }
   }
 
   .community__header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    align-self: stretch;
+    display: grid;
+    grid-template-rows: auto auto;
+    align-items: start;
   }
 
-  .community__background {
-    align-self: stretch;
-    container-type: inline-size;
-
-    > img {
-      width: 100%;
-      height: auto;
-      max-height: 12rem;
-      aspect-ratio: 4 / 1;
-      border-radius: 0.5rem;
-      object-fit: cover;
-      background: var(--color-ui-surface-1);
-      opacity: 0.8;
-    }
-
-    .skeleton {
-      width: 100%;
-      max-height: 12rem;
-      aspect-ratio: 4 / 1;
-    }
-
-    @container (width < 20rem) {
-      > img {
-        border-radius: 0.25rem;
-      }
-    }
-  }
-
-  .community__background--packagePage {
-    > img {
-      max-height: 6rem;
-      aspect-ratio: 8 / 1;
-      opacity: 0.3;
-      mix-blend-mode: luminosity;
-    }
-  }
-
-  .community__content-header-wrapper {
-    z-index: 1;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    align-items: flex-end;
-    align-self: stretch;
-    justify-content: space-between;
-    height: max-content;
-    margin-top: -1rem;
-    padding-left: 1rem;
-  }
-
-  .community__content-header {
-    display: flex;
-    flex-grow: 1;
-    gap: 1.5rem;
-    align-items: flex-end;
-    align-self: stretch;
-    min-width: 75%;
-    height: max-content;
-  }
-
-  .community__content-header--hide {
-    display: none;
-  }
-
-  .community__game-icon {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    align-self: flex-start;
-    width: 7rem;
-    height: 7rem;
-    padding: var(--Space-12, 0.75rem);
-    border: 1px solid var(--Color-border-bright, rgb(70 70 149 / 0.66));
-    border-radius: var(--radius-xl, 1rem);
-    background: var(--Color-Surface-1, #070721);
+  .community__header--compact {
+    grid-template-rows: auto;
   }
 
   .community__game-icon-tinified {
     display: flex;
-    flex: 1 0 0;
     align-items: center;
     justify-content: center;
     width: 5.5rem;
@@ -109,25 +44,109 @@
     }
   }
 
+  .community__background {
+    --community-hero-max-height: 12rem;
+    --community-hero-aspect-ratio: 4 / 1;
+
+    container-type: inline-size;
+    margin-bottom: calc(-1 * var(--gap-md));
+
+    .community__background-image,
+    .skeleton {
+      width: 100%;
+      max-height: var(--community-hero-max-height);
+      aspect-ratio: var(--community-hero-aspect-ratio);
+    }
+
+    .community__background-image {
+      border-radius: var(--radius-md);
+      overflow: hidden;
+      background-color: var(--color-ui-surface-1);
+    }
+
+    .community__background-image > img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0.8;
+    }
+
+    @container (width < 20rem) {
+      .community__background-image {
+        border-radius: var(--radius-sm);
+      }
+    }
+  }
+
+  .community__background--packagePage {
+    --community-hero-max-height: 6rem;
+    --community-hero-aspect-ratio: 8 / 1;
+
+    margin-bottom: 0;
+
+    .community__background-image > img {
+      opacity: 0.3;
+      mix-blend-mode: luminosity;
+    }
+  }
+
+  .community__content-header-wrapper {
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--gap-xl);
+    align-items: end;
+    min-width: 0;
+    padding-left: var(--gap-md);
+  }
+
+  .community__content-header {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--gap-xl);
+    align-items: end;
+    min-width: 0;
+  }
+
+  .community__content-header--hide {
+    display: none;
+  }
+
+  .community__upload-button {
+    justify-self: end;
+  }
+
+  .community__game-icon {
+    display: flex;
+    gap: var(--gap-xs);
+    align-items: center;
+    align-self: flex-start;
+    width: 7rem;
+    height: 7rem;
+    padding: var(--Space-12, 0.75rem);
+    border: 1px solid var(--Color-border-bright, rgb(70 70 149 / 0.66));
+    border-radius: var(--radius-xl, 1rem);
+    background: var(--Color-Surface-1, #070721);
+  }
+
   .community__content-header-content {
     display: flex;
     flex-direction: column;
-    flex-grow: 1;
-    gap: 0.75rem;
+    gap: var(--gap-sm);
     align-items: flex-start;
     justify-content: center;
-    padding-top: 1.5rem;
+    padding-top: var(--gap-xl);
   }
 
   .community__header-info {
     display: flex;
     flex: 1 0 0;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--gap-2xs);
     align-items: flex-start;
     align-self: stretch;
     min-width: 60%;
-    max-width: 100%;
 
     > h1 {
       line-height: 80%;
@@ -138,7 +157,7 @@
   .community__header-meta {
     display: flex;
     flex: 0 1 60%;
-    gap: 1.5rem;
+    gap: var(--gap-xl);
     align-items: center;
     min-width: 60%;
     min-height: 1rem;
@@ -146,34 +165,6 @@
     > .skeleton {
       height: 1rem;
     }
-  }
-
-  .community__small-image {
-    width: 3.5rem;
-    height: 3.5rem;
-
-    --aspect-ratio: 1;
-
-    > svg {
-      width: 50%;
-    }
-  }
-
-  .community__content {
-    flex-wrap: wrap;
-  }
-
-  .community__info {
-    flex-shrink: 0;
-    min-width: 8ch;
-    overflow-wrap: anywhere;
-  }
-
-  .community__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--gap-3xl);
-    align-items: center;
   }
 
   .community__item {
@@ -190,13 +181,17 @@
     }
   }
 
-  @media (width < 41rem) {
+  @media (width < 48rem) {
     .community__header {
-      gap: 1rem;
+      gap: var(--gap-md);
+    }
+
+    .community__background {
+      margin-bottom: 0;
     }
 
     .community__content-header-wrapper {
-      margin-top: 0;
+      grid-template-columns: 1fr;
       padding-left: 0;
     }
 
@@ -209,24 +204,12 @@
     }
 
     .community__upload-button {
+      justify-self: stretch;
       width: 100%;
-    }
-  }
-
-  @media (width <= 48rem) {
-    .community__meta {
-      gap: var(--gap-2xs);
     }
 
     .community__item {
       font-size: var(--font-size-body-sm);
-    }
-  }
-
-  @media (width <= 24rem) {
-    .community__info {
-      font-size: 2rem;
-      line-height: var(--line-height-sm);
     }
   }
 }

--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -104,8 +104,18 @@ export default function Community() {
   const outletContext = useOutletContext() as OutletContextShape;
 
   return (
-    <>
-      <div className="community__header">
+    <div
+      className={classnames(
+        "community",
+        isPackageListingSubPath ? "community--packageListingSubpath" : null
+      )}
+    >
+      <div
+        className={classnames(
+          "community__header",
+          isPackageListingSubPath ? "community__header--compact" : null
+        )}
+      >
         <div
           className={classnames(
             "community__background",
@@ -118,10 +128,12 @@ export default function Community() {
             <Await resolve={community}>
               {(resolvedValue) =>
                 resolvedValue.hero_image_url ? (
-                  <img
-                    src={resolvedValue.hero_image_url}
-                    alt={resolvedValue.name}
-                  />
+                  <div className="community__background-image">
+                    <img
+                      src={resolvedValue.hero_image_url}
+                      alt={resolvedValue.name}
+                    />
+                  </div>
                 ) : null
               }
             </Await>
@@ -231,6 +243,6 @@ export default function Community() {
         </div>
       </div>
       <Outlet context={outletContext} />
-    </>
+    </div>
   );
 }

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/MobileNavigation.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/MobileNavigation.css
@@ -96,7 +96,7 @@
   }
 
   /* Mobile breakpoint */
-  @media (width <= 750px) {
+  @media (width <= 48rem) {
     .mobile-navigation {
       position: fixed;
       bottom: 0;

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.css
@@ -240,7 +240,7 @@
   }
 
   /* Mobile breakpoint */
-  @media (width <= 750px) {
+  @media (width <= 48rem) {
     .navigation-header__start {
       padding: 0 var(--space-8);
     }

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
@@ -167,35 +167,13 @@
   }
 
   @media (width <= 48rem) {
-    .package-search__tools {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
     .package-search__results {
       align-items: stretch;
       justify-content: center;
     }
 
-    .package-search__sorting {
-      width: 100%;
-    }
-
     .package-search__grid {
       grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
-    }
-  }
-
-  @media (width <= 475px) {
-    .package-search {
-      flex-direction: column;
-      gap: 0.25rem;
-    }
-
-    .package-search__tools {
-      flex-direction: column;
-      gap: 0.5rem;
-      align-items: stretch;
     }
 
     .package-search__sidebar {
@@ -214,6 +192,14 @@
       display: flex;
     }
 
+    .package-search__tools {
+      flex-direction: column;
+      gap: 0.5rem;
+      align-items: stretch;
+    }
+  }
+
+  @media (width <= 475px) {
     .package-search__results {
       align-items: stretch;
       justify-content: center;

--- a/apps/cyberstorm-remix/app/p/packageListing.css
+++ b/apps/cyberstorm-remix/app/p/packageListing.css
@@ -1,4 +1,14 @@
 @layer nimbus-layout {
+  .package-listing__package-section {
+    position: relative;
+    display: flex;
+    flex: 1 0 0;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    align-items: flex-start;
+    align-self: stretch;
+  }
+
   .package-listing__main {
     display: flex;
     gap: var(--gap-3xl);
@@ -6,15 +16,55 @@
     align-self: stretch;
   }
 
-  .package-listing__package-section {
-    position: relative;
+  .package-listing__package-content-section {
     display: flex;
     flex: 1 0 0;
     flex-direction: column;
-    gap: 8px;
+    gap: var(--gap-xl);
+    align-items: flex-start;
+    padding-top: var(--gap-md);
+    overflow-x: scroll;
+    scrollbar-width: none;
+  }
+
+  .community--packageListingSubpath .package-listing__package-content-section {
+    padding-top: 0;
+  }
+
+  .package-listing__page-header-skeleton {
+    height: 10rem;
+  }
+
+  .package-listing__nav-skeleton {
+    height: 47px;
+  }
+
+  .package-listing__content {
+    display: flex;
+    flex: 1 0 0;
+    flex-direction: column;
+    gap: var(--gap-3xl);
+    align-items: stretch;
+    align-self: stretch;
+  }
+
+  .package-listing__package-actions {
+    display: flex;
+    gap: var(--gap-xs);
     align-items: flex-start;
     align-self: stretch;
-    justify-content: flex-start;
+  }
+
+  .package-listing__narrow-actions {
+    display: none;
+    flex-direction: column;
+    gap: var(--gap-xs);
+    align-items: flex-start;
+    align-self: stretch;
+  }
+
+  .package-listing__drawer-button {
+    width: 100%;
   }
 
   .package-listing-management-tools {
@@ -29,7 +79,7 @@
   .package-listing-management-tools__island {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: var(--space-6);
     align-items: center;
     justify-content: flex-end;
     padding: var(--space-8);
@@ -38,6 +88,7 @@
     background: var(--color-surface-1);
   }
 
+  .package-listing-sidebar__categories,
   .review-information-card {
     display: flex;
     flex-direction: column;
@@ -60,16 +111,14 @@
   .review-package__block {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: var(--gap-md);
     align-items: flex-start;
   }
 
   .review-package__label {
     color: var(--color-text-primary);
-    font-weight: 700;
-    font-size: 1rem;
-    font-style: normal;
-    line-height: normal;
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-body-md);
   }
 
   .review-package__textarea {
@@ -83,34 +132,6 @@
     justify-content: space-between;
   }
 
-  .package-listing__package-content-section {
-    display: flex;
-    flex: 1 0 0;
-    flex-direction: column;
-    gap: var(--gap-xl);
-    align-items: flex-start;
-    padding-top: 1rem;
-    overflow-x: scroll;
-    scrollbar-width: none;
-  }
-
-  .package-listing__page-header-skeleton {
-    height: 10rem;
-  }
-
-  .package-listing__nav-skeleton {
-    height: 47px;
-  }
-
-  .package-listing__content {
-    display: flex;
-    flex: 1 0 0;
-    flex-direction: column;
-    gap: var(--gap-3xl);
-    align-items: stretch;
-    align-self: stretch;
-  }
-
   .package-listing-sidebar {
     position: sticky;
     top: var(--header-height);
@@ -119,27 +140,6 @@
     flex-shrink: 0;
     gap: var(--gap-md);
     align-items: flex-start;
-    padding-top: var(--gap-md);
-  }
-
-  .package-listing-sidebar__skeleton {
-    width: 20rem;
-    height: 21.4rem;
-  }
-
-  .package-listing-sidebar__install-skeleton {
-    width: 20rem;
-    height: 3.56rem;
-  }
-
-  .package-listing-sidebar__actions-skeleton {
-    width: 20rem;
-    height: 2.25rem;
-  }
-
-  .package-listing-sidebar__install {
-    justify-content: center;
-    width: 100%;
   }
 
   .package-listing-sidebar__main {
@@ -150,19 +150,27 @@
     align-self: stretch;
   }
 
-  .package-listing__package-actions {
-    display: flex;
-    gap: var(--gap-xs);
-    align-items: flex-start;
-    align-self: stretch;
+  .package-listing-sidebar__actions-skeleton,
+  .package-listing-sidebar__install-skeleton,
+  .package-listing-sidebar__skeleton {
+    width: 20rem;
   }
 
-  .package-listing__narrow-actions {
-    display: none;
-    flex-direction: column;
-    gap: var(--gap-xs);
-    align-items: flex-start;
-    align-self: stretch;
+  .package-listing-sidebar__skeleton {
+    height: 21.4rem;
+  }
+
+  .package-listing-sidebar__install-skeleton {
+    height: 3.56rem;
+  }
+
+  .package-listing-sidebar__actions-skeleton {
+    height: 2.25rem;
+  }
+
+  .package-listing-sidebar__install {
+    justify-content: center;
+    width: 100%;
   }
 
   .package-listing-sidebar__download {
@@ -195,19 +203,21 @@
     background: var(--color-surface-default);
   }
 
+  .package-listing-sidebar__content,
+  .package-listing-sidebar__dependency-string,
   .package-listing-sidebar__label {
-    color: var(--color-text-tertiary);
     font-weight: var(--font-weight-bold);
     font-size: var(--font-size-body-sm);
     line-height: normal;
   }
 
+  .package-listing-sidebar__label {
+    color: var(--color-text-tertiary);
+  }
+
   .package-listing-sidebar__content {
     flex: 1 0 0;
     color: var(--color-text-primary);
-    font-weight: var(--font-weight-bold);
-    font-size: var(--font-size-body-sm);
-    line-height: normal;
     text-align: right;
   }
 
@@ -221,27 +231,8 @@
 
   .package-listing-sidebar__dependency-string {
     max-width: 15ch;
-
-    /* overflow-x: clip; */
     color: var(--color-text-primary);
-    font-weight: var(--font-weight-bold);
-    font-size: var(--font-size-body-sm);
-
-    /* white-space: nowrap; */
-
-    /* text-overflow: ellipsis; */
     word-break: break-word;
-  }
-
-  .package-listing-sidebar__categories {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-md);
-    align-items: flex-start;
-    align-self: stretch;
-    padding: var(--space-16);
-    border-radius: var(--radius-md);
-    background-color: var(--color-surface-default);
   }
 
   .package-listing-sidebar__header {
@@ -258,28 +249,21 @@
     align-content: flex-start;
     align-items: flex-start;
     align-self: stretch;
-    min-width: 100px;
-    max-width: 300px;
-  }
-
-  .package-listing__drawer-button {
-    width: 100%;
+    min-width: 6.25rem;
+    max-width: 18.75rem;
   }
 
   @media (width < 41rem) {
     .package-listing-management-tools {
       flex: 1 1 0;
-      flex-flow: row wrap;
     }
 
     .package-listing-management-tools__island {
-      flex-flow: row wrap;
       justify-content: center;
       width: 100%;
     }
   }
 
-  /* Sidebar narrow/wide switch breakpoint */
   @media (width <= 990px) {
     .package-listing__narrow-actions {
       display: flex;


### PR DESCRIPTION
…d listing spacing

Community
- Wrap route in .community grid shell; grid for header row (hero + title/upload)
- Hero: wrapper for placeholder bg; negative margin on banner; package subpath tweaks
- Tinified package-page hero (--packagePage), compact header, gap token for subpath

Package search
- Use filters drawer from max-width 64rem (sidebar hidden); keep narrow-phone tweaks

Package listing
- Remove sidebar padding-top on wide two-column layout
- Tighten spacing under community banner on package subpath (content padding)

Community.css
- Deduplicate hero/skeleton sizing with local CSS variables; design tokens; remove dead rules

And a LOT of generic CSS refactoring