### PR TITLE
Fix missing community icon fallback and refactor Image fallback API

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.css
+++ b/apps/cyberstorm-remix/app/c/Community.css
@@ -103,9 +103,19 @@
     width: 5.5rem;
     height: 5.5rem;
 
-    > img {
+    .community__game-icon-image {
       width: 5.5rem;
       height: 5.5rem;
+    }
+
+    .community__game-icon-image .image__src {
+      width: 5.5rem;
+      height: 5.5rem;
+    }
+
+    .community__game-icon-image .image__icon {
+      width: 2.75rem;
+      height: 2.75rem;
     }
   }
 

--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -1,5 +1,9 @@
 import { faDiscord } from "@fortawesome/free-brands-svg-icons";
-import { faBook, faDownload } from "@fortawesome/free-solid-svg-icons";
+import {
+  faBook,
+  faDownload,
+  faGamepad,
+} from "@fortawesome/free-solid-svg-icons";
 import { faArrowUpRight } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
@@ -17,6 +21,7 @@ import {
 
 import {
   Heading,
+  Image,
   NewButton,
   NewIcon,
   NewLink,
@@ -139,14 +144,17 @@ export default function Community() {
               <div className="community__game-icon-tinified">
                 <Suspense fallback={<SkeletonBox />}>
                   <Await resolve={community}>
-                    {(resolvedValue) =>
-                      resolvedValue.community_icon_url ? (
-                        <img
-                          src={resolvedValue.community_icon_url}
-                          alt={resolvedValue.name}
-                        />
-                      ) : null
-                    }
+                    {(resolvedValue) => (
+                      <Image
+                        src={resolvedValue.community_icon_url}
+                        fallbackIcon={faGamepad}
+                        square
+                        alt={resolvedValue.name}
+                        intrinsicWidth={88}
+                        intrinsicHeight={88}
+                        rootClasses="community__game-icon-image"
+                      />
+                    )}
                   </Await>
                 </Suspense>
               </div>

--- a/apps/cyberstorm-remix/app/commonComponents/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,9 @@
+import { faGamepad } from "@fortawesome/free-solid-svg-icons";
 import { Suspense, useMemo } from "react";
 import { Await, type UIMatch, useMatches } from "react-router";
 
 import {
+  Image,
   NewBreadCrumbs,
   NewBreadCrumbsLink,
   isRecord,
@@ -340,13 +342,19 @@ function getCommunityBreadcrumb(
                   typeof resolvedValue.name === "string"
                     ? resolvedValue.name
                     : communityPage.params.communityId;
-                icon =
-                  Object.prototype.hasOwnProperty.call(
-                    resolvedValue,
-                    "community_icon_url"
-                  ) && typeof resolvedValue.community_icon_url === "string" ? (
-                    <img src={resolvedValue.community_icon_url} alt="" />
-                  ) : undefined;
+                icon = (
+                  <Image
+                    src={
+                      typeof resolvedValue.community_icon_url === "string"
+                        ? resolvedValue.community_icon_url
+                        : null
+                    }
+                    fallbackIcon={faGamepad}
+                    square
+                    alt=""
+                    rootClasses="breadcrumbs__community-icon"
+                  />
+                );
               }
               return isNotLast ? (
                 <NewBreadCrumbsLink

--- a/apps/cyberstorm-remix/app/commonComponents/ListingDependency/ListingDependency.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/ListingDependency/ListingDependency.tsx
@@ -1,3 +1,5 @@
+import { faBan } from "@fortawesome/free-solid-svg-icons";
+
 import { Image, NewLink, formatToDisplayName } from "@thunderstore/cyberstorm";
 import { type PackageVersionDependency } from "@thunderstore/thunderstore-api";
 
@@ -13,7 +15,7 @@ export function ListingDependency(props: ListingDependencyProps) {
     <div className="listing-dependency">
       <Image
         src={dependency.icon_url}
-        cardType="package"
+        fallbackIcon={faBan}
         square={true}
         intrinsicWidth={80}
         intrinsicHeight={80}

--- a/apps/cyberstorm-remix/app/commonComponents/PageHeader/PageHeader.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PageHeader/PageHeader.tsx
@@ -1,3 +1,4 @@
+import { faBan, faGamepad } from "@fortawesome/free-solid-svg-icons";
 import { type PropsWithChildren, type ReactElement, memo } from "react";
 
 import { Heading, Image, classnames } from "@thunderstore/cyberstorm";
@@ -19,8 +20,8 @@ export const PageHeader = memo(function PageHeader(props: PageHeaderProps) {
     headingSize,
     headingLevel,
     description = null,
-    image = null,
-    icon = null,
+    image,
+    icon,
     meta,
     variant = "simple",
   } = props;
@@ -32,21 +33,21 @@ export const PageHeader = memo(function PageHeader(props: PageHeaderProps) {
         variant === "detailed" ? "page-header--detailed" : "page-header--simple"
       )}
     >
-      {image ? (
+      {image !== undefined ? (
         <Image
           src={image}
           square
-          cardType="community"
+          fallbackIcon={faBan}
           intrinsicWidth={96}
           intrinsicHeight={96}
           rootClasses="page-header__image"
         />
       ) : null}
-      {icon ? (
+      {icon !== undefined ? (
         <Image
           src={icon}
           square
-          cardType="community"
+          fallbackIcon={faGamepad}
           intrinsicWidth={56}
           intrinsicHeight={56}
           rootClasses="page-header__icon"

--- a/apps/storybook/src/stories/cyberstormComponents/Image.stories.tsx
+++ b/apps/storybook/src/stories/cyberstormComponents/Image.stories.tsx
@@ -1,4 +1,6 @@
+import { faBan, faGamepad } from "@fortawesome/free-solid-svg-icons";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { CSSProperties, ComponentProps } from "react";
 
 import { Image } from "@thunderstore/cyberstorm";
 import "@thunderstore/cyberstorm-theme";
@@ -6,15 +8,45 @@ import { ImageVariantsList } from "@thunderstore/cyberstorm-theme/src/components
 
 import catHeim from "../assets/catheim.png";
 
+const fallbackIconByKey = {
+  gamepad: faGamepad,
+  ban: faBan,
+} as const;
+
+const fallbackIconOptions = Object.keys(
+  fallbackIconByKey
+) as (keyof typeof fallbackIconByKey)[];
+
+type ImageStoryArgs = Omit<ComponentProps<typeof Image>, "fallbackIcon"> & {
+  fallbackIcon: keyof typeof fallbackIconByKey;
+};
+
+function toImageProps(args: ImageStoryArgs): ComponentProps<typeof Image> {
+  const { fallbackIcon, ...rest } = args;
+  return { ...rest, fallbackIcon: fallbackIconByKey[fallbackIcon] };
+}
+
+function ImageStory(args: ImageStoryArgs) {
+  return <Image {...toImageProps(args)} />;
+}
+
+function renderImage(args: ImageStoryArgs, style: CSSProperties) {
+  return (
+    <div style={style}>
+      <ImageStory {...args} />
+    </div>
+  );
+}
+
 const meta = {
   title: "Cyberstorm/Image",
-  component: Image,
+  component: ImageStory,
   tags: ["autodocs"],
   argTypes: {
     csVariant: { control: "select", options: ImageVariantsList },
-    cardType: {
+    fallbackIcon: {
       control: "select",
-      options: ["community", "communityIcon", "package"],
+      options: fallbackIconOptions,
     },
     src: { control: "text" },
     alt: { control: "text" },
@@ -22,52 +54,31 @@ const meta = {
   },
   args: {
     src: null,
-    cardType: "community",
+    fallbackIcon: "gamepad",
     intrinsicWidth: 150,
     intrinsicHeight: 200,
   },
-} satisfies Meta<typeof Image>;
+  render: (args) => renderImage(args, { width: "300px", height: "400px" }),
+} satisfies Meta<typeof ImageStory>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {},
-  render: (args) => (
-    <div style={{ width: "300px", height: "400px" }}>
-      <Image {...args} />
-    </div>
-  ),
 };
+
 export const WithImageAsset: Story = {
-  args: { src: catHeim, alt: "catHeim", cardType: "community" },
-  render: (args) => (
-    <div style={{ width: "150px", height: "200px" }}>
-      <Image {...args} />
-    </div>
-  ),
+  args: { src: catHeim, alt: "catHeim", fallbackIcon: "gamepad" },
+  render: (args) => renderImage(args, { width: "150px", height: "200px" }),
 };
-export const Community: Story = {
-  args: { alt: "Community", cardType: "community" },
-  render: (args) => (
-    <div style={{ width: "150px", height: "200px" }}>
-      <Image {...args} />
-    </div>
-  ),
+
+export const CommunityFallback: Story = {
+  args: { alt: "Community", fallbackIcon: "gamepad" },
+  render: (args) => renderImage(args, { width: "150px", height: "200px" }),
 };
-export const CommunityIcon: Story = {
-  args: { alt: "Community", cardType: "communityIcon" },
-  render: (args) => (
-    <div style={{ width: "150px", height: "200px" }}>
-      <Image {...args} />
-    </div>
-  ),
-};
+
 export const Package: Story = {
-  args: { alt: "Package", cardType: "package" },
-  render: (args) => (
-    <div style={{ width: "150px", height: "200px" }}>
-      <Image {...args} />
-    </div>
-  ),
+  args: { alt: "Package", fallbackIcon: "ban" },
+  render: (args) => renderImage(args, { width: "150px", height: "200px" }),
 };

--- a/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
+++ b/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
@@ -39,6 +39,18 @@
       aspect-ratio: 1/1;
     }
 
+    .breadcrumbs__community-icon {
+      width: 1rem;
+      height: 1rem;
+      border-radius: 0;
+    }
+
+    .breadcrumbs__community-icon .image__src,
+    .breadcrumbs__community-icon .image__icon {
+      width: 1rem;
+      height: 1rem;
+    }
+
     > * {
       position: relative;
       display: flex;

--- a/packages/cyberstorm/src/newComponents/Card/CardCommunity/CardCommunity.tsx
+++ b/packages/cyberstorm/src/newComponents/Card/CardCommunity/CardCommunity.tsx
@@ -2,6 +2,7 @@ import {
   faBoxOpen,
   faDownload,
   faFire,
+  faGamepad,
 } from "@fortawesome/free-solid-svg-icons";
 import { faSparkles } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -58,7 +59,7 @@ export const CardCommunity = memo(function CardCommunity(props: Props) {
       >
         <Image
           src={community.cover_image_url}
-          cardType="community"
+          fallbackIcon={faGamepad}
           rootClasses="card-community__image"
           intrinsicWidth={360}
           intrinsicHeight={480}

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
@@ -1,4 +1,5 @@
 import {
+  faBan,
   faClockRotateLeft,
   faCodeMerge,
   faDownload,
@@ -239,7 +240,7 @@ export function CardPackage(props: Props) {
         ) : null}
         <Image
           src={packageData.icon_url}
-          cardType="package"
+          fallbackIcon={faBan}
           rootClasses="card-package__image-wrapper"
           square
           intrinsicWidth={256}

--- a/packages/cyberstorm/src/newComponents/Image/Image.tsx
+++ b/packages/cyberstorm/src/newComponents/Image/Image.tsx
@@ -1,4 +1,4 @@
-import { faBan, faGamepad } from "@fortawesome/free-solid-svg-icons";
+import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo } from "react";
 
@@ -12,10 +12,10 @@ import { classnames, componentClasses } from "../../utils/utils";
 import { Icon as NewIcon } from "../Icon/Icon";
 import "./Image.css";
 
-interface ImageProps extends Omit<FrameWindowProps, "primitiveType"> {
+export interface ImageProps extends Omit<FrameWindowProps, "primitiveType"> {
   src: string | null | undefined;
-  /** Type of the image defines the icon used as the fallback. */
-  cardType: "community" | "communityIcon" | "package";
+  /** Icon shown when `src` is missing. */
+  fallbackIcon: IconDefinition;
   /** Alt text for the image. Leave empty for decorative images. */
   alt?: string;
   /** Force 1:1 aspect ratio */
@@ -26,14 +26,13 @@ interface ImageProps extends Omit<FrameWindowProps, "primitiveType"> {
   intrinsicHeight?: number;
 }
 
-// TODO: Needs a storybook story
 /**
  * Show the image, or use predefined icon as the fallback.
  */
 export const Image = memo(function Image(props: ImageProps) {
   const {
     src,
-    cardType,
+    fallbackIcon,
     alt = "",
     rootClasses,
     square = false,
@@ -95,7 +94,7 @@ export const Image = memo(function Image(props: ImageProps) {
           noWrapper
           csMode="inline"
         >
-          <FontAwesomeIcon icon={getIcon(cardType)} />
+          <FontAwesomeIcon icon={fallbackIcon} />
         </NewIcon>
       )}
     </Frame>
@@ -103,13 +102,3 @@ export const Image = memo(function Image(props: ImageProps) {
 });
 
 Image.displayName = "Image";
-
-// There is an issue with Typescript (eslint) and prettier disagreeing if
-// the type should have parentheses
-// prettier-ignore
-const getIcon = (type: ImageProps["cardType"] = "community") =>
-  ({
-    communityIcon: faGamepad,
-    community: faGamepad,
-    package: faBan,
-  }[type]);


### PR DESCRIPTION
- Replace cardType with fallbackIcon on Image
- Show gamepad when community_icon_url is absent (community page, breadcrumbs)
- Align package fallbacks (faBan) across cards and PageHeader