### PR TITLE
Error pages (TS-3396)

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 import {
@@ -36,39 +37,41 @@ import "./Community.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const community = await dapper.getCommunity(params.communityId);
+      const url = new URL(request.url);
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        community: community,
+        seo: createSeo({
+          descriptors: [
+            { title: `The ${community.name} Mod Database` },
+            { name: "description", content: `Mods for ${community.name}` },
+            { property: "og:image", content: community.cover_image_url ?? "" },
+            {
+              property: "og:url",
+              content: `${url.origin}${url.pathname}`,
+            },
+            {
+              property: "og:description",
+              content: `Thunderstore is a mod database and API for downloading ${community.name} mods`,
+            },
+            { property: "og:image:width", content: "360" },
+            { property: "og:image:height", content: "480" },
+          ],
+        }),
       };
-    });
-    const community = await dapper.getCommunity(params.communityId);
-    const url = new URL(request.url);
-    return {
-      community: community,
-      seo: createSeo({
-        descriptors: [
-          { title: `The ${community.name} Mod Database` },
-          { name: "description", content: `Mods for ${community.name}` },
-          { property: "og:image", content: community.cover_image_url ?? "" },
-          {
-            property: "og:url",
-            content: `${url.origin}${url.pathname}`,
-          },
-          {
-            property: "og:description",
-            content: `Thunderstore is a mod database and API for downloading ${community.name} mods`,
-          },
-          { property: "og:image:width", content: "360" },
-          { property: "og:image:height", content: "480" },
-        ],
-      }),
-    };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -34,6 +34,8 @@ import { type OutletContextShape } from "../root";
 import type { Route } from "./+types/Community";
 import "./Community.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params, request }: Route.LoaderArgs) {
   if (params.communityId) {
     const dapper = new DapperTs(() => {

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { getSectionDefault } from "cyberstorm/utils/section";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
 import { PackageOrderOptions } from "~/commonComponents/PackageSearch/components/packageOrderOptions";
@@ -11,58 +12,60 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 
 import type { Route } from "./+types/PackageSearch";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const community = await dapper.getCommunity(params.communityId);
+
+      const finalSection = getSectionDefault(section, filters.sections);
+
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
-      };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const community = await dapper.getCommunity(params.communityId);
-
-    const finalSection = getSectionDefault(section, filters.sections);
-
-    return {
-      filters: filters,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "community",
-          communityId: params.communityId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        finalSection,
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
-          { title: `Packages for ${community.name} | Thunderstore` },
+        filters: filters,
+        listings: await dapper.getPackageListings(
           {
-            name: "description",
-            content: `Browse packages for ${community.name}`,
+            kind: "community",
+            communityId: params.communityId,
           },
-        ],
-      }),
-    };
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          finalSection,
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            { title: `Packages for ${community.name} | Thunderstore` },
+            {
+              name: "description",
+              content: `Browse packages for ${community.name}`,
+            },
+          ],
+        }),
+      };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -31,6 +31,8 @@ import type { Communities } from "@thunderstore/dapper/types";
 import type { Route } from "./+types/communities";
 import "./Communities.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 enum SortOptions {
   Name = "name",
   Latest = "-datetime_created",

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense, memo, useEffect, useRef, useState } from "react";
 import {
   Await,
@@ -58,7 +59,7 @@ const selectOptions = [
   },
 ];
 
-export async function loader({ request }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   const searchParams = url.searchParams;
   const order = searchParams.get("order") ?? SortOptions.Popular;
@@ -97,7 +98,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/login/login.tsx
+++ b/apps/cyberstorm-remix/app/login/login.tsx
@@ -4,6 +4,8 @@ import { useSearchParams } from "react-router";
 
 import { NotLoggedIn } from "../commonComponents/NotLoggedIn/NotLoggedIn";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader() {
   return {
     seo: createSeo({

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -19,6 +19,8 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Dependants";
 import "./Dependants.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params, request }: Route.LoaderArgs) {
   if (params.communityId && params.packageId && params.namespaceId) {
     const dapper = new DapperTs(() => {

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { getSectionDefault } from "cyberstorm/utils/section";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
@@ -21,94 +22,96 @@ import "./Dependants.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId && params.packageId && params.namespaceId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId && params.packageId && params.namespaceId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const listing = await dapper.getPackageListingDetails(
+        params.communityId,
+        params.namespaceId,
+        params.packageId
+      );
+
+      const finalSection = getSectionDefault(section, filters.sections);
+
+      if (!listing) {
+        throw new Response("Package not found", { status: 404 });
+      }
+
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        community: dapper.getCommunity(params.communityId),
+        listing,
+        filters: filters,
+        listings: await dapper.getPackageListings(
+          {
+            kind: "package-dependants",
+            communityId: params.communityId,
+            namespaceId: params.namespaceId,
+            packageName: params.packageId,
+          },
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          finalSection,
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `Dependants of ${formatToDisplayName(
+                listing.name
+              )} | Thunderstore`,
+            },
+            {
+              name: "description",
+              content: `Mods that depend on ${listing.name}`,
+            },
+            { property: "og:type", content: "website" },
+            { property: "og:url", content: request.url },
+            {
+              property: "og:title",
+              content: `Dependants of ${formatToDisplayName(
+                listing.name
+              )} | Thunderstore`,
+            },
+            {
+              property: "og:description",
+              content: `Mods that depend on ${listing.name}`,
+            },
+            ...(listing.icon_url
+              ? [
+                  { property: "og:image", content: listing.icon_url },
+                  { property: "og:image:width", content: "256" },
+                  { property: "og:image:height", content: "256" },
+                ]
+              : []),
+            { property: "og:site_name", content: "Thunderstore" },
+          ],
+        }),
       };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const listing = await dapper.getPackageListingDetails(
-      params.communityId,
-      params.namespaceId,
-      params.packageId
-    );
-
-    const finalSection = getSectionDefault(section, filters.sections);
-
-    if (!listing) {
-      throw new Response("Package not found", { status: 404 });
     }
-
-    return {
-      community: dapper.getCommunity(params.communityId),
-      listing,
-      filters: filters,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "package-dependants",
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-          packageName: params.packageId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        finalSection,
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `Dependants of ${formatToDisplayName(
-              listing.name
-            )} | Thunderstore`,
-          },
-          {
-            name: "description",
-            content: `Mods that depend on ${listing.name}`,
-          },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: request.url },
-          {
-            property: "og:title",
-            content: `Dependants of ${formatToDisplayName(
-              listing.name
-            )} | Thunderstore`,
-          },
-          {
-            property: "og:description",
-            content: `Mods that depend on ${listing.name}`,
-          },
-          ...(listing.icon_url
-            ? [
-                { property: "og:image", content: listing.icon_url },
-                { property: "og:image:width", content: "256" },
-                { property: "og:image:height", content: "256" },
-              ]
-            : []),
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
-    };
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -55,7 +55,7 @@ export const loader = ssrLoader(
       }
 
       return {
-        community: dapper.getCommunity(params.communityId),
+        community: await dapper.getCommunity(params.communityId),
         listing,
         filters: filters,
         listings: await dapper.getPackageListings(

--- a/apps/cyberstorm-remix/app/p/packageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/packageEdit.tsx
@@ -31,6 +31,8 @@ import { ApiAction } from "@thunderstore/ts-api-react-actions";
 import type { Route } from "./+types/packageEdit";
 import "./packageEdit.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 const package404 = new Response("Package not found", { status: 404 });
 
 export async function loader({ params }: Route.LoaderArgs) {

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -62,6 +62,8 @@ import {
 } from "./listingUtils";
 import "./packageListing.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 type PackageListingOutletContext = OutletContextShape & {
   packageDownloadUrl?: string;
 };

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -13,6 +13,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import {
   type ReactElement,
   Suspense,
@@ -68,70 +69,72 @@ type PackageListingOutletContext = OutletContextShape & {
   packageDownloadUrl?: string;
 };
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId } = params;
 
-  if (!communityId || !namespaceId || !packageId) {
-    throw new Response("Package not found", { status: 404 });
+    if (!communityId || !namespaceId || !packageId) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
+
+    const listing = await getPublicListing(dapper, {
+      communityId,
+      namespaceId,
+      packageId,
+    });
+
+    if (!listing) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const community = await dapper.getCommunity(communityId);
+    const url = new URL(request.url);
+
+    return {
+      community,
+      communityFilters: await dapper.getCommunityFilters(communityId),
+      listing: listing,
+      listingStatus: undefined,
+      team: await dapper.getTeamDetails(namespaceId),
+      permissions: undefined,
+      community_identifier: communityId,
+      namespace_id: namespaceId,
+      package_id: packageId,
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${formatToDisplayName(listing.name)} | Thunderstore - The ${
+              community.name
+            } Mod Database`,
+          },
+          { name: "description", content: listing.description },
+          { property: "og:type", content: "website" },
+          { property: "og:url", content: url.href },
+          {
+            property: "og:title",
+            content: `${formatToDisplayName(listing.name)} by ${
+              listing.namespace
+            }`,
+          },
+          { property: "og:description", content: listing.description },
+          ...(listing.icon_url
+            ? [
+                { property: "og:image", content: listing.icon_url },
+                { property: "og:image:width", content: "256" },
+                { property: "og:image:height", content: "256" },
+              ]
+            : []),
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
+    };
   }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  const listing = await getPublicListing(dapper, {
-    communityId,
-    namespaceId,
-    packageId,
-  });
-
-  if (!listing) {
-    throw new Response("Package not found", { status: 404 });
-  }
-
-  const community = await dapper.getCommunity(communityId);
-  const url = new URL(request.url);
-
-  return {
-    community,
-    communityFilters: await dapper.getCommunityFilters(communityId),
-    listing: listing,
-    listingStatus: undefined,
-    team: await dapper.getTeamDetails(namespaceId),
-    permissions: undefined,
-    community_identifier: communityId,
-    namespace_id: namespaceId,
-    package_id: packageId,
-    seo: createSeo({
-      descriptors: [
-        {
-          title: `${formatToDisplayName(listing.name)} | Thunderstore - The ${
-            community.name
-          } Mod Database`,
-        },
-        { name: "description", content: listing.description },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: url.href },
-        {
-          property: "og:title",
-          content: `${formatToDisplayName(listing.name)} by ${
-            listing.namespace
-          }`,
-        },
-        { property: "og:description", content: listing.description },
-        ...(listing.icon_url
-          ? [
-              { property: "og:image", content: listing.icon_url },
-              { property: "og:image:width", content: "256" },
-              { property: "og:image:height", content: "256" },
-            ]
-          : []),
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 import {
@@ -39,66 +40,68 @@ import "./packageListing.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId, packageVersion } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId, packageVersion } = params;
 
-  if (!communityId || !namespaceId || !packageId || !packageVersion) {
-    throw new Response("Package not found", { status: 404 });
+    if (!communityId || !namespaceId || !packageId || !packageVersion) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
+
+    const listing = await getPublicListing(dapper, {
+      communityId,
+      namespaceId,
+      packageId,
+      packageVersion,
+    });
+
+    if (!listing) {
+      throw new Response("Package not found", { status: 404 });
+    }
+
+    const community = await dapper.getCommunity(communityId);
+    const url = new URL(request.url);
+
+    return {
+      community,
+      listing,
+      packageVersion,
+      team: await dapper.getTeamDetails(namespaceId),
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${formatToDisplayName(listing.name)} v${packageVersion} | ${
+              community.name
+            } Mod Database`,
+          },
+          { name: "description", content: listing.description },
+          { property: "og:type", content: "website" },
+          { property: "og:url", content: url.href },
+          {
+            property: "og:title",
+            content: `${formatToDisplayName(
+              listing.name
+            )} v${packageVersion} by ${listing.namespace}`,
+          },
+          { property: "og:description", content: listing.description },
+          ...(listing.icon_url
+            ? [
+                { property: "og:image", content: listing.icon_url },
+                { property: "og:image:width", content: "256" },
+                { property: "og:image:height", content: "256" },
+              ]
+            : []),
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
+    };
   }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  const listing = await getPublicListing(dapper, {
-    communityId,
-    namespaceId,
-    packageId,
-    packageVersion,
-  });
-
-  if (!listing) {
-    throw new Response("Package not found", { status: 404 });
-  }
-
-  const community = await dapper.getCommunity(communityId);
-  const url = new URL(request.url);
-
-  return {
-    community,
-    listing,
-    packageVersion,
-    team: await dapper.getTeamDetails(namespaceId),
-    seo: createSeo({
-      descriptors: [
-        {
-          title: `${formatToDisplayName(listing.name)} v${packageVersion} | ${
-            community.name
-          } Mod Database`,
-        },
-        { name: "description", content: listing.description },
-        { property: "og:type", content: "website" },
-        { property: "og:url", content: url.href },
-        {
-          property: "og:title",
-          content: `${formatToDisplayName(
-            listing.name
-          )} v${packageVersion} by ${listing.namespace}`,
-        },
-        { property: "og:description", content: listing.description },
-        ...(listing.icon_url
-          ? [
-              { property: "og:image", content: listing.icon_url },
-              { property: "og:image:width", content: "256" },
-              { property: "og:image:height", content: "256" },
-            ]
-          : []),
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-}
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -37,6 +37,8 @@ import { PackageActions } from "./components/PackageListing/PackageActions";
 import { getPrivateListing, getPublicListing } from "./listingUtils";
 import "./packageListing.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params, request }: Route.LoaderArgs) {
   const { communityId, namespaceId, packageId, packageVersion } = params;
 

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -2,6 +2,7 @@ import { TabFetchState } from "app/p/components/TabFetchState/TabFetchState";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData } from "react-router";
 
@@ -27,7 +28,7 @@ async function fetchChangelogSafe(
   }
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -52,7 +53,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -2,6 +2,7 @@ import { TabFetchState } from "app/p/components/TabFetchState/TabFetchState";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -12,7 +13,7 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 import type { Route } from "./+types/PackageVersionReadme";
 import "./Readme.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const dapper = new DapperTs(() => {
       return {
@@ -47,7 +48,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       descriptors: [{ title: "Readme Not Found | Thunderstore" }],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -2,6 +2,7 @@ import { TabFetchState } from "app/p/components/TabFetchState/TabFetchState";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -28,7 +29,7 @@ async function fetchReadmeSafe(
   }
 }
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -54,7 +55,7 @@ export async function loader({ params }: Route.LoaderArgs) {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -6,6 +6,7 @@ import { getPrivateListing, getPublicListing } from "app/p/listingUtils";
 import { getDapperForRequest } from "cyberstorm/utils/dapperSingleton";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData } from "react-router";
 
@@ -24,58 +25,60 @@ const getPageFromUrl = (url: string): number | undefined => {
   return maybePage ? Number(maybePage) : undefined;
 };
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  const { communityId, namespaceId, packageId, packageVersion } = params;
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    const { communityId, namespaceId, packageId, packageVersion } = params;
 
-  // Either communityId or packageVersion is required depending on route.
-  if (!namespaceId || !packageId || (!communityId && !packageVersion)) {
-    throw Dependency404;
-  }
-
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
-
-  let version: string;
-
-  if (packageVersion) {
-    version = packageVersion;
-  } else if (communityId) {
-    const listingArgs = { communityId, namespaceId, packageId };
-    const listing = await getPublicListing(dapper, listingArgs);
-
-    // Listing that's not available on unauthenticated SSR request
-    // might be available for authenticated user on client. Return
-    // undefined rather than throw error to allow refetch on client.
-    if (!listing) {
-      return { dependencies: undefined, seo: createSeo({ descriptors: [] }) };
+    // Either communityId or packageVersion is required depending on route.
+    if (!namespaceId || !packageId || (!communityId && !packageVersion)) {
+      throw Dependency404;
     }
 
-    version = listing.latest_version_number;
-  } else {
-    throw Dependency404; // Can't happen, satisfies TypeScript
-  }
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
 
-  return {
-    communityId: communityId,
-    dependencies: await dapper.getPackageVersionDependencies(
-      namespaceId,
-      packageId,
-      version,
-      getPageFromUrl(request.url)
-    ),
-    seo: createSeo({
-      descriptors: [
-        { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
-        {
-          name: "description",
-          content: `Dependencies for ${namespaceId}-${packageId}`,
-        },
-      ],
-    }),
-  };
-}
+    let version: string;
+
+    if (packageVersion) {
+      version = packageVersion;
+    } else if (communityId) {
+      const listingArgs = { communityId, namespaceId, packageId };
+      const listing = await getPublicListing(dapper, listingArgs);
+
+      // Listing that's not available on unauthenticated SSR request
+      // might be available for authenticated user on client. Return
+      // undefined rather than throw error to allow refetch on client.
+      if (!listing) {
+        return { dependencies: undefined, seo: createSeo({ descriptors: [] }) };
+      }
+
+      version = listing.latest_version_number;
+    } else {
+      throw Dependency404; // Can't happen, satisfies TypeScript
+    }
+
+    return {
+      communityId: communityId,
+      dependencies: await dapper.getPackageVersionDependencies(
+        namespaceId,
+        packageId,
+        version,
+        getPageFromUrl(request.url)
+      ),
+      seo: createSeo({
+        descriptors: [
+          { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
+          {
+            name: "description",
+            content: `Dependencies for ${namespaceId}-${packageId}`,
+          },
+        ],
+      }),
+    };
+  }
+);
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -3,6 +3,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -21,7 +22,7 @@ import { columns } from "./Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -56,7 +57,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     versions: [],
     seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -3,6 +3,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { rowSemverCompare } from "cyberstorm/utils/semverCompare";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await } from "react-router";
 import { useLoaderData } from "react-router";
@@ -21,7 +22,7 @@ import type { Route } from "./+types/Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -56,7 +57,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     versions: [],
     seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import {
   Await,
@@ -30,7 +31,7 @@ import "./Wiki.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -76,7 +77,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -45,13 +45,10 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
     try {
       wiki = await dapper.getPackageWiki(params.namespaceId, params.packageId);
     } catch (error) {
-      if (isApiError(error)) {
-        if (error.response.status === 404) {
-          wiki = undefined;
-        } else {
-          wiki = undefined;
-          console.error("Error fetching package wiki:", error);
-        }
+      if (isApiError(error) && error.response.status === 404) {
+        wiki = undefined;
+      } else {
+        throw error;
       }
     }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -28,6 +28,8 @@ import { isApiError } from "@thunderstore/thunderstore-api";
 import type { Route } from "./+types/Wiki";
 import "./Wiki.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params }: Route.LoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -2,6 +2,7 @@ import { TabFetchState } from "app/p/components/TabFetchState/TabFetchState";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useState } from "react";
 import { useLoaderData, useRouteLoaderData } from "react-router";
 
@@ -26,7 +27,7 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (params.communityId && params.namespaceId && params.packageId) {
     const dapper = new DapperTs(() => {
       return {
@@ -103,7 +104,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     return result;
   }
   throw new Error("Namespace ID or Package ID is missing");
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -2,6 +2,7 @@ import { TabFetchState } from "app/p/components/TabFetchState/TabFetchState";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useState } from "react";
 import { useLoaderData, useRouteLoaderData } from "react-router";
 
@@ -26,7 +27,7 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (
     params.communityId &&
     params.namespaceId &&
@@ -113,7 +114,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -58,7 +58,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
     );
     const pageId = wiki.pages.find((p) => p.slug === params.slug)?.id;
     if (!pageId) {
-      throw new Error("Page not found");
+      throw new Response("Page not found", { status: 404 });
     }
     const page = await dapper.getPackageWikiPage(pageId);
 
@@ -80,7 +80,9 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
       }),
     };
   } else {
-    throw new Error("Namespace ID or Package ID is missing");
+    throw new Response("Namespace ID or Package ID is missing", {
+      status: 404,
+    });
   }
 });
 
@@ -138,7 +140,7 @@ export async function clientLoader({
     );
     const pageId = wiki.pages.find((p) => p.slug === params.slug)?.id;
     if (!pageId) {
-      throw new Error("Page not found");
+      throw new Response("Page not found", { status: 404 });
     }
     const page = await dapper.getPackageWikiPage(pageId);
 
@@ -150,7 +152,9 @@ export async function clientLoader({
       seo: (await serverLoader()).seo,
     };
   } else {
-    throw new Error("Namespace ID or Package ID is missing");
+    throw new Response("Namespace ID or Package ID is missing", {
+      status: 404,
+    });
   }
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -3,6 +3,7 @@ import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { redirectToLogin } from "cyberstorm/utils/ThunderstoreAuth";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useReducer, useState } from "react";
 import {
   useLoaderData,
@@ -38,7 +39,7 @@ import { ApiAction } from "@thunderstore/ts-api-react-actions";
 import type { Route } from "./+types/WikiPageEdit";
 import "./Wiki.css";
 
-export async function loader({ params }: Route.LoaderArgs) {
+export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   if (
     params.communityId &&
     params.namespaceId &&
@@ -81,7 +82,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   } else {
     throw new Error("Namespace ID or Package ID is missing");
   }
-}
+});
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -2,6 +2,7 @@ import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { getSectionDefault } from "cyberstorm/utils/section";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useLoaderData, useOutletContext } from "react-router";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
@@ -15,75 +16,77 @@ import "./Team.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export async function loader({ params, request }: Route.LoaderArgs) {
-  if (params.communityId && params.namespaceId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params, request }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      const searchParams = new URL(request.url).searchParams;
+      const ordering =
+        searchParams.get("ordering") ?? PackageOrderOptions.Updated;
+      const page = searchParams.get("page");
+      const search = searchParams.get("search");
+      const includedCategories = searchParams.get("includedCategories");
+      const excludedCategories = searchParams.get("excludedCategories");
+      const section = searchParams.get("section");
+      const nsfw = searchParams.get("nsfw");
+      const deprecated = searchParams.get("deprecated");
+      const filters = await dapper.getCommunityFilters(params.communityId);
+      const community = await dapper.getCommunity(params.communityId);
+
+      const finalSection = getSectionDefault(section, filters.sections);
+
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        teamId: params.namespaceId,
+        filters: filters,
+        // Community is required for the breadcrumbs in the root layout
+        community: community,
+        listings: await dapper.getPackageListings(
+          {
+            kind: "namespace",
+            communityId: params.communityId,
+            namespaceId: params.namespaceId,
+          },
+          ordering ?? "",
+          page === null ? undefined : Number(page),
+          search ?? "",
+          includedCategories?.split(",") ?? undefined,
+          excludedCategories?.split(",") ?? undefined,
+          finalSection,
+          nsfw === "true" ? true : false,
+          deprecated === "true" ? true : false
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `Mods uploaded by ${params.namespaceId} | Thunderstore - The ${community.name} Mod Database`,
+            },
+            {
+              name: "description",
+              content: `Browse mods uploaded by ${params.namespaceId}`,
+            },
+            { property: "og:type", content: "website" },
+            { property: "og:url", content: request.url },
+            {
+              property: "og:title",
+              content: `Mods by ${params.namespaceId} | Thunderstore`,
+            },
+            {
+              property: "og:description",
+              content: `Browse mods uploaded by ${params.namespaceId}`,
+            },
+            { property: "og:site_name", content: "Thunderstore" },
+          ],
+        }),
       };
-    });
-    const searchParams = new URL(request.url).searchParams;
-    const ordering =
-      searchParams.get("ordering") ?? PackageOrderOptions.Updated;
-    const page = searchParams.get("page");
-    const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
-    const section = searchParams.get("section");
-    const nsfw = searchParams.get("nsfw");
-    const deprecated = searchParams.get("deprecated");
-    const filters = await dapper.getCommunityFilters(params.communityId);
-    const community = await dapper.getCommunity(params.communityId);
-
-    const finalSection = getSectionDefault(section, filters.sections);
-
-    return {
-      teamId: params.namespaceId,
-      filters: filters,
-      // Community is required for the breadcrumbs in the root layout
-      community: community,
-      listings: await dapper.getPackageListings(
-        {
-          kind: "namespace",
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-        },
-        ordering ?? "",
-        page === null ? undefined : Number(page),
-        search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
-        finalSection,
-        nsfw === "true" ? true : false,
-        deprecated === "true" ? true : false
-      ),
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `Mods uploaded by ${params.namespaceId} | Thunderstore - The ${community.name} Mod Database`,
-          },
-          {
-            name: "description",
-            content: `Browse mods uploaded by ${params.namespaceId}`,
-          },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: request.url },
-          {
-            property: "og:title",
-            content: `Mods by ${params.namespaceId} | Thunderstore`,
-          },
-          {
-            property: "og:description",
-            content: `Browse mods uploaded by ${params.namespaceId}`,
-          },
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
-    };
+    }
+    throw new Response("Community not found", { status: 404 });
   }
-  throw new Response("Community not found", { status: 404 });
-}
+);
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -13,6 +13,8 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Team";
 import "./Team.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params, request }: Route.LoaderArgs) {
   if (params.communityId && params.namespaceId) {
     const dapper = new DapperTs(() => {

--- a/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/Teams.tsx
@@ -39,6 +39,8 @@ import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Teams";
 import "./Teams.css";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 function formFieldUpdateAction(
   state: TeamCreateRequestData,
   action: {

--- a/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
+++ b/apps/cyberstorm-remix/app/settings/teams/team/teamSettings.tsx
@@ -7,6 +7,8 @@ import { NewLink, Tabs } from "@thunderstore/cyberstorm";
 
 import type { Route } from "./+types/teamSettings";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 export async function loader({ params, request }: Route.LoaderArgs) {
   const teamName = params.namespaceId ?? "";
   const url = new URL(request.url);

--- a/apps/cyberstorm-remix/app/settings/user/Connections/Connections.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Connections/Connections.tsx
@@ -82,7 +82,7 @@ export default function Connections() {
     let message = "Error when disconnecting account.";
 
     if (isApiError(error)) {
-      const fieldErrors = error.getFieldErrors();
+      const fieldErrors = error.getFieldErrors?.() ?? {};
       message =
         fieldErrors.non_field_errors?.[0] ||
         fieldErrors.detail?.[0] ||

--- a/apps/cyberstorm-remix/app/settings/user/Connections/Connections.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Connections/Connections.tsx
@@ -15,7 +15,7 @@ import {
   useToast,
 } from "@thunderstore/cyberstorm";
 import {
-  ApiError,
+  isApiError,
   userLinkedAccountDisconnect,
 } from "@thunderstore/thunderstore-api";
 import { ApiAction } from "@thunderstore/ts-api-react-actions";
@@ -81,7 +81,7 @@ export default function Connections() {
   const onSubmitError = (error: unknown) => {
     let message = "Error when disconnecting account.";
 
-    if (error instanceof ApiError) {
+    if (isApiError(error)) {
       const fieldErrors = error.getFieldErrors();
       message =
         fieldErrors.non_field_errors?.[0] ||

--- a/apps/cyberstorm-remix/app/settings/user/Settings.tsx
+++ b/apps/cyberstorm-remix/app/settings/user/Settings.tsx
@@ -9,6 +9,8 @@ import { NewLink, Tabs } from "@thunderstore/cyberstorm";
 import { type OutletContextShape } from "../../root";
 import type { Route } from "./+types/Settings";
 
+export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
 // Client loader to fetch current user for SEO titles and secure the route
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const tools = getSessionTools();

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -11,6 +11,7 @@ import { useStrongForm } from "cyberstorm/utils/StrongForm/useStrongForm";
 import { redirectToLogin } from "cyberstorm/utils/ThunderstoreAuth";
 import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useLoaderData, useOutletContext } from "react-router";
 
@@ -59,7 +60,7 @@ interface CategoryOption {
   label: string;
 }
 
-export async function loader() {
+export const loader = ssrLoader(async () => {
   const dapper = new DapperTs(() => {
     return {
       apiHost: getApiHostForSsr(),
@@ -79,7 +80,7 @@ export async function loader() {
       ],
     }),
   };
-}
+});
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/cyberstorm/utils/dapperClientLoaders.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/dapperClientLoaders.ts
@@ -3,7 +3,10 @@ import { assertTeamAccess } from "cyberstorm/utils/permissions";
 import { type LoaderFunctionArgs } from "react-router";
 
 import { DapperTs } from "@thunderstore/dapper-ts";
-import { ApiError, type GenericApiError } from "@thunderstore/thunderstore-api";
+import {
+  type GenericApiError,
+  isApiError,
+} from "@thunderstore/thunderstore-api";
 
 /**
  * TODO
@@ -34,7 +37,7 @@ export function makeTeamSettingsTabLoader<T>(
       const data = await dataFetcher(dapper, teamName);
       return { teamName, ...data };
     } catch (error) {
-      if (error instanceof ApiError) {
+      if (isApiError(error)) {
         const status = error.response.status;
         const statusText =
           (error.responseJson as GenericApiError)?.detail ??

--- a/packages/dapper-ts/src/methods/__tests__/currentUser.test.ts
+++ b/packages/dapper-ts/src/methods/__tests__/currentUser.test.ts
@@ -27,8 +27,13 @@ vi.mock("@thunderstore/thunderstore-api", () => {
     }
   }
 
+  function isApiError(e: unknown): e is InstanceType<typeof ApiError> {
+    return e instanceof ApiError;
+  }
+
   return {
     ApiError,
+    isApiError,
     fetchCurrentUser: vi.fn(),
     fetchCurrentUserTeamPermissions: vi.fn(),
   };

--- a/packages/dapper-ts/src/methods/currentUser.ts
+++ b/packages/dapper-ts/src/methods/currentUser.ts
@@ -1,7 +1,7 @@
 import {
-  ApiError,
   fetchCurrentUser,
   fetchCurrentUserTeamPermissions,
+  isApiError,
 } from "@thunderstore/thunderstore-api";
 
 import type { DapperTsInterface } from "../index";
@@ -16,7 +16,7 @@ export async function getCurrentUser(this: DapperTsInterface) {
     });
     return data;
   } catch (error) {
-    if (error instanceof ApiError && error.response.status === 401) {
+    if (isApiError(error) && error.response.status === 401) {
       // Any 401 means the session/auth context is invalid or stale.
       // Clear persisted session data to allow consumers to recover (e.g. re-auth).
       this.removeSessionHook?.();

--- a/packages/dapper-ts/src/methods/package.ts
+++ b/packages/dapper-ts/src/methods/package.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import {
-  ApiError,
   fetchPackageChangelog,
   fetchPackagePermissions,
   fetchPackageReadme,
@@ -11,6 +10,7 @@ import {
   fetchPackageVersions,
   fetchPackageWiki,
   fetchPackageWikiPage,
+  isApiError,
   postPackageSubmission,
 } from "@thunderstore/thunderstore-api";
 import type { PackageVersionDependenciesRequestQueryParams } from "@thunderstore/thunderstore-api";
@@ -226,7 +226,7 @@ export async function getPackagePermissions(
     return response;
   } catch (error) {
     // In case of user not being logged in or stale session
-    if (error instanceof ApiError && error.response.status === 401) {
+    if (isApiError(error) && error.response.status === 401) {
       return undefined;
     } else {
       throw error;


### PR DESCRIPTION
* Export ErrorBoundary on layout/parent routes
* Export ErrorBoundary on standalone routes
* Use `isApiError `instead of `instanceof ApiError`
* Use `ssrLoader `for component SSR `loader()` functions