### PR TITLE
fix(react-router link): Use currect link behavior when PESPA is not available

### DIFF
--- a/apps/cyberstorm-remix/cyberstorm/utils/LinkLibrary.tsx
+++ b/apps/cyberstorm-remix/cyberstorm/utils/LinkLibrary.tsx
@@ -7,6 +7,35 @@ import type {
   ThunderstoreLinkProps,
 } from "@thunderstore/cyberstorm";
 
+import { getPublicEnvVariables } from "../security/publicEnvVariables";
+
+// Returns true when the current document is NOT being served by the React Router
+// app, in which case in-app <Link> navigations need to force a full document
+// load (otherwise React Router would intercept clicks and try to handle
+// routes that only exist on the React Router side). We treat
+// VITE_BETA_SITE_URL as the canonical React Router app origin: if the current
+// hostname matches it, we know we are inside the React Router app and SPA
+// navigation is safe. This intentionally allows the React Router app to be served
+// from either the beta subdomain (e.g. new.thunderstore.io) or the base
+// domain (e.g. thunderstore.dev in QA).
+// TODO: Remove usage of VITE_BETA_SITE_URL as the canonical React Router origin
+// once the React Router app is deployed to the base domain in production, and
+// update the name of the env variable to reflect its new purpose.
+export function shouldReloadDocument(
+  hostname = typeof window !== "undefined"
+    ? window.location.hostname
+    : undefined
+): boolean {
+  if (hostname === undefined) return false;
+  const { VITE_BETA_SITE_URL } = getPublicEnvVariables(["VITE_BETA_SITE_URL"]);
+  if (!VITE_BETA_SITE_URL) return false;
+  try {
+    return hostname !== new URL(VITE_BETA_SITE_URL).hostname;
+  } catch {
+    return false;
+  }
+}
+
 interface LinkProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement>,
     PropsWithChildren,
@@ -46,15 +75,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         {...fProps}
         className={className}
         ref={forwardedRef}
-        // TODO: Remove this when the site is deployed to full use. This here only to correct the link behaviour
-        // in "https://thunderstore.io/communities/" page as it's a Remix page that links to Django pages directly.
-        // Linking to Django pages wouldn't be a problem if there were not inconsistent expectations between the new. subdomain
-        // and the subdomainless Remix pages that are served. (At the time of writing it's only "https://thunderstore.io/communities/")
-        // For simplicity and time saving the new. subdomain is hardcoded here. If that subdomain is changed; this should be updated too.
-        reloadDocument={
-          typeof window !== "undefined" &&
-          !window.location.hostname.startsWith("new.")
-        }
+        reloadDocument={shouldReloadDocument()}
       >
         {children}
       </RRLink>

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/LinkLibrary.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/LinkLibrary.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as publicEnvVariables from "../../security/publicEnvVariables";
+import { shouldReloadDocument } from "../LinkLibrary";
+
+vi.mock("../../security/publicEnvVariables", () => ({
+  getPublicEnvVariables: vi.fn(),
+}));
+
+const mockGetPublicEnvVariables = vi.mocked(
+  publicEnvVariables.getPublicEnvVariables
+);
+
+describe("shouldReloadDocument", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when VITE_BETA_SITE_URL is not set", () => {
+    mockGetPublicEnvVariables.mockReturnValue({
+      VITE_BETA_SITE_URL: undefined,
+    });
+    expect(shouldReloadDocument("thunderstore.io")).toBe(false);
+  });
+
+  it("returns false when VITE_BETA_SITE_URL is an empty string", () => {
+    mockGetPublicEnvVariables.mockReturnValue({ VITE_BETA_SITE_URL: "" });
+    expect(shouldReloadDocument("thunderstore.io")).toBe(false);
+  });
+
+  it("returns false when hostname matches VITE_BETA_SITE_URL (same host)", () => {
+    mockGetPublicEnvVariables.mockReturnValue({
+      VITE_BETA_SITE_URL: "https://new.thunderstore.io",
+    });
+    expect(shouldReloadDocument("new.thunderstore.io")).toBe(false);
+  });
+
+  it("returns true when hostname differs from VITE_BETA_SITE_URL (different host)", () => {
+    mockGetPublicEnvVariables.mockReturnValue({
+      VITE_BETA_SITE_URL: "https://new.thunderstore.io",
+    });
+    expect(shouldReloadDocument("thunderstore.io")).toBe(true);
+  });
+
+  it("returns true when served from a completely different domain", () => {
+    mockGetPublicEnvVariables.mockReturnValue({
+      VITE_BETA_SITE_URL: "https://new.thunderstore.io",
+    });
+    expect(shouldReloadDocument("thunderstore.dev")).toBe(true);
+  });
+
+  it("returns false when VITE_BETA_SITE_URL is an invalid URL", () => {
+    mockGetPublicEnvVariables.mockReturnValue({
+      VITE_BETA_SITE_URL: "not-a-valid-url",
+    });
+    expect(shouldReloadDocument("thunderstore.io")).toBe(false);
+  });
+});


### PR DESCRIPTION
Previously the in-app Link wrapper forced reloadDocument on any host whose name didn't start with new., which broke PESPA navigation in QA where the Remix app is served from the base thunderstore.dev domain. Compare the current hostname against VITE_BETA_SITE_URL instead so the React Router app does client-side navigation wherever it is hosted, while still falling back to a full document load when all navigations are pointed to Django served paths.