### PR TITLE
refactor(cyberstorm-remix): avoid extra .data fetches on client nav

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -73,10 +73,7 @@ export const loader = ssrLoader(
   }
 );
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -88,7 +85,6 @@ export async function clientLoader({
     const community = dapper.getCommunity(params.communityId);
     return {
       community: community,
-      seo: (await serverLoader()).seo,
     };
   }
   throw new Response("Community not found", { status: 404 });

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -70,7 +70,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   request,
   params,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   if (params.communityId) {
     const tools = getSessionTools();
@@ -91,10 +90,7 @@ export async function clientLoader({
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
 
-    // Use the filters already fetched by the server so that React Router
-    // doesn't send an extra data request during client-side hydration
-    const serverData = await serverLoader();
-    const filters = serverData.filters;
+    const filters = await dapper.getCommunityFilters(params.communityId);
 
     const listingsPromise = (async () => {
       const finalSection = getSectionDefault(section, filters.sections);
@@ -118,7 +114,6 @@ export async function clientLoader({
     return {
       filters: filters,
       listings: listingsPromise,
-      seo: serverData.seo,
     };
   }
   throw new Response("Community not found", { status: 404 });

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -100,10 +100,7 @@ export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
   };
 });
 
-export async function clientLoader({
-  request,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const tools = getSessionTools();
   const dapper = new DapperTs(() => {
     return {
@@ -121,7 +118,6 @@ export async function clientLoader({
       order ?? SortOptions.Popular,
       search ?? ""
     ),
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -116,7 +116,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   request,
   params,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   if (params.communityId && params.packageId && params.namespaceId) {
     const tools = getSessionTools();
@@ -137,9 +136,17 @@ export async function clientLoader({
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
 
-    // Leverage identical data coming from serverLoader
-    const serverData = await serverLoader();
-    const filters = serverData.filters;
+    const filters = await dapper.getCommunityFilters(params.communityId);
+    const community = dapper.getCommunity(params.communityId);
+    const listing = await dapper.getPackageListingDetails(
+      params.communityId,
+      params.namespaceId,
+      params.packageId
+    );
+
+    if (!listing) {
+      throw new Response("Package not found", { status: 404 });
+    }
 
     const listingsPromise = (async () => {
       const finalSection = getSectionDefault(section, filters.sections);
@@ -163,11 +170,10 @@ export async function clientLoader({
     })();
 
     return {
-      community: serverData.community,
-      listing: serverData.listing,
+      community: community,
+      listing: listing,
       filters: filters,
       listings: listingsPromise,
-      seo: serverData.seo,
     };
   }
   throw new Response("Community not found", { status: 404 });

--- a/apps/cyberstorm-remix/app/p/packageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/packageEdit.tsx
@@ -52,7 +52,6 @@ export async function loader({ params }: Route.LoaderArgs) {
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   const { communityId, namespaceId, packageId } = params;
 
@@ -81,7 +80,7 @@ export async function clientLoader({
       throw new Response("Unauthorized", { status: 403 });
     }
 
-    return { listing, permissions, filters, seo: (await serverLoader()).seo };
+    return { listing, permissions, filters };
   } catch (error) {
     if (isApiError(error) && error.response.status === 404) {
       throw package404;

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -139,7 +139,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   const { communityId, namespaceId, packageId } = params;
 
@@ -178,7 +177,6 @@ export async function clientLoader({
     community_identifier: communityId,
     namespace_id: namespaceId,
     package_id: packageId,
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -106,7 +106,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   const { communityId, namespaceId, packageId, packageVersion } = params;
 
@@ -128,7 +127,6 @@ export async function clientLoader({
     listing,
     packageVersion,
     team: dapper.getTeamDetails(namespaceId),
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
+++ b/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
@@ -95,12 +95,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   throw new Response("Package not found", { status: 404 });
 }
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: LoaderFunctionArgs & {
-  serverLoader: () => ReturnType<typeof loader>;
-}) {
+export async function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -116,12 +111,10 @@ export async function clientLoader({
       params.packageVersion
     );
     const team = await dapper.getTeamDetails(params.namespaceId);
-    const sl = await serverLoader();
 
     return {
       version: version,
       team: team,
-      seo: sl.seo,
     };
   }
   throw new Response("Package not found", { status: 404 });

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -55,10 +55,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   };
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -71,7 +68,6 @@ export async function clientLoader({
 
   return {
     changelog: fetchChangelogSafe(dapper, params.namespaceId, params.packageId),
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -50,10 +50,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   };
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -68,14 +65,12 @@ export async function clientLoader({
         params.packageId,
         params.packageVersion
       ),
-      seo: (await serverLoader()).seo,
     };
   }
   return {
     status: "error",
     message: "Failed to load readme",
     readme: { html: "" },
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionWithoutCommunityReadme.tsx
@@ -49,12 +49,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   };
 }
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: LoaderFunctionArgs & {
-  serverLoader: () => Promise<ReturnType<typeof loader>>;
-}) {
+export async function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -69,14 +64,12 @@ export async function clientLoader({
         params.packageId,
         params.packageVersion
       ),
-      seo: (await serverLoader()).seo,
     };
   }
   return {
     status: "error",
     message: "Failed to load readme",
     readme: { html: "" },
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -57,10 +57,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   };
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {
     throw new Response("Not Found", { status: 404 });
   }
@@ -75,7 +72,6 @@ export async function clientLoader({
 
   return {
     readme: fetchReadmeSafe(dapper, params.namespaceId, params.packageId),
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -83,7 +83,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   const { communityId, namespaceId, packageId, packageVersion } = params;
 
@@ -113,7 +112,6 @@ export async function clientLoader({
       version,
       getPageFromUrl(request.url)
     ),
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -64,10 +64,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 }
 clientLoader.hydrate = true;
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -90,14 +87,12 @@ export async function clientLoader({
         status: null,
         source: source,
         message: undefined,
-        seo: (await serverLoader()).seo,
       };
     } catch (error) {
       result = {
         status: "error",
         source: undefined,
         message: "Analysis not available",
-        seo: (await serverLoader()).seo,
       };
       throw error;
     }
@@ -107,7 +102,6 @@ export async function clientLoader({
     status: "error",
     message: "Analysis not available",
     source: undefined,
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
@@ -56,12 +56,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   };
 }
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: LoaderFunctionArgs & {
-  serverLoader: () => Promise<ReturnType<typeof loader>>;
-}) {
+export async function clientLoader({ params }: LoaderFunctionArgs) {
   if (params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -74,14 +69,12 @@ export async function clientLoader({
       namespaceId: params.namespaceId,
       packageId: params.packageId,
       versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-      seo: (await serverLoader()).seo,
     };
   }
   return {
     status: "error",
     message: "Failed to load versions",
     versions: [],
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -59,10 +59,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   };
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -76,14 +73,12 @@ export async function clientLoader({
       namespaceId: params.namespaceId,
       packageId: params.packageId,
       versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
-      seo: (await serverLoader()).seo,
     };
   }
   return {
     status: "error",
     message: "Failed to load versions",
     versions: [],
-    seo: (await serverLoader()).seo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -76,10 +76,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   }
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -111,7 +108,6 @@ export async function clientLoader({
       packageId: params.packageId,
       slug: params.slug,
       permissions: permissions,
-      seo: (await serverLoader()).seo,
     };
   } else {
     throw new Error("Namespace ID or Package ID is missing");

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -106,10 +106,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   throw new Error("Namespace ID or Package ID is missing");
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
     const dapper = new DapperTs(() => {
@@ -119,15 +116,12 @@ export async function clientLoader({
       };
     });
 
-    const serverData = await serverLoader();
-
     let result: ResultType = {
       wiki: undefined,
       firstPage: undefined,
       communityId: params.communityId,
       namespaceId: params.namespaceId,
       packageId: params.packageId,
-      seo: serverData.seo,
     };
 
     try {
@@ -143,7 +137,6 @@ export async function clientLoader({
           communityId: params.communityId,
           namespaceId: params.namespaceId,
           packageId: params.packageId,
-          seo: serverData.seo,
         };
       } else {
         result = {
@@ -152,7 +145,6 @@ export async function clientLoader({
           communityId: params.communityId,
           namespaceId: params.namespaceId,
           packageId: params.packageId,
-          seo: serverData.seo,
         };
       }
     } catch (error) {
@@ -165,7 +157,6 @@ export async function clientLoader({
             communityId: params.communityId,
             namespaceId: params.namespaceId,
             packageId: params.packageId,
-            seo: serverData.seo,
           };
         } else {
           throw error;

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
@@ -50,7 +50,6 @@ export async function loader({ params }: Route.LoaderArgs) {
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {
     const tools = getSessionTools();
@@ -94,7 +93,6 @@ export async function clientLoader({
       communityId: params.communityId,
       namespaceId: params.namespaceId,
       packageId: params.packageId,
-      seo: (await serverLoader()).seo,
     };
   } else {
     throw new Error("Namespace ID or Package ID is missing");

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -116,10 +116,7 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   }
 });
 
-export async function clientLoader({
-  params,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (
     params.communityId &&
     params.namespaceId &&
@@ -134,15 +131,12 @@ export async function clientLoader({
       };
     });
 
-    const serverData = await serverLoader();
-
     let result: ResultType = {
       wiki: undefined,
       page: undefined,
       communityId: params.communityId,
       namespaceId: params.namespaceId,
       packageId: params.packageId,
-      seo: serverData.seo,
     };
 
     try {
@@ -158,7 +152,6 @@ export async function clientLoader({
           communityId: params.communityId,
           namespaceId: params.namespaceId,
           packageId: params.packageId,
-          seo: serverData.seo,
         };
         return result;
       }
@@ -169,7 +162,6 @@ export async function clientLoader({
         communityId: params.communityId,
         namespaceId: params.namespaceId,
         packageId: params.packageId,
-        seo: serverData.seo,
       };
     } catch (error) {
       if (isApiError(error)) {
@@ -181,7 +173,6 @@ export async function clientLoader({
             communityId: params.communityId,
             namespaceId: params.namespaceId,
             packageId: params.packageId,
-            seo: serverData.seo,
           };
         } else {
           throw error;

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -90,7 +90,6 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
 export async function clientLoader({
   params,
   request,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   if (
     params.communityId &&
@@ -150,7 +149,6 @@ export async function clientLoader({
       communityId: params.communityId,
       namespaceId: params.namespaceId,
       packageId: params.packageId,
-      seo: (await serverLoader()).seo,
     };
   } else {
     throw new Response("Namespace ID or Package ID is missing", {

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -91,7 +91,6 @@ export const loader = ssrLoader(
 export async function clientLoader({
   request,
   params,
-  serverLoader,
 }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId) {
     const tools = getSessionTools();
@@ -112,9 +111,9 @@ export async function clientLoader({
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
 
-    const serverData = await serverLoader();
-    const filters = serverData.filters;
-    const community = serverData.community;
+    const filters = await dapper.getCommunityFilters(params.communityId);
+    // Community is required for the breadcrumbs in the root layout
+    const community = dapper.getCommunity(params.communityId);
 
     const listingsPromise = (async () => {
       const finalSection = getSectionDefault(section, filters.sections);
@@ -139,10 +138,8 @@ export async function clientLoader({
     return {
       teamId: params.namespaceId,
       filters: filters,
-      // Community is required for the breadcrumbs in the root layout
       community: community,
       listings: listingsPromise,
-      seo: serverData.seo,
     };
   }
   throw new Response("Community not found", { status: 404 });

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -100,6 +100,20 @@ export type OutletContextShape = {
   dapper: DapperTs;
 };
 
+const rootSeo = createSeo({
+  descriptors: [
+    { title: "Thunderstore" },
+    {
+      name: "description",
+      content: "A ecosystem for sharing mods for games!",
+    },
+    { name: "msapplication-TileColor", content: "#29295b" },
+    { name: "theme-color", content: "#29295b" },
+    { charSet: "utf-8" },
+    { name: "viewport", content: "width=device-width, initial-scale=1" },
+  ],
+});
+
 export async function loader() {
   return {
     publicEnvVariables: getPublicEnvVariables([
@@ -116,26 +130,11 @@ export async function loader() {
       apiHost: getApiHostForSsr(),
       sessionId: undefined,
     },
-    seo: createSeo({
-      descriptors: [
-        { title: "Thunderstore" },
-        {
-          name: "description",
-          content: "A ecosystem for sharing mods for games!",
-        },
-        { name: "msapplication-TileColor", content: "#29295b" },
-        { name: "theme-color", content: "#29295b" },
-        { charSet: "utf-8" },
-        { name: "viewport", content: "width=device-width, initial-scale=1" },
-      ],
-    }),
+    seo: rootSeo,
   };
 }
 
-export async function clientLoader({
-  request,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const publicEnvVariables = getPublicEnvVariables([
     "VITE_SITE_URL",
     "VITE_BETA_SITE_URL",
@@ -186,7 +185,7 @@ export async function clientLoader({
     publicEnvVariables: publicEnvVariables,
     currentUser: currentUser.username ? currentUser : undefined,
     config,
-    seo: (await serverLoader()).seo,
+    seo: rootSeo,
   };
 }
 

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -82,10 +82,7 @@ export const loader = ssrLoader(async () => {
   };
 });
 
-export async function clientLoader({
-  request,
-  serverLoader,
-}: Route.ClientLoaderArgs) {
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const tools = getSessionTools();
   const currentUser = await tools?.getSessionCurrentUser(true);
 
@@ -94,7 +91,13 @@ export async function clientLoader({
     return redirectToLogin(url.pathname + url.search + url.hash);
   }
 
-  const communities = await serverLoader();
+  const dapper = new DapperTs(() => {
+    return {
+      apiHost: tools?.getConfig().apiHost,
+      sessionId: tools?.getConfig().sessionId,
+    };
+  });
+  const communities = await dapper.getCommunities();
   return communities;
 }
 


### PR DESCRIPTION
clientLoaders were awaiting serverLoader() just to copy the `seo`
field, triggering a round-trip to the SSR endpoint on every client-
side navigation. Drop `seo` from clientLoaders and rely on the
nearest ancestor's SEO (root hoists a static `rootSeo` shared with
its loader). Where clientLoaders also reused other server-computed
fields, fetch them directly via dapper instead.