### PR TITLE
Fix Footer element ordering on mobile widths

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -19,6 +19,7 @@
     "import-notation": "string",
     "number-max-precision": 3,
     "custom-property-pattern": null,
+    "property-no-unknown": [true, { "ignoreProperties": ["reading-flow"] }],
     "selector-class-pattern": null,
     "selector-id-pattern": null,
     "selector-no-vendor-prefix": null,

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.css
@@ -228,6 +228,15 @@
   @media (width <= 72rem) {
     .footer__content {
       flex-direction: column;
+      reading-flow: flex-visual;
+    }
+
+    .footer__info {
+      reading-flow: flex-visual;
+    }
+
+    .footer__company {
+      order: 1;
     }
 
     .footer__links,
@@ -260,6 +269,7 @@
       gap: var(--gap-xs);
       align-items: flex-start;
       align-self: stretch;
+      order: -1;
       width: 100%;
       padding: 3rem var(--space-24) 0;
     }


### PR DESCRIPTION
Use reading-flow to reorder the Footer elements on narrower widths