### PR TITLE
Add readme upload preview

### DIFF
--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -37,6 +37,7 @@ import {
   useSubmissionStatusPolling,
   useUploadCategoryOptions,
 } from "./uploadHooks";
+import UploadPreview from "./uploadPreview";
 import {
   type UploadFormFieldAction,
   buildCommunityOptions,
@@ -392,6 +393,7 @@ export default function Upload() {
             />
           ) : null}
         </FormSections>
+        <UploadPreview file={file} />
       </section>
     </>
   );

--- a/apps/cyberstorm-remix/app/upload/uploadPreview.tsx
+++ b/apps/cyberstorm-remix/app/upload/uploadPreview.tsx
@@ -1,0 +1,66 @@
+import { strFromU8, unzipSync } from "fflate";
+import { useEffect, useState } from "react";
+import { Markdown } from "~/commonComponents/Markdown/Markdown";
+
+import { Heading } from "@thunderstore/cyberstorm";
+
+const MAX_PREVIEW_BYTES = 100 * 1024 * 1024; // 100 MB
+
+export default function UploadPreview({ file }: { file: File | null }) {
+  const [readme, setReadme] = useState<string | null>(null);
+  const [changelog, setChangelog] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!file) {
+      setReadme(null);
+      setChangelog(null);
+      return;
+    }
+
+    if (file.size > MAX_PREVIEW_BYTES) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = new Uint8Array(reader.result as ArrayBuffer);
+        const unzipped = unzipSync(data);
+        const readmeFile = Object.keys(unzipped).find(
+          (name) => name === "README.md"
+        );
+        const changelogFile = Object.keys(unzipped).find(
+          (name) => name === "CHANGELOG.md"
+        );
+        if (readmeFile) {
+          setReadme(strFromU8(unzipped[readmeFile]));
+        }
+        if (changelogFile) {
+          setChangelog(strFromU8(unzipped[changelogFile]));
+        }
+      } catch (e) {}
+    };
+    reader.readAsArrayBuffer(file);
+  }, [file]);
+
+  return (
+    <div>
+      {readme && (
+        <div>
+          <Heading csLevel="2" csSize="2" style={{ margin: "2rem 0" }}>
+            Readme Preview
+          </Heading>
+          <Markdown input={readme} />
+        </div>
+      )}
+      {changelog && (
+        <div>
+          <Heading csLevel="2" csSize="2" style={{ margin: "2rem 0" }}>
+            Changelog Preview
+          </Heading>
+          <Markdown input={changelog} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.36.1",
+    "fflate": "^0.8.3",
     "globals": "^16.4.0",
     "plop": "^4.0.1",
     "prettier": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5736,6 +5736,11 @@ fdir@^6.5.0:
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
+  integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
+
 file-entry-cache@^11.1.1:
   version "11.1.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz#728918c624dbeb09372276837ea0c413ec78806b"


### PR DESCRIPTION
Port of thunderstore-io/Thunderstore#1285 to the new UI.

Since this project doesn't have a zip extraction yet, I arbitrary choose fflate. I think it still makes sense to extract the zip locally to show the readme and changelog, instead of dancing with the backend.

<img width="949" height="785" alt="image" src="https://github.com/user-attachments/assets/4ec673e9-f9c0-4932-85ca-9bc91645e05d" />
