### PR TITLE
Refine upload page UX with submit-time uploads, clearer progress stat…

### DIFF
--- a/apps/cyberstorm-remix/app/upload/Upload.css
+++ b/apps/cyberstorm-remix/app/upload/Upload.css
@@ -1,7 +1,26 @@
 @layer nimbus-layout {
+  .upload {
+    gap: var(--gap-xl);
+  }
+
+  .upload__helper-alerts {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    align-self: stretch;
+  }
+
+  .upload__helper-text {
+    margin: 0;
+  }
+
+  .upload__helper-text + .upload__helper-text {
+    margin-top: var(--gap-xs);
+  }
+
   .upload__no-teams {
     display: flex;
-    gap: 4px;
+    gap: var(--gap-2xs);
     align-items: center;
   }
 
@@ -27,81 +46,22 @@
     font-size: var(--font-size-body-md);
   }
 
-  .drag-n-drop {
-    display: flex;
-    flex: 1 0 0;
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: center;
-    align-self: stretch;
-    justify-content: center;
-    padding: 1.5rem 2rem;
-    border: 2px dashed var(--color-surface-a9);
-
-    border-radius: var(--radius-md);
-    background: var(--color-surface-a4);
-
-    cursor: pointer;
-  }
-
-  .drag-n-drop--success {
-    border: 2px solid var(--color-cyber-green-7);
-    background: var(--color-surface-1);
-  }
-
-  .drag-n-drop--error {
-    border: 2px solid var(--color-accent-red-7);
-    background: var(--color-surface-1);
+  .upload__category-placeholder {
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-body-md);
   }
 
   .upload__alert {
     align-self: stretch;
   }
 
-  .drag-n-drop__body {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: center;
-    justify-content: center;
+  .upload__helper-text a:hover {
+    text-decoration-thickness: 2px;
   }
 
-  .drag-n-drop__icon {
-    display: flex;
-    flex-direction: column;
-    flex-shrink: 0;
-    justify-content: center;
-    width: 2.25rem;
-    height: 2.25rem;
-  }
-
-  .drag-n-drop__main-text {
-    color: var(--color-text-primary);
-    font-weight: var(--font-weight-bold);
-
-    font-size: var(--font-size-body-lg);
-    text-align: center;
-  }
-
-  .drag-n-drop__sub-text {
-    color: var(--color-text-tertiary);
-    font-weight: var(--font-weight-medium);
-
-    font-size: var(--font-size-body-md);
-    text-align: center;
-  }
-
-  .drag-n-drop__remove-button {
-    color: var(--color-text-tertiary);
-    font-weight: var(--font-weight-regular);
-    font-size: var(--font-size-body-md);
-    background: transparent;
-    text-decoration-line: underline;
-    text-decoration-style: solid;
-    text-decoration-skip-ink: none;
-    text-decoration-thickness: auto;
-    text-underline-offset: auto;
-    text-underline-position: from-font;
+  .upload__buttons .new-button:hover:not(:disabled) {
+    filter: brightness(1.05);
   }
 
   .upload__nsfw-switch {
@@ -125,27 +85,23 @@
     align-self: stretch;
   }
 
-  .upload__processing {
-    color: var(--color-text-tertiary);
-    font-weight: var(--font-weight-medium);
-    font-size: var(--font-size-body-md);
-  }
-
   .submission__status {
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
   }
 
-  .submission__status-item {
+  .upload__upload-indicator {
     display: flex;
-    flex: 1 1 0;
-    flex-direction: row;
-    gap: var(--gap-md);
-    align-items: center;
-    padding: 1rem;
-    border: 1px solid var(--color-surface-a9);
-    border-radius: var(--radius-md);
-    background-color: var(--color-surface-a4);
+    flex-direction: column;
+    gap: var(--gap-xs);
+    align-self: stretch;
+  }
+
+  .upload__upload-indicator-label {
+    margin: 0;
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-body-md);
   }
 }

--- a/apps/cyberstorm-remix/app/upload/__tests__/uploadHooks.test.ts
+++ b/apps/cyberstorm-remix/app/upload/__tests__/uploadHooks.test.ts
@@ -102,7 +102,7 @@ describe("usePackageFileUpload", () => {
     unmount();
   });
 
-  it("starts multipart upload for valid zip files", async () => {
+  it("does not start upload on file select", async () => {
     const requestConfig = vi.fn(() => ({
       apiHost: "https://api.example.com",
     }));
@@ -122,7 +122,36 @@ describe("usePackageFileUpload", () => {
 
     await act(async () => {
       await Promise.resolve();
-      await Promise.resolve();
+    });
+
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(latest?.isDone).toBe(false);
+    expect(latest?.usermedia).toBeUndefined();
+    expect(latest?.uploadError).toBeNull();
+
+    unmount();
+  });
+
+  it("starts multipart upload when startUpload is called", async () => {
+    const requestConfig = vi.fn(() => ({
+      apiHost: "https://api.example.com",
+    }));
+
+    let latest: ReturnType<typeof usePackageFileUpload> | undefined;
+
+    function Harness() {
+      latest = usePackageFileUpload(requestConfig);
+      return null;
+    }
+
+    const unmount = render(React.createElement(Harness));
+
+    act(() => {
+      latest?.selectFile(zipFile());
+    });
+
+    await act(async () => {
+      await latest?.startUpload();
     });
 
     expect(mockStart).toHaveBeenCalledTimes(1);
@@ -133,7 +162,7 @@ describe("usePackageFileUpload", () => {
     unmount();
   });
 
-  it("surfaces missing API host configuration", async () => {
+  it("surfaces missing API host configuration on submit-triggered upload", async () => {
     const requestConfig = vi.fn(() => ({
       apiHost: "",
     })) as unknown as Parameters<typeof usePackageFileUpload>[0];
@@ -152,8 +181,9 @@ describe("usePackageFileUpload", () => {
     });
 
     await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+      await expect(latest?.startUpload()).rejects.toThrow(
+        "API host is not configured"
+      );
     });
 
     expect(latest?.uploadError).toBe("API host is not configured");
@@ -166,6 +196,7 @@ describe("usePackageFileUpload", () => {
     const requestConfig = vi.fn(() => ({
       apiHost: "https://api.example.com",
     }));
+    mockStart.mockImplementation(() => new Promise<void>(() => undefined));
 
     let latest: ReturnType<typeof usePackageFileUpload> | undefined;
 
@@ -181,7 +212,7 @@ describe("usePackageFileUpload", () => {
     });
 
     await act(async () => {
-      await Promise.resolve();
+      void latest?.startUpload();
       await Promise.resolve();
     });
 

--- a/apps/cyberstorm-remix/app/upload/__tests__/uploadUtils.test.ts
+++ b/apps/cyberstorm-remix/app/upload/__tests__/uploadUtils.test.ts
@@ -5,6 +5,7 @@ import {
   formatBytes,
   getSubmissionErrorMessages,
   getSubmissionErrorsBySection,
+  getUploadProgressPercent,
   isPackageZipFile,
   isUploadResetDisabled,
   isUploadSubmitDisabled,
@@ -115,12 +116,13 @@ describe("formatBytes", () => {
 });
 
 describe("isUploadSubmitDisabled", () => {
-  it("is disabled while submitting, pending, missing upload, or no communities", () => {
+  it("is disabled while submitting, pending, missing team/file, or no communities", () => {
     expect(
       isUploadSubmitDisabled({
         submitting: true,
         submissionPending: false,
-        uploadUuid: "uuid",
+        authorName: "TeamA",
+        hasSelectedFile: true,
         communitiesCount: 1,
       })
     ).toBe(true);
@@ -129,7 +131,8 @@ describe("isUploadSubmitDisabled", () => {
       isUploadSubmitDisabled({
         submitting: false,
         submissionPending: true,
-        uploadUuid: "uuid",
+        authorName: "TeamA",
+        hasSelectedFile: true,
         communitiesCount: 1,
       })
     ).toBe(true);
@@ -138,7 +141,8 @@ describe("isUploadSubmitDisabled", () => {
       isUploadSubmitDisabled({
         submitting: false,
         submissionPending: false,
-        uploadUuid: undefined,
+        authorName: "",
+        hasSelectedFile: true,
         communitiesCount: 1,
       })
     ).toBe(true);
@@ -147,18 +151,30 @@ describe("isUploadSubmitDisabled", () => {
       isUploadSubmitDisabled({
         submitting: false,
         submissionPending: false,
-        uploadUuid: "uuid",
+        authorName: "TeamA",
+        hasSelectedFile: false,
+        communitiesCount: 1,
+      })
+    ).toBe(true);
+
+    expect(
+      isUploadSubmitDisabled({
+        submitting: false,
+        submissionPending: false,
+        authorName: "TeamA",
+        hasSelectedFile: true,
         communitiesCount: 0,
       })
     ).toBe(true);
   });
 
-  it("is enabled when upload and communities are ready", () => {
+  it("is enabled when team, file, and communities are ready", () => {
     expect(
       isUploadSubmitDisabled({
         submitting: false,
         submissionPending: false,
-        uploadUuid: "uuid",
+        authorName: "TeamA",
+        hasSelectedFile: true,
         communitiesCount: 2,
       })
     ).toBe(false);
@@ -203,6 +219,27 @@ describe("getSubmissionErrorsBySection", () => {
     expect(sections.communities).toEqual(["Invalid community selection"]);
     expect(sections.categories).toEqual(["Unknown category slug"]);
     expect(sections.submit).toEqual(["Server error"]);
+  });
+});
+
+describe("getUploadProgressPercent", () => {
+  it("returns 0 when progress is missing or total is zero", () => {
+    expect(getUploadProgressPercent(undefined)).toBe(0);
+    expect(
+      getUploadProgressPercent({
+        total: 0,
+        complete: 0,
+      } as Parameters<typeof getUploadProgressPercent>[0])
+    ).toBe(0);
+  });
+
+  it("returns percentage from complete and total bytes", () => {
+    expect(
+      getUploadProgressPercent({
+        total: 200,
+        complete: 50,
+      } as Parameters<typeof getUploadProgressPercent>[0])
+    ).toBe(25);
   });
 });
 

--- a/apps/cyberstorm-remix/app/upload/components/SubmissionProcessingSkeleton.css
+++ b/apps/cyberstorm-remix/app/upload/components/SubmissionProcessingSkeleton.css
@@ -1,0 +1,64 @@
+@layer nimbus-layout {
+  .submission-processing__header {
+    display: flex;
+    gap: var(--gap-md);
+    align-items: flex-start;
+  }
+
+  .submission-processing__icon {
+    flex-shrink: 0;
+    width: 4rem;
+    height: 4rem;
+
+    --skeleton-radius: var(--radius-md);
+  }
+
+  .submission-processing__header-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    min-width: 0;
+  }
+
+  .submission-processing__title {
+    width: 40%;
+    height: 1.5rem;
+  }
+
+  .submission-processing__description {
+    width: 75%;
+    height: 1rem;
+  }
+
+  .submission-processing__table {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    margin-top: var(--gap-lg);
+  }
+
+  .submission-processing__table-heading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-xs);
+  }
+
+  .submission-processing__table-subtitle {
+    width: 55%;
+    height: 1rem;
+  }
+
+  .submission-processing__rows {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+  }
+
+  .submission-processing__row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--gap-md);
+    height: 1.25rem;
+  }
+}

--- a/apps/cyberstorm-remix/app/upload/components/SubmissionProcessingSkeleton.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/SubmissionProcessingSkeleton.tsx
@@ -1,0 +1,49 @@
+import { Heading, SkeletonBox } from "@thunderstore/cyberstorm";
+
+import "./SubmissionProcessingSkeleton.css";
+
+const SKELETON_ROW_COUNT = 3;
+
+export function SubmissionProcessingSkeleton() {
+  return (
+    <div
+      className="container container--y container--full island submission-processing"
+      aria-busy="true"
+      aria-label="Processing submission"
+    >
+      <div className="submission-processing__header">
+        <div className="submission-processing__icon">
+          <SkeletonBox />
+        </div>
+        <div className="submission-processing__header-content">
+          <div className="submission-processing__title">
+            <SkeletonBox />
+          </div>
+          <div className="submission-processing__description">
+            <SkeletonBox />
+          </div>
+        </div>
+      </div>
+
+      <div className="submission-processing__table">
+        <div className="submission-processing__table-heading">
+          <Heading csLevel="3" csSize="3">
+            Processing…
+          </Heading>
+          <div className="submission-processing__table-subtitle">
+            <SkeletonBox />
+          </div>
+        </div>
+        <div className="submission-processing__rows">
+          {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+            <div key={index} className="submission-processing__row">
+              <SkeletonBox />
+              <SkeletonBox />
+              <SkeletonBox />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/cyberstorm-remix/app/upload/components/SubmissionResult.css
+++ b/apps/cyberstorm-remix/app/upload/components/SubmissionResult.css
@@ -1,0 +1,7 @@
+@layer nimbus-layout {
+  .submission-result__categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gap-2xs);
+  }
+}

--- a/apps/cyberstorm-remix/app/upload/components/SubmissionResult.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/SubmissionResult.tsx
@@ -12,6 +12,7 @@ import {
 import { type PackageSubmissionResult } from "@thunderstore/dapper/types";
 
 import { PageHeader } from "../../commonComponents/PageHeader/PageHeader";
+import "./SubmissionResult.css";
 
 export interface SubmissionResultProps {
   submissionStatusResult: PackageSubmissionResult;
@@ -107,11 +108,15 @@ export function SubmissionResult({
             sortValue: v.url,
           },
           {
-            value: v.categories.map((c) => (
-              <NewTag key={c.slug} csSize="small">
-                {c.name}
-              </NewTag>
-            )),
+            value: (
+              <div className="submission-result__categories">
+                {v.categories.map((c) => (
+                  <NewTag key={c.slug} csSize="small">
+                    {c.name}
+                  </NewTag>
+                ))}
+              </div>
+            ),
             sortValue: v.categories.map((c) => c.name).join(", "),
           },
         ])}

--- a/apps/cyberstorm-remix/app/upload/components/UploadCategoriesSection.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/UploadCategoriesSection.tsx
@@ -30,6 +30,11 @@ export function UploadCategoriesSection({
       description="Select descriptive categories to help people discover your package."
     >
       <SectionErrors errors={sectionErrors} />
+      {communities.length === 0 ? (
+        <p className="upload__category-placeholder">
+          Select a community to view available categories
+        </p>
+      ) : null}
       {communities.map((community) => {
         const communityData = communityResults.find(
           (c) => c.identifier === community

--- a/apps/cyberstorm-remix/app/upload/components/UploadFileSection.css
+++ b/apps/cyberstorm-remix/app/upload/components/UploadFileSection.css
@@ -1,0 +1,93 @@
+@layer nimbus-layout {
+  .drag-n-drop {
+    display: flex;
+    flex: 1 0 0;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+    align-self: stretch;
+    justify-content: center;
+    padding: 1.5rem 2rem;
+    border: 2px dashed var(--color-surface-a9);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-a4);
+    cursor: pointer;
+    transition:
+      border-color var(--animation-duration-xs) ease,
+      background-color var(--animation-duration-xs) ease,
+      box-shadow var(--animation-duration-xs) ease,
+      transform var(--animation-duration-xs) ease;
+  }
+
+  .drag-n-drop.dnd-file-input--dragging,
+  .drag-n-drop--success {
+    border-color: var(--color-cyber-green-7);
+    background: var(--color-surface-1);
+  }
+
+  .drag-n-drop.dnd-file-input--dragging {
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--color-cyber-green-7) 22%, transparent);
+    transform: scale(1.01);
+  }
+
+  .drag-n-drop:not(.drag-n-drop--success):hover {
+    border-color: var(--color-surface-a11);
+    background: var(--color-surface-a3);
+  }
+
+  .drag-n-drop--error {
+    border-color: var(--color-accent-red-7);
+    background: var(--color-surface-1);
+  }
+
+  .drag-n-drop__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .drag-n-drop__icon {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+
+  .drag-n-drop__main-text {
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-body-lg);
+  }
+
+  .drag-n-drop__sub-text {
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-body-md);
+  }
+
+  .drag-n-drop__remove-button {
+    padding: 0;
+    border: 0;
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-body-md);
+    line-height: inherit;
+    text-decoration: underline;
+    background: transparent;
+    cursor: pointer;
+    transition: color var(--animation-duration-xs) ease;
+  }
+
+  .drag-n-drop__remove-button:hover {
+    color: var(--color-text-primary);
+  }
+
+  .drag-n-drop__remove-button:focus-visible {
+    outline: 2px solid var(--color-cyber-green-7);
+    outline-offset: 2px;
+  }
+
+  .drag-n-drop:hover .drag-n-drop__remove-button {
+    color: var(--color-text-primary);
+  }
+}

--- a/apps/cyberstorm-remix/app/upload/components/UploadFileSection.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/UploadFileSection.tsx
@@ -14,12 +14,12 @@ import type { IBaseUploadHandle } from "@thunderstore/ts-uploader";
 import { FormSection } from "../../commonComponents/FormSection/FormSection";
 import { PACKAGE_ZIP_ACCEPT, formatBytes } from "../uploadUtils";
 import { SectionErrors } from "./SectionErrors";
+import "./UploadFileSection.css";
 
 export interface UploadFileSectionProps {
   file: File | null;
   uploadError: string | null;
   handle?: IBaseUploadHandle;
-  isDone: boolean;
   sectionErrors: string[];
   fileInputRef: RefObject<HTMLInputElement | null>;
   onFileChange: (file: File | null) => void;
@@ -30,7 +30,6 @@ export function UploadFileSection({
   file,
   uploadError,
   handle,
-  isDone,
   sectionErrors,
   fileInputRef,
   onFileChange,
@@ -44,7 +43,7 @@ export function UploadFileSection({
       <DnDFileInput
         rootClasses={classnames(
           "drag-n-drop",
-          uploadError ? "drag-n-drop--error" : null,
+          file && uploadError ? "drag-n-drop--error" : null,
           file && !uploadError ? "drag-n-drop--success" : null
         )}
         name="file"
@@ -85,7 +84,12 @@ export function UploadFileSection({
                   </>
                 )}
                 <button
+                  type="button"
                   className="drag-n-drop__remove-button"
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
                   onClick={(e) => {
                     e.stopPropagation();
                     e.preventDefault();
@@ -101,7 +105,7 @@ export function UploadFileSection({
                   <FontAwesomeIcon icon={faFileZip} />
                 </NewIcon>
                 <span className="drag-n-drop__main-text">
-                  Drag and drop your ZIP file here
+                  Choose or drag ZIP file here
                 </span>
                 <span className="drag-n-drop__sub-text">5GB max</span>
               </>
@@ -113,26 +117,26 @@ export function UploadFileSection({
             <NewIcon wrapperClasses="drag-n-drop__icon" csVariant="accent">
               <FontAwesomeIcon icon={faTreasureChest} />
             </NewIcon>
+            <span className="drag-n-drop__main-text">Drop ZIP file here</span>
             {file ? (
-              <span>{file.name}</span>
-            ) : (
-              <span className="drag-n-drop__main-text">Drag file here</span>
-            )}
+              <span className="drag-n-drop__sub-text">{file.name}</span>
+            ) : null}
+            <span className="drag-n-drop__sub-text">5GB max</span>
           </div>
         }
         onChange={(files) => {
-          onFileChange(files.item(0));
+          const nextFile = files.item(0);
+          if (nextFile) {
+            onFileChange(nextFile);
+          }
         }}
-        readonly={!!handle}
+        readonly={!!handle || !!file}
         fileInputRef={fileInputRef}
       />
       {uploadError ? (
         <NewAlert csVariant="danger" rootClasses="upload__alert">
           {uploadError}
         </NewAlert>
-      ) : null}
-      {handle && !isDone ? (
-        <p className="upload__processing">Uploading…</p>
       ) : null}
       <SectionErrors errors={sectionErrors} />
     </FormSection>

--- a/apps/cyberstorm-remix/app/upload/components/UploadProgressBar.css
+++ b/apps/cyberstorm-remix/app/upload/components/UploadProgressBar.css
@@ -1,0 +1,45 @@
+@layer nimbus-layout {
+  .upload-progress {
+    align-self: stretch;
+    width: 100%;
+    height: 0.5rem;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background: var(--color-skeleton-bg-color);
+  }
+
+  .upload-progress__bar {
+    height: 100%;
+    border-radius: var(--radius-sm);
+    background-color: var(--color-accent-blue-7);
+    background-image: linear-gradient(
+      45deg,
+      rgb(255 255 255 / 0.15) 25%,
+      transparent 25%,
+      transparent 50%,
+      rgb(255 255 255 / 0.15) 50%,
+      rgb(255 255 255 / 0.15) 75%,
+      transparent 75%,
+      transparent
+    );
+    background-size: 1rem 1rem;
+    transition: width 0.15s ease-out;
+    animation: upload-progress-stripes 1s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .upload-progress__bar {
+      animation: none;
+    }
+  }
+
+  @keyframes upload-progress-stripes {
+    from {
+      background-position: 1rem 0;
+    }
+
+    to {
+      background-position: 0 0;
+    }
+  }
+}

--- a/apps/cyberstorm-remix/app/upload/components/UploadProgressBar.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/UploadProgressBar.tsx
@@ -1,0 +1,29 @@
+import "./UploadProgressBar.css";
+
+export interface UploadProgressBarProps {
+  progress: number;
+  labelId?: string;
+}
+
+export function UploadProgressBar({
+  progress,
+  labelId,
+}: UploadProgressBarProps) {
+  const value = Math.min(100, Math.max(0, Math.trunc(progress)));
+
+  return (
+    <div
+      className="upload-progress"
+      role="progressbar"
+      {...(labelId
+        ? { "aria-labelledby": labelId }
+        : { "aria-label": "Upload progress" })}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value}
+      aria-valuetext={`${value}%`}
+    >
+      <div className="upload-progress__bar" style={{ width: `${value}%` }} />
+    </div>
+  );
+}

--- a/apps/cyberstorm-remix/app/upload/components/UploadSubmissionStatus.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/UploadSubmissionStatus.tsx
@@ -3,36 +3,41 @@ import type { PackageSubmissionStatus } from "@thunderstore/dapper/types";
 
 import { FormSectionSeparator } from "../../commonComponents/FormSection/FormSection";
 import { SectionErrors } from "./SectionErrors";
+import { SubmissionProcessingSkeleton } from "./SubmissionProcessingSkeleton";
 import { SubmissionResult } from "./SubmissionResult";
 
 export interface UploadSubmissionStatusProps {
-  submissionStatus: PackageSubmissionStatus;
+  submitting: boolean;
+  submissionStatus?: PackageSubmissionStatus;
   pollingError: string | null;
   submitSectionErrors: string[];
   onRetryPolling: () => void;
 }
 
 export function UploadSubmissionStatus({
+  submitting,
   submissionStatus,
   pollingError,
   submitSectionErrors,
   onRetryPolling,
 }: UploadSubmissionStatusProps) {
-  const showRetryPolling =
-    submissionStatus.status === "PENDING" || pollingError != null;
+  const showProcessing =
+    submitting ||
+    (submissionStatus?.status === "PENDING" && !submissionStatus.result);
 
   return (
     <>
       <FormSectionSeparator />
       <div className="submission__status">
         <SectionErrors errors={submitSectionErrors} />
-        {submissionStatus.result ? (
+        {submissionStatus?.result ? (
           <SubmissionResult submissionStatusResult={submissionStatus.result} />
         ) : null}
-        {showRetryPolling ? (
+        {showProcessing ? <SubmissionProcessingSkeleton /> : null}
+        {!showProcessing && pollingError != null ? (
           <NewButton onClick={onRetryPolling}>Retry Status Check</NewButton>
         ) : null}
-        {pollingError ? (
+        {!showProcessing && pollingError ? (
           <NewAlert csVariant="danger" rootClasses="upload__alert">
             {pollingError}
           </NewAlert>

--- a/apps/cyberstorm-remix/app/upload/components/UploadSubmitSection.tsx
+++ b/apps/cyberstorm-remix/app/upload/components/UploadSubmitSection.tsx
@@ -3,6 +3,7 @@ import type { PackageSubmissionStatus } from "@thunderstore/dapper/types";
 
 import { FormSection } from "../../commonComponents/FormSection/FormSection";
 import { isUploadResetDisabled } from "../uploadUtils";
+import { UploadProgressBar } from "./UploadProgressBar";
 
 export interface UploadSubmitSectionProps {
   submitError: string | null;
@@ -10,6 +11,8 @@ export interface UploadSubmitSectionProps {
   submissionStatus?: PackageSubmissionStatus;
   hasSubmissionFormErrors: boolean;
   submitDisabled: boolean;
+  isUploading: boolean;
+  uploadProgressPercent: number;
   onReset: () => void;
   onSubmit: () => void;
 }
@@ -20,6 +23,8 @@ export function UploadSubmitSection({
   submissionStatus,
   hasSubmissionFormErrors,
   submitDisabled,
+  isUploading,
+  uploadProgressPercent,
   onReset,
   onSubmit,
 }: UploadSubmitSectionProps) {
@@ -27,6 +32,10 @@ export function UploadSubmitSection({
     submitting: strongFormSubmitting,
     submissionPending: submissionStatus?.status === "PENDING",
   });
+  const displayUploadProgressPercent = Math.min(
+    100,
+    Math.max(0, Math.trunc(uploadProgressPercent))
+  );
 
   return (
     <FormSection
@@ -68,6 +77,20 @@ export function UploadSubmitSection({
               : "Submit"}
         </NewButton>
       </div>
+      {isUploading ? (
+        <div className="upload__upload-indicator">
+          <UploadProgressBar
+            progress={displayUploadProgressPercent}
+            labelId="upload-progress-label"
+          />
+          <p
+            id="upload-progress-label"
+            className="upload__upload-indicator-label"
+          >
+            Uploading… {displayUploadProgressPercent}%
+          </p>
+        </div>
+      ) : null}
     </FormSection>
   );
 }

--- a/apps/cyberstorm-remix/app/upload/components/__tests__/SectionErrors.test.ts
+++ b/apps/cyberstorm-remix/app/upload/components/__tests__/SectionErrors.test.ts
@@ -22,7 +22,11 @@ vi.mock("@thunderstore/cyberstorm", () => ({
   }) =>
     React.createElement(
       "div",
-      { "data-variant": csVariant, "data-testid": "alert" },
+      {
+        role: "alert",
+        "data-variant": csVariant,
+        "data-testid": "alert",
+      },
       children
     ),
 }));

--- a/apps/cyberstorm-remix/app/upload/components/__tests__/UploadSubmissionStatus.test.ts
+++ b/apps/cyberstorm-remix/app/upload/components/__tests__/UploadSubmissionStatus.test.ts
@@ -45,6 +45,13 @@ vi.mock("../SubmissionResult", () => ({
     React.createElement("div", { "data-testid": "submission-result" }),
 }));
 
+vi.mock("../SubmissionProcessingSkeleton", () => ({
+  SubmissionProcessingSkeleton: () =>
+    React.createElement("div", {
+      "data-testid": "submission-processing-skeleton",
+    }),
+}));
+
 function render(element: React.ReactElement) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -81,24 +88,39 @@ function asStatus(
 }
 
 describe("UploadSubmissionStatus", () => {
-  it("shows retry button while submission is pending", () => {
-    const onRetryPolling = vi.fn();
+  it("shows processing skeleton while submission is pending", () => {
     const { container, unmount } = render(
       React.createElement(UploadSubmissionStatus, {
+        submitting: false,
         submissionStatus: asStatus("PENDING"),
         pollingError: null,
         submitSectionErrors: [],
-        onRetryPolling,
+        onRetryPolling: vi.fn(),
       })
     );
 
-    const retryButton = container.querySelector("button");
-    expect(retryButton?.textContent).toBe("Retry Status Check");
+    expect(
+      container.querySelector("[data-testid='submission-processing-skeleton']")
+    ).not.toBeNull();
+    expect(container.querySelector("button")).toBeNull();
 
-    act(() => {
-      retryButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    expect(onRetryPolling).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("shows processing skeleton while form is submitting", () => {
+    const { container, unmount } = render(
+      React.createElement(UploadSubmissionStatus, {
+        submitting: true,
+        pollingError: null,
+        submitSectionErrors: [],
+        onRetryPolling: vi.fn(),
+      })
+    );
+
+    expect(
+      container.querySelector("[data-testid='submission-processing-skeleton']")
+    ).not.toBeNull();
+    expect(container.querySelector("button")).toBeNull();
 
     unmount();
   });
@@ -106,6 +128,7 @@ describe("UploadSubmissionStatus", () => {
   it("renders submission result and section errors when present", () => {
     const { container, unmount } = render(
       React.createElement(UploadSubmissionStatus, {
+        submitting: false,
         submissionStatus: asStatus("FINISHED", true),
         pollingError: null,
         submitSectionErrors: ["Submit failed"],
@@ -122,9 +145,30 @@ describe("UploadSubmissionStatus", () => {
     unmount();
   });
 
+  it("hides polling error UI while processing is active", () => {
+    const { container, unmount } = render(
+      React.createElement(UploadSubmissionStatus, {
+        submitting: true,
+        submissionStatus: asStatus("PENDING"),
+        pollingError: "network error",
+        submitSectionErrors: [],
+        onRetryPolling: vi.fn(),
+      })
+    );
+
+    expect(
+      container.querySelector("[data-testid='submission-processing-skeleton']")
+    ).not.toBeNull();
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector("[data-testid='alert']")).toBeNull();
+
+    unmount();
+  });
+
   it("shows polling error alert and retry when polling fails", () => {
     const { container, unmount } = render(
       React.createElement(UploadSubmissionStatus, {
+        submitting: false,
         submissionStatus: asStatus("FINISHED"),
         pollingError: "network error",
         submitSectionErrors: [],

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -5,14 +5,16 @@ import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useMemo, useReducer, useState } from "react";
-import { useLoaderData, useOutletContext } from "react-router";
+import { Link, useLoaderData, useOutletContext } from "react-router";
 
+import { NewAlert } from "@thunderstore/cyberstorm";
 import {
   DapperTs,
   postPackageSubmissionMetadata,
 } from "@thunderstore/dapper-ts";
 import { type PackageSubmissionStatus } from "@thunderstore/dapper/types";
 import { type PackageSubmissionRequestData } from "@thunderstore/thunderstore-api";
+import { useUploadProgress } from "@thunderstore/ts-uploader-react";
 
 import { RouteErrorBoundary } from "../commonComponents/ErrorBoundary/RouteErrorBoundary";
 import {
@@ -40,6 +42,7 @@ import {
   buildCommunityOptions,
   getSubmissionErrorMessages,
   getSubmissionErrorsBySection,
+  getUploadProgressPercent,
   initialUploadFormInputs,
   isUploadSubmitDisabled,
   pruneCommunityCategories,
@@ -123,6 +126,7 @@ export default function Upload() {
 
   const {
     file,
+    startUpload,
     selectFile,
     fileInputRef,
     handle,
@@ -131,6 +135,10 @@ export default function Upload() {
     uploadError,
     clearFile,
   } = usePackageFileUpload(requestConfig);
+
+  const uploadProgress = useUploadProgress(handle);
+  const isUploading = !!handle && !isDone;
+  const uploadProgressPercent = getUploadProgressPercent(uploadProgress);
 
   const { pollingError, setPollingError, retryPolling } =
     useSubmissionStatusPolling(dapper, submissionStatus, setSubmissionStatus);
@@ -164,13 +172,30 @@ export default function Upload() {
   >;
 
   async function submitor(data: typeof formInputs): Promise<SubmitorOutput> {
+    let uploadUuid = data.upload_uuid;
+
+    if (!uploadUuid) {
+      const uploadedMedia = await startUpload();
+      uploadUuid = uploadedMedia?.uuid;
+
+      if (!uploadUuid) {
+        throw new Error("Upload failed before submission.");
+      }
+
+      updateFormFieldState({
+        field: "upload_uuid",
+        value: uploadUuid,
+      });
+    }
+
     const config = requestConfig();
     const submitDapper = new DapperTs(() => config);
+
     return await submitDapper.postPackageSubmissionMetadata(
       data.author_name,
       data.communities,
       data.has_nsfw_content,
-      data.upload_uuid,
+      uploadUuid,
       data.categories,
       data.community_categories
     );
@@ -218,7 +243,8 @@ export default function Upload() {
   const submitDisabled = isUploadSubmitDisabled({
     submitting: strongForm.submitting,
     submissionPending: submissionStatus?.status === "PENDING",
-    uploadUuid: usermedia?.uuid,
+    authorName: formInputs.author_name,
+    hasSelectedFile: !!file,
     communitiesCount: formInputs.communities.length,
   });
 
@@ -232,6 +258,7 @@ export default function Upload() {
   const handleSubmit = () => {
     setSubmitError(null);
     setPollingError(null);
+    setSubmissionStatus(undefined);
     strongForm.submit();
   };
 
@@ -241,7 +268,55 @@ export default function Upload() {
         Upload package
       </PageHeader>
       <section className="container container--y container--full upload">
-        <FormSections rootClasses="upload">
+        <div className="upload__helper-alerts">
+          <NewAlert csVariant="info">
+            <p className="upload__helper-text">
+              Need help formatting your package? Check out the{" "}
+              <a
+                href="https://wiki.thunderstore.io/mods/creating-a-package"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Thunderstore wiki
+              </a>
+              .
+            </p>
+            <p className="upload__helper-text">
+              Review your readme before upload using the{" "}
+              <Link to="/tools/markdown-preview">markdown preview tool</Link>.
+            </p>
+            <p className="upload__helper-text">
+              Uploading a large file? Check your package manifest first with the{" "}
+              <Link to="/tools/manifest-validator">
+                package manifest validator
+              </Link>
+              .
+            </p>
+          </NewAlert>
+        </div>
+        <FormSections>
+          <UploadFileSection
+            file={file}
+            uploadError={uploadError}
+            handle={handle}
+            sectionErrors={submissionErrorsBySection.uploadFile}
+            fileInputRef={fileInputRef}
+            onFileChange={(nextFile) => {
+              selectFile(nextFile);
+              updateFormFieldState({
+                field: "upload_uuid",
+                value: "",
+              });
+            }}
+            onRemoveFile={() => {
+              clearFile();
+              updateFormFieldState({
+                field: "upload_uuid",
+                value: "",
+              });
+            }}
+          />
+          <FormSectionSeparator />
           <UploadTeamSection
             availableTeams={availableTeams}
             authorName={formInputs.author_name}
@@ -253,80 +328,63 @@ export default function Upload() {
             }}
           />
           <FormSectionSeparator />
-          {formInputs.author_name ? (
-            <>
-              <UploadFileSection
-                file={file}
-                uploadError={uploadError}
-                handle={handle}
-                isDone={isDone}
-                sectionErrors={submissionErrorsBySection.uploadFile}
-                fileInputRef={fileInputRef}
-                onFileChange={selectFile}
-                onRemoveFile={clearFile}
-              />
-              <FormSectionSeparator />
-            </>
-          ) : null}
-          {isDone && usermedia?.uuid ? (
-            <>
-              <UploadCommunitiesSection
-                communityOptions={communityOptions}
-                communities={formInputs.communities}
-                sectionErrors={submissionErrorsBySection.communities}
-                onCommunitiesChange={(communities) => {
-                  updateFormFieldState({
-                    field: "communities",
-                    value: communities,
-                  });
-                  updateFormFieldState({
-                    field: "community_categories",
-                    value: pruneCommunityCategories(
-                      formInputs.community_categories,
-                      communities
-                    ),
-                  });
-                }}
-              />
-              {formInputs.communities.length > 0 ? (
-                <UploadCategoriesSection
-                  communities={formInputs.communities}
-                  communityCategories={formInputs.community_categories}
-                  categoryOptions={categoryOptions}
-                  communityResults={uploadData.results}
-                  sectionErrors={submissionErrorsBySection.categories}
-                  onCommunityCategoriesChange={(communityCategories) => {
-                    updateFormFieldState({
-                      field: "community_categories",
-                      value: communityCategories,
-                    });
-                  }}
-                />
-              ) : null}
-              <FormSectionSeparator />
-              <UploadNsfwSection
-                hasNsfwContent={formInputs.has_nsfw_content}
-                onHasNsfwContentChange={(hasNsfwContent) => {
-                  updateFormFieldState({
-                    field: "has_nsfw_content",
-                    value: hasNsfwContent,
-                  });
-                }}
-              />
-              <FormSectionSeparator />
-            </>
-          ) : null}
+          <UploadCommunitiesSection
+            communityOptions={communityOptions}
+            communities={formInputs.communities}
+            sectionErrors={submissionErrorsBySection.communities}
+            onCommunitiesChange={(communities) => {
+              updateFormFieldState({
+                field: "communities",
+                value: communities,
+              });
+              updateFormFieldState({
+                field: "community_categories",
+                value: pruneCommunityCategories(
+                  formInputs.community_categories,
+                  communities
+                ),
+              });
+            }}
+          />
+          <FormSectionSeparator />
+          <UploadCategoriesSection
+            communities={formInputs.communities}
+            communityCategories={formInputs.community_categories}
+            categoryOptions={categoryOptions}
+            communityResults={uploadData.results}
+            sectionErrors={submissionErrorsBySection.categories}
+            onCommunityCategoriesChange={(communityCategories) => {
+              updateFormFieldState({
+                field: "community_categories",
+                value: communityCategories,
+              });
+            }}
+          />
+          <FormSectionSeparator />
+          <UploadNsfwSection
+            hasNsfwContent={formInputs.has_nsfw_content}
+            onHasNsfwContentChange={(hasNsfwContent) => {
+              updateFormFieldState({
+                field: "has_nsfw_content",
+                value: hasNsfwContent,
+              });
+            }}
+          />
+          <FormSectionSeparator />
           <UploadSubmitSection
             submitError={submitError}
             strongFormSubmitting={strongForm.submitting}
             submissionStatus={submissionStatus}
             hasSubmissionFormErrors={hasSubmissionFormErrors}
             submitDisabled={submitDisabled}
+            isUploading={isUploading}
+            uploadProgressPercent={uploadProgressPercent}
             onReset={handleReset}
             onSubmit={handleSubmit}
           />
-          {submissionStatus ? (
+          {submissionStatus || strongForm.submitting ? (
             <UploadSubmissionStatus
+              submitting={strongForm.submitting}
               submissionStatus={submissionStatus}
               pollingError={pollingError}
               submitSectionErrors={submissionErrorsBySection.submit}

--- a/apps/cyberstorm-remix/app/upload/uploadHooks.ts
+++ b/apps/cyberstorm-remix/app/upload/uploadHooks.ts
@@ -25,23 +25,31 @@ export function usePackageFileUpload(
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   const startUpload = useCallback(async () => {
-    if (!file) return;
+    if (!file) {
+      const message = "Please choose a ZIP file before submitting.";
+      setUploadError(message);
+      throw new Error(message);
+    }
 
     if (!isPackageZipFile(file)) {
-      setUploadError(PACKAGE_ZIP_FILE_ERROR_MESSAGE);
+      const message = PACKAGE_ZIP_FILE_ERROR_MESSAGE;
+      setUploadError(message);
       setFile(null);
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
-      return;
+      throw new Error(message);
     }
 
     setUploadError(null);
+    setIsDone(false);
+    setUsermedia(undefined);
 
     const config = requestConfig();
     if (!config.apiHost) {
-      setUploadError("API host is not configured");
-      return;
+      const message = "API host is not configured";
+      setUploadError(message);
+      throw new Error(message);
     }
 
     const upload = new MultipartUpload({ file }, requestConfig);
@@ -51,17 +59,18 @@ export function usePackageFileUpload(
       await upload.start();
       setUsermedia(upload.handle);
       setIsDone(true);
+      return upload.handle;
     } catch (error) {
-      setUploadError(error instanceof Error ? error.message : "Upload failed");
+      const message = error instanceof Error ? error.message : "Upload failed";
+      setUploadError(message);
+      setIsDone(false);
+      setUsermedia(undefined);
+      setHandle(undefined);
+      throw new Error(message);
+    } finally {
       setHandle(undefined);
     }
   }, [file, requestConfig]);
-
-  useEffect(() => {
-    if (file) {
-      void startUpload();
-    }
-  }, [file, startUpload]);
 
   const clearFile = useCallback(() => {
     setFile(null);
@@ -103,6 +112,7 @@ export function usePackageFileUpload(
 
   return {
     file,
+    startUpload,
     selectFile,
     fileInputRef,
     handle,

--- a/apps/cyberstorm-remix/app/upload/uploadUtils.ts
+++ b/apps/cyberstorm-remix/app/upload/uploadUtils.ts
@@ -1,4 +1,5 @@
 import type { PackageSubmissionRequestData } from "@thunderstore/thunderstore-api";
+import type { UploadProgress } from "@thunderstore/ts-uploader";
 
 /** Value for `<input type="file" accept="...">` — MIME types plus `.zip` for file picker UX. */
 export const PACKAGE_ZIP_ACCEPT =
@@ -68,6 +69,16 @@ export function formatBytes(bytes: number, decimals = 2) {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+export function getUploadProgressPercent(
+  progress: UploadProgress | undefined
+): number {
+  if (!progress || progress.total <= 0) {
+    return 0;
+  }
+
+  return (progress.complete / progress.total) * 100;
 }
 
 export const initialUploadFormInputs: PackageSubmissionRequestData = {
@@ -149,16 +160,22 @@ export function getSubmissionErrorMessages(formErrors: unknown): string[] {
 export function isUploadSubmitDisabled({
   submitting,
   submissionPending,
-  uploadUuid,
+  authorName,
+  hasSelectedFile,
   communitiesCount,
 }: {
   submitting: boolean;
   submissionPending: boolean;
-  uploadUuid: string | undefined;
+  authorName: string;
+  hasSelectedFile: boolean;
   communitiesCount: number;
 }): boolean {
   return (
-    submitting || submissionPending || !uploadUuid || communitiesCount === 0
+    submitting ||
+    submissionPending ||
+    !authorName ||
+    !hasSelectedFile ||
+    communitiesCount === 0
   );
 }
 

--- a/packages/ts-uploader-react/src/index.tsx
+++ b/packages/ts-uploader-react/src/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import {
+import type {
   IBaseUploadHandle,
   UploadError,
   UploadProgress,


### PR DESCRIPTION
…es, and result polish

* Moved file transfer to submit-time by exposing startUpload() and invoking it from the submit flow, with stronger error handling for missing file/API host and failed pre-submit upload.
* Updated submit enablement logic to require team, selected file, and communities, while clearing stale upload_uuid on file change/remove without resetting other form fields.
* Added a submit-area upload progress indicator and replaced confusing pending retry behavior with a dedicated submission-processing skeleton; retry is now shown only for polling failures.
* Polished upload/result presentation by extracting drag-drop styles, improving file input copy and interactions, adding a category placeholder when no community is selected, and fixing missing spacing between category tags in submission results.
* Updated upload hook/status/util tests to cover deferred upload behavior, new status rendering, and upload progress percent calculation.