### PR TITLE
Nimbus SSR loader caching (TS-3735)

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -74,8 +74,13 @@ export const loader = ssrLoader(
       };
     }
     throw new Response("Community not found", { status: 404 });
-  }
+  },
+  { cache: true }
 );
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId) {

--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -78,9 +78,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId) {

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -67,6 +67,9 @@ export const loader = ssrLoader(
   }
 );
 
+// The loader is anonymous, so this landing page could be CDN-cached, but the
+// listing's staleness window is a concern. Kept uncached (overriding the cached
+// Community parent's headers) for now; revisit caching it after QA.
 export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({

--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -67,6 +67,8 @@ export const loader = ssrLoader(
   }
 );
 
+export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+
 export async function clientLoader({
   request,
   params,

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -60,46 +60,53 @@ const selectOptions = [
   },
 ];
 
-export const loader = ssrLoader(async ({ request }: Route.LoaderArgs) => {
-  const url = new URL(request.url);
-  const searchParams = url.searchParams;
-  const order = searchParams.get("order") ?? SortOptions.Popular;
-  const search = searchParams.get("search");
-  const page = undefined;
-  const dapper = new DapperTs(() => {
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
+
+export const loader = ssrLoader(
+  async ({ request }: Route.LoaderArgs) => {
+    const url = new URL(request.url);
+    const searchParams = url.searchParams;
+    const order = searchParams.get("order") ?? SortOptions.Popular;
+    const search = searchParams.get("search");
+    const page = undefined;
+    const dapper = new DapperTs(() => {
+      return {
+        apiHost: getApiHostForSsr(),
+        sessionId: undefined,
+      };
+    });
     return {
-      apiHost: getApiHostForSsr(),
-      sessionId: undefined,
+      communities: await dapper.getCommunities(
+        page,
+        order === null ? undefined : order,
+        search === null ? undefined : search
+      ),
+      seo: createSeo({
+        descriptors: [
+          { title: "Communities | Thunderstore" },
+          {
+            name: "description",
+            content: "Browse all communities on Thunderstore",
+          },
+          { property: "og:type", content: "website" },
+          {
+            property: "og:url",
+            content: `${url.origin}/communities`,
+          },
+          { property: "og:title", content: "Communities | Thunderstore" },
+          {
+            property: "og:description",
+            content: "Browse all communities on Thunderstore",
+          },
+          { property: "og:site_name", content: "Thunderstore" },
+        ],
+      }),
     };
-  });
-  return {
-    communities: await dapper.getCommunities(
-      page,
-      order === null ? undefined : order,
-      search === null ? undefined : search
-    ),
-    seo: createSeo({
-      descriptors: [
-        { title: "Communities | Thunderstore" },
-        {
-          name: "description",
-          content: "Browse all communities on Thunderstore",
-        },
-        { property: "og:type", content: "website" },
-        {
-          property: "og:url",
-          content: `${url.origin}/communities`,
-        },
-        { property: "og:title", content: "Communities | Thunderstore" },
-        {
-          property: "og:description",
-          content: "Browse all communities on Thunderstore",
-        },
-        { property: "og:site_name", content: "Thunderstore" },
-      ],
-    }),
-  };
-});
+  },
+  { cache: true }
+);
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const tools = getSessionTools();

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -60,9 +60,7 @@ const selectOptions = [
   },
 ];
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export const loader = ssrLoader(
   async ({ request }: Route.LoaderArgs) => {

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -136,9 +136,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -132,8 +132,13 @@ export const loader = ssrLoader(
       };
     }
     throw new Response("Community not found", { status: 404 });
-  }
+  },
+  { cache: true }
 );
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({
   request,

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -155,8 +155,13 @@ export const loader = ssrLoader(
         ],
       }),
     };
-  }
+  },
+  { cache: true }
 );
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -159,9 +159,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -126,8 +126,13 @@ export const loader = ssrLoader(
         ],
       }),
     };
-  }
+  },
+  { cache: true }
 );
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -130,9 +130,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -58,9 +58,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -28,32 +28,39 @@ async function fetchChangelogSafe(
   }
 }
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (!params.namespaceId || !params.packageId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (!params.namespaceId || !params.packageId) {
+      throw new Response("Not Found", { status: 404 });
+    }
 
-  const dapper = new DapperTs(() => ({
-    apiHost: getApiHostForSsr(),
-    sessionId: undefined,
-  }));
+    const dapper = new DapperTs(() => ({
+      apiHost: getApiHostForSsr(),
+      sessionId: undefined,
+    }));
 
-  const changelog = await fetchChangelogSafe(
-    dapper,
-    params.namespaceId,
-    params.packageId
-  );
+    const changelog = await fetchChangelogSafe(
+      dapper,
+      params.namespaceId,
+      params.packageId
+    );
 
-  return {
-    changelog,
-    seo: createSeo({
-      descriptors: [
-        { title: `Changelog for ${params.packageId} | Thunderstore` },
-        { name: "description", content: `Changelog for ${params.packageId}` },
-      ],
-    }),
-  };
-});
+    return {
+      changelog,
+      seo: createSeo({
+        descriptors: [
+          { title: `Changelog for ${params.packageId} | Thunderstore` },
+          { name: "description", content: `Changelog for ${params.packageId}` },
+        ],
+      }),
+    };
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -53,9 +53,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/PackageVersionReadme.tsx
@@ -13,42 +13,49 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 import type { Route } from "./+types/PackageVersionReadme";
 import "./Readme.css";
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (params.namespaceId && params.packageId && params.packageVersion) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (params.namespaceId && params.packageId && params.packageVersion) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        readme: await dapper.getPackageReadme(
+          params.namespaceId,
+          params.packageId,
+          params.packageVersion
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `${params.namespaceId}-${params.packageId} ${params.packageVersion} Readme | Thunderstore`,
+            },
+            {
+              name: "description",
+              content: `Readme for ${params.namespaceId}-${params.packageId} ${params.packageVersion}`,
+            },
+          ],
+        }),
       };
-    });
+    }
     return {
-      readme: await dapper.getPackageReadme(
-        params.namespaceId,
-        params.packageId,
-        params.packageVersion
-      ),
+      status: "error",
+      message: "Failed to load readme",
+      readme: { html: "" },
       seo: createSeo({
-        descriptors: [
-          {
-            title: `${params.namespaceId}-${params.packageId} ${params.packageVersion} Readme | Thunderstore`,
-          },
-          {
-            name: "description",
-            content: `Readme for ${params.namespaceId}-${params.packageId} ${params.packageVersion}`,
-          },
-        ],
+        descriptors: [{ title: "Readme Not Found | Thunderstore" }],
       }),
     };
-  }
-  return {
-    status: "error",
-    message: "Failed to load readme",
-    readme: { html: "" },
-    seo: createSeo({
-      descriptors: [{ title: "Readme Not Found | Thunderstore" }],
-    }),
-  };
-});
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.namespaceId && params.packageId && params.packageVersion) {

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -64,9 +64,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Readme/Readme.tsx
@@ -29,33 +29,44 @@ async function fetchReadmeSafe(
   }
 }
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (!params.namespaceId || !params.packageId) {
-    throw new Response("Not Found", { status: 404 });
-  }
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (!params.namespaceId || !params.packageId) {
+      throw new Response("Not Found", { status: 404 });
+    }
 
-  const dapper = new DapperTs(() => {
+    const dapper = new DapperTs(() => {
+      return {
+        apiHost: getApiHostForSsr(),
+        sessionId: undefined,
+      };
+    });
+
     return {
-      apiHost: getApiHostForSsr(),
-      sessionId: undefined,
+      readme: await fetchReadmeSafe(
+        dapper,
+        params.namespaceId,
+        params.packageId
+      ),
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${params.namespaceId}-${params.packageId} Readme | Thunderstore`,
+          },
+          {
+            name: "description",
+            content: `Readme for ${params.namespaceId}-${params.packageId}`,
+          },
+        ],
+      }),
     };
-  });
+  },
+  { cache: true }
+);
 
-  return {
-    readme: await fetchReadmeSafe(dapper, params.namespaceId, params.packageId),
-    seo: createSeo({
-      descriptors: [
-        {
-          title: `${params.namespaceId}-${params.packageId} Readme | Thunderstore`,
-        },
-        {
-          name: "description",
-          content: `Readme for ${params.namespaceId}-${params.packageId}`,
-        },
-      ],
-    }),
-  };
-});
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (!params.namespaceId || !params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -81,9 +81,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -77,8 +77,13 @@ export const loader = ssrLoader(
         ],
       }),
     };
-  }
+  },
+  { cache: true }
 );
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -57,6 +57,9 @@ export async function loader({ params }: Route.LoaderArgs) {
     seo: createSeo({ descriptors: [{ title: "Source Not Found" }] }),
   };
 }
+
+export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+
 clientLoader.hydrate = true;
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -62,9 +62,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -22,42 +22,49 @@ import { columns } from "./Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (params.communityId && params.namespaceId && params.packageId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId && params.packageId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: await dapper.getPackageVersions(
+          params.namespaceId,
+          params.packageId
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
+            },
+            {
+              name: "description",
+              content: `Versions for ${params.namespaceId}-${params.packageId}`,
+            },
+          ],
+        }),
       };
-    });
+    }
     return {
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: await dapper.getPackageVersions(
-        params.namespaceId,
-        params.packageId
-      ),
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
-          },
-          {
-            name: "description",
-            content: `Versions for ${params.namespaceId}-${params.packageId}`,
-          },
-        ],
-      }),
+      status: "error",
+      message: "Failed to load versions",
+      versions: [],
+      seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
     };
-  }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-    seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
-  };
-});
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({
   params,

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -62,9 +62,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -22,42 +22,49 @@ import type { Route } from "./+types/Versions";
 import "./Versions.css";
 import { DownloadLink, InstallLink, ModManagerBanner } from "./common";
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (params.communityId && params.namespaceId && params.packageId) {
-    const dapper = new DapperTs(() => {
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId && params.packageId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
       return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        versions: await dapper.getPackageVersions(
+          params.namespaceId,
+          params.packageId
+        ),
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
+            },
+            {
+              name: "description",
+              content: `Versions for ${params.namespaceId}-${params.packageId}`,
+            },
+          ],
+        }),
       };
-    });
+    }
     return {
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      versions: await dapper.getPackageVersions(
-        params.namespaceId,
-        params.packageId
-      ),
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
-          },
-          {
-            name: "description",
-            content: `Versions for ${params.namespaceId}-${params.packageId}`,
-          },
-        ],
-      }),
+      status: "error",
+      message: "Failed to load versions",
+      versions: [],
+      seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
     };
-  }
-  return {
-    status: "error",
-    message: "Failed to load versions",
-    versions: [],
-    seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
-  };
-});
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -31,50 +31,60 @@ import "./Wiki.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (params.communityId && params.namespaceId && params.packageId) {
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
-      };
-    });
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId && params.packageId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
 
-    let wiki: Awaited<ReturnType<typeof getPackageWiki>> | undefined;
+      let wiki: Awaited<ReturnType<typeof getPackageWiki>> | undefined;
 
-    try {
-      wiki = await dapper.getPackageWiki(params.namespaceId, params.packageId);
-    } catch (error) {
-      if (isApiError(error) && error.response.status === 404) {
-        wiki = undefined;
-      } else {
-        throw error;
+      try {
+        wiki = await dapper.getPackageWiki(
+          params.namespaceId,
+          params.packageId
+        );
+      } catch (error) {
+        if (isApiError(error) && error.response.status === 404) {
+          wiki = undefined;
+        } else {
+          throw error;
+        }
       }
-    }
 
-    return {
-      wiki: wiki,
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-      slug: params.slug,
-      permissions: undefined,
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${params.namespaceId}-${params.packageId} Wiki | Thunderstore`,
-          },
-          {
-            name: "description",
-            content: `Wiki for ${params.namespaceId}-${params.packageId}`,
-          },
-        ],
-      }),
-    };
-  } else {
-    throw new Error("Namespace ID or Package ID is missing");
-  }
-});
+      return {
+        wiki: wiki,
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
+        slug: params.slug,
+        permissions: undefined,
+        seo: createSeo({
+          descriptors: [
+            {
+              title: `${params.namespaceId}-${params.packageId} Wiki | Thunderstore`,
+            },
+            {
+              name: "description",
+              content: `Wiki for ${params.namespaceId}-${params.packageId}`,
+            },
+          ],
+        }),
+      };
+    } else {
+      throw new Error("Namespace ID or Package ID is missing");
+    }
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -82,9 +82,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -27,84 +27,91 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (params.communityId && params.namespaceId && params.packageId) {
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (params.communityId && params.namespaceId && params.packageId) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
+        };
+      });
+      let result: ResultType = {
+        wiki: undefined,
+        firstPage: undefined,
+        communityId: params.communityId,
+        namespaceId: params.namespaceId,
+        packageId: params.packageId,
       };
-    });
-    let result: ResultType = {
-      wiki: undefined,
-      firstPage: undefined,
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-    };
 
-    try {
-      const wiki = await dapper.getPackageWiki(
-        params.namespaceId,
-        params.packageId
-      );
-      if (wiki.pages && wiki.pages.length > 0) {
-        const firstPage = await dapper.getPackageWikiPage(wiki.pages[0].id);
-        result = {
-          wiki: wiki,
-          firstPage: firstPage,
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-          packageId: params.packageId,
-          seo: createSeo({
-            descriptors: [
-              {
-                title: `${firstPage.title} - ${params.namespaceId}-${params.packageId} | Thunderstore`,
-              },
-              {
-                name: "description",
-                content: `Wiki page for ${params.namespaceId}-${params.packageId}`,
-              },
-            ],
-          }),
-        };
-      } else {
-        result = {
-          wiki: wiki,
-          firstPage: undefined,
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-          packageId: params.packageId,
-          seo: createSeo({
-            descriptors: [
-              { title: `${params.namespaceId}-${params.packageId} Wiki` },
-            ],
-          }),
-        };
-      }
-    } catch (error) {
-      if (isApiError(error)) {
-        // There is no wiki or the User does not have permission to view the wiki, return empty wiki and undefined firstPage
-        if (error.response.status === 404) {
+      try {
+        const wiki = await dapper.getPackageWiki(
+          params.namespaceId,
+          params.packageId
+        );
+        if (wiki.pages && wiki.pages.length > 0) {
+          const firstPage = await dapper.getPackageWikiPage(wiki.pages[0].id);
           result = {
-            wiki: undefined,
+            wiki: wiki,
+            firstPage: firstPage,
+            communityId: params.communityId,
+            namespaceId: params.namespaceId,
+            packageId: params.packageId,
+            seo: createSeo({
+              descriptors: [
+                {
+                  title: `${firstPage.title} - ${params.namespaceId}-${params.packageId} | Thunderstore`,
+                },
+                {
+                  name: "description",
+                  content: `Wiki page for ${params.namespaceId}-${params.packageId}`,
+                },
+              ],
+            }),
+          };
+        } else {
+          result = {
+            wiki: wiki,
             firstPage: undefined,
             communityId: params.communityId,
             namespaceId: params.namespaceId,
             packageId: params.packageId,
-            seo: createSeo({ descriptors: [{ title: "Wiki Not Found" }] }),
+            seo: createSeo({
+              descriptors: [
+                { title: `${params.namespaceId}-${params.packageId} Wiki` },
+              ],
+            }),
           };
+        }
+      } catch (error) {
+        if (isApiError(error)) {
+          // There is no wiki or the User does not have permission to view the wiki, return empty wiki and undefined firstPage
+          if (error.response.status === 404) {
+            result = {
+              wiki: undefined,
+              firstPage: undefined,
+              communityId: params.communityId,
+              namespaceId: params.namespaceId,
+              packageId: params.packageId,
+              seo: createSeo({ descriptors: [{ title: "Wiki Not Found" }] }),
+            };
+          } else {
+            throw error;
+          }
         } else {
           throw error;
         }
-      } else {
-        throw error;
       }
+      return result;
     }
-    return result;
-  }
-  throw new Error("Namespace ID or Package ID is missing");
-});
+    throw new Error("Namespace ID or Package ID is missing");
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiFirstPage.tsx
@@ -109,9 +109,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (params.communityId && params.namespaceId && params.packageId) {

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiNewPage.tsx
@@ -47,6 +47,8 @@ export async function loader({ params }: Route.LoaderArgs) {
   }
 }
 
+export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+
 export async function clientLoader({
   params,
   request,

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -119,9 +119,7 @@ export const loader = ssrLoader(
   { cache: true }
 );
 
-export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
-  return loaderHeaders;
-};
+export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPage.tsx
@@ -27,94 +27,101 @@ type ResultType = {
   seo?: ReturnType<typeof createSeo>;
 };
 
-export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
-  if (
-    params.communityId &&
-    params.namespaceId &&
-    params.packageId &&
-    params.slug
-  ) {
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: getApiHostForSsr(),
-        sessionId: undefined,
-      };
-    });
-
-    let result: ResultType = {
-      wiki: undefined,
-      page: undefined,
-      communityId: params.communityId,
-      namespaceId: params.namespaceId,
-      packageId: params.packageId,
-    };
-
-    try {
-      const wiki = await dapper.getPackageWiki(
-        params.namespaceId,
-        params.packageId
-      );
-      const pageId = wiki.pages?.find((p) => p.slug === params.slug)?.id;
-      if (!pageId) {
-        result = {
-          wiki,
-          page: undefined,
-          communityId: params.communityId,
-          namespaceId: params.namespaceId,
-          packageId: params.packageId,
-          seo: createSeo({
-            descriptors: [
-              { title: `${params.slug} | Wiki Not Found | Thunderstore` },
-            ],
-          }),
+export const loader = ssrLoader(
+  async ({ params }: Route.LoaderArgs) => {
+    if (
+      params.communityId &&
+      params.namespaceId &&
+      params.packageId &&
+      params.slug
+    ) {
+      const dapper = new DapperTs(() => {
+        return {
+          apiHost: getApiHostForSsr(),
+          sessionId: undefined,
         };
-        return result;
-      }
-      const page = await dapper.getPackageWikiPage(pageId);
-      result = {
-        wiki: wiki,
-        page: page,
+      });
+
+      let result: ResultType = {
+        wiki: undefined,
+        page: undefined,
         communityId: params.communityId,
         namespaceId: params.namespaceId,
         packageId: params.packageId,
-        seo: createSeo({
-          descriptors: [
-            {
-              title: `${page.title} - ${params.namespaceId}-${params.packageId} | Thunderstore`,
-            },
-            {
-              name: "description",
-              content: `Wiki page for ${params.namespaceId}-${params.packageId}`,
-            },
-          ],
-        }),
       };
-    } catch (error) {
-      if (isApiError(error)) {
-        // There is no wiki or the User does not have permission to view the wiki, return empty wiki and undefined firstPage
-        if (error.response.status === 404) {
+
+      try {
+        const wiki = await dapper.getPackageWiki(
+          params.namespaceId,
+          params.packageId
+        );
+        const pageId = wiki.pages?.find((p) => p.slug === params.slug)?.id;
+        if (!pageId) {
           result = {
-            wiki: undefined,
+            wiki,
             page: undefined,
             communityId: params.communityId,
             namespaceId: params.namespaceId,
             packageId: params.packageId,
             seo: createSeo({
-              descriptors: [{ title: "Wiki Not Found | Thunderstore" }],
+              descriptors: [
+                { title: `${params.slug} | Wiki Not Found | Thunderstore` },
+              ],
             }),
           };
+          return result;
+        }
+        const page = await dapper.getPackageWikiPage(pageId);
+        result = {
+          wiki: wiki,
+          page: page,
+          communityId: params.communityId,
+          namespaceId: params.namespaceId,
+          packageId: params.packageId,
+          seo: createSeo({
+            descriptors: [
+              {
+                title: `${page.title} - ${params.namespaceId}-${params.packageId} | Thunderstore`,
+              },
+              {
+                name: "description",
+                content: `Wiki page for ${params.namespaceId}-${params.packageId}`,
+              },
+            ],
+          }),
+        };
+      } catch (error) {
+        if (isApiError(error)) {
+          // There is no wiki or the User does not have permission to view the wiki, return empty wiki and undefined firstPage
+          if (error.response.status === 404) {
+            result = {
+              wiki: undefined,
+              page: undefined,
+              communityId: params.communityId,
+              namespaceId: params.namespaceId,
+              packageId: params.packageId,
+              seo: createSeo({
+                descriptors: [{ title: "Wiki Not Found | Thunderstore" }],
+              }),
+            };
+          } else {
+            throw error;
+          }
         } else {
           throw error;
         }
-      } else {
-        throw error;
       }
+      return result;
+    } else {
+      throw new Error("Namespace ID or Package ID is missing");
     }
-    return result;
-  } else {
-    throw new Error("Namespace ID or Package ID is missing");
-  }
-});
+  },
+  { cache: true }
+);
+
+export const headers: Route.HeadersFunction = ({ loaderHeaders }) => {
+  return loaderHeaders;
+};
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   if (

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/WikiPageEdit.tsx
@@ -87,6 +87,8 @@ export const loader = ssrLoader(async ({ params }: Route.LoaderArgs) => {
   }
 });
 
+export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+
 export async function clientLoader({
   params,
   request,

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cache.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { cacheControl } from "../cache";
+
+const value = (options?: Parameters<typeof cacheControl>[0]) =>
+  cacheControl(options)["Cache-Control"];
+
+describe("cacheControl", () => {
+  it("emits the default public directive set", () => {
+    expect(value()).toBe(
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=600"
+    );
+  });
+
+  it("honors custom public durations", () => {
+    expect(
+      value({ browserMaxAge: 30, cdnMaxAge: 120, staleWhileRevalidate: 90 })
+    ).toBe("public, max-age=30, s-maxage=120, stale-while-revalidate=90");
+  });
+
+  it("emits only private + max-age when isPrivate (no s-maxage / SWR)", () => {
+    const result = value({
+      isPrivate: true,
+      browserMaxAge: 45,
+      cdnMaxAge: 999,
+      staleWhileRevalidate: 999,
+    });
+    expect(result).toBe("private, max-age=45");
+    expect(result).not.toContain("s-maxage");
+    expect(result).not.toContain("stale-while-revalidate");
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(value({ browserMaxAge: -5, cdnMaxAge: -1 })).toBe(
+      "public, max-age=0, s-maxage=0, stale-while-revalidate=600"
+    );
+  });
+
+  it("floors non-integer values", () => {
+    expect(value({ browserMaxAge: 60.9, staleWhileRevalidate: 10.2 })).toBe(
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=10"
+    );
+  });
+
+  it("coerces non-finite values (NaN/Infinity) to 0", () => {
+    expect(value({ browserMaxAge: NaN, cdnMaxAge: Infinity })).toBe(
+      "public, max-age=0, s-maxage=0, stale-while-revalidate=600"
+    );
+  });
+
+  it("clamps the private branch too", () => {
+    expect(value({ isPrivate: true, browserMaxAge: -10 })).toBe(
+      "private, max-age=0"
+    );
+  });
+});

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedLoaderAnonymity.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedLoaderAnonymity.test.ts
@@ -1,46 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-// Read route source as raw strings via Vite (Node's fs is unavailable in the
-// browser test environment). Keyed by path relative to this file.
-const routeSources = import.meta.glob("../../../app/**/*.tsx", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
+import { cachedRoutes, extractSsrLoaderCall } from "./cachedRoutes";
 
-function sourceOf(appRelativePath: string): string {
-  const key = `../../../${appRelativePath}`;
-  const content = routeSources[key];
-  if (content === undefined) {
-    throw new Error(`Route source not found for ${appRelativePath}`);
-  }
-  return content;
-}
-
-// Routes whose loader is wrapped with `ssrLoader(..., { cache: ... })`. The
-// emitted Cache-Control is `public` with no `Vary`, applied to both the
-// document HTML and the single-fetch `.data` responses, so these loaders MUST
-// stay fully anonymous — no session/cookie reads, per-user data deferred to
-// clientLoader. A session-dependent cached loader would let the CDN cross-serve
-// one user's response to everyone. This guard catches such a regression at the
-// source. See cyberstorm/utils/ssrLoader.ts.
-const cachedRouteFiles = [
-  "app/communities/communities.tsx",
-  "app/p/packageListing.tsx",
-  "app/p/packageListingVersion.tsx",
-  "app/p/dependants/Dependants.tsx",
-  "app/p/tabs/Wiki/WikiFirstPage.tsx",
-  "app/p/tabs/Wiki/WikiPage.tsx",
-  "app/p/tabs/Wiki/Wiki.tsx",
-  "app/p/tabs/Readme/PackageVersionReadme.tsx",
-  "app/p/tabs/Readme/Readme.tsx",
-  "app/p/tabs/Changelog/Changelog.tsx",
-  "app/p/tabs/Required/Required.tsx",
-  "app/p/tabs/Versions/Versions.tsx",
-  "app/p/tabs/Versions/PackageVersionVersions.tsx",
-  "app/c/Community.tsx",
-];
-
+// The Cache-Control emitted by cached loaders is `public` with no `Vary`, and is
+// applied to both the document HTML and the cookie-bearing single-fetch `.data`
+// responses, so these loaders MUST stay fully anonymous — no session/cookie
+// reads, per-user data deferred to clientLoader. A session-dependent cached
+// loader would let the CDN cross-serve one user's response to everyone. This
+// guard catches such a regression at the source. See cyberstorm/utils/ssrLoader.ts.
+//
 // Patterns that indicate a loader reads the session/cookie. `sessionId: undefined`
 // is the explicit anonymous marker and is allowed; anything else assigned to
 // sessionId is not.
@@ -56,38 +24,23 @@ const FORBIDDEN = [
   },
 ];
 
-/**
- * Extracts the full `ssrLoader( ... )` call expression (server loader + options)
- * by matching balanced parentheses, so the scan ignores the route's clientLoader
- * and imports, which legitimately read the session.
- */
-function extractSsrLoaderCall(source: string): string {
-  const marker = "ssrLoader(";
-  const start = source.indexOf(marker);
-  if (start === -1) {
-    throw new Error("no ssrLoader( call found");
-  }
-  let depth = 0;
-  for (let i = start + marker.length - 1; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === "(") depth++;
-    else if (ch === ")" && --depth === 0) {
-      return source.slice(start, i + 1);
-    }
-  }
-  throw new Error("unbalanced ssrLoader( call");
-}
-
 describe("cached ssrLoader loaders stay anonymous", () => {
-  for (const file of cachedRouteFiles) {
-    it(file, () => {
-      const loaderCall = extractSsrLoaderCall(sourceOf(file));
+  const routes = cachedRoutes();
+
+  it("discovers the expected cached routes", () => {
+    expect(routes.length).toBeGreaterThanOrEqual(14);
+  });
+
+  for (const route of routes) {
+    it(route.path, () => {
+      // cachedRoutes() only includes routes whose ssrLoader call was found.
+      const loaderCall = route.loaderCall as string;
       const violations = FORBIDDEN.filter(({ re }) => re.test(loaderCall)).map(
         ({ label }) => label
       );
       expect(
         violations,
-        `${file} cached loader must not read session/cookie state ` +
+        `${route.path} cached loader must not read session/cookie state ` +
           `(found: ${violations.join(
             ", "
           )}). Defer per-user data to clientLoader.`
@@ -104,7 +57,8 @@ describe("extractSsrLoaderCall / FORBIDDEN sanity", () => {
          return { x: tools };
        }, { cache: true });`
     );
-    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(true);
+    expect(call).not.toBeNull();
+    expect(FORBIDDEN.some(({ re }) => re.test(call as string))).toBe(true);
   });
 
   it("allows an anonymous loader (sessionId: undefined)", () => {
@@ -114,7 +68,8 @@ describe("extractSsrLoaderCall / FORBIDDEN sanity", () => {
          return { x: 1 };
        }, { cache: true });`
     );
-    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(false);
+    expect(call).not.toBeNull();
+    expect(FORBIDDEN.some(({ re }) => re.test(call as string))).toBe(false);
   });
 
   it("does not scan the clientLoader (session reads there are fine)", () => {
@@ -127,6 +82,7 @@ describe("extractSsrLoaderCall / FORBIDDEN sanity", () => {
         return { sessionId: tools.getConfig().sessionId };
       }`;
     const call = extractSsrLoaderCall(source);
-    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(false);
+    expect(call).not.toBeNull();
+    expect(FORBIDDEN.some(({ re }) => re.test(call as string))).toBe(false);
   });
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedLoaderAnonymity.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedLoaderAnonymity.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+// Read route source as raw strings via Vite (Node's fs is unavailable in the
+// browser test environment). Keyed by path relative to this file.
+const routeSources = import.meta.glob("../../../app/**/*.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function sourceOf(appRelativePath: string): string {
+  const key = `../../../${appRelativePath}`;
+  const content = routeSources[key];
+  if (content === undefined) {
+    throw new Error(`Route source not found for ${appRelativePath}`);
+  }
+  return content;
+}
+
+// Routes whose loader is wrapped with `ssrLoader(..., { cache: ... })`. The
+// emitted Cache-Control is `public` with no `Vary`, applied to both the
+// document HTML and the single-fetch `.data` responses, so these loaders MUST
+// stay fully anonymous — no session/cookie reads, per-user data deferred to
+// clientLoader. A session-dependent cached loader would let the CDN cross-serve
+// one user's response to everyone. This guard catches such a regression at the
+// source. See cyberstorm/utils/ssrLoader.ts.
+const cachedRouteFiles = [
+  "app/communities/communities.tsx",
+  "app/p/packageListing.tsx",
+  "app/p/packageListingVersion.tsx",
+  "app/p/dependants/Dependants.tsx",
+  "app/p/tabs/Wiki/WikiFirstPage.tsx",
+  "app/p/tabs/Wiki/WikiPage.tsx",
+  "app/p/tabs/Wiki/Wiki.tsx",
+  "app/p/tabs/Readme/PackageVersionReadme.tsx",
+  "app/p/tabs/Readme/Readme.tsx",
+  "app/p/tabs/Changelog/Changelog.tsx",
+  "app/p/tabs/Required/Required.tsx",
+  "app/p/tabs/Versions/Versions.tsx",
+  "app/p/tabs/Versions/PackageVersionVersions.tsx",
+  "app/c/Community.tsx",
+];
+
+// Patterns that indicate a loader reads the session/cookie. `sessionId: undefined`
+// is the explicit anonymous marker and is allowed; anything else assigned to
+// sessionId is not.
+const FORBIDDEN = [
+  { re: /getSession\w*/, label: "getSession* (session/cookie read)" },
+  {
+    re: /\.headers\.get\(\s*["']cookie["']/i,
+    label: 'request.headers.get("cookie")',
+  },
+  {
+    re: /sessionId:\s*(?!undefined\b)[A-Za-z_$]/,
+    label: "non-anonymous sessionId assignment",
+  },
+];
+
+/**
+ * Extracts the full `ssrLoader( ... )` call expression (server loader + options)
+ * by matching balanced parentheses, so the scan ignores the route's clientLoader
+ * and imports, which legitimately read the session.
+ */
+function extractSsrLoaderCall(source: string): string {
+  const marker = "ssrLoader(";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error("no ssrLoader( call found");
+  }
+  let depth = 0;
+  for (let i = start + marker.length - 1; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "(") depth++;
+    else if (ch === ")" && --depth === 0) {
+      return source.slice(start, i + 1);
+    }
+  }
+  throw new Error("unbalanced ssrLoader( call");
+}
+
+describe("cached ssrLoader loaders stay anonymous", () => {
+  for (const file of cachedRouteFiles) {
+    it(file, () => {
+      const loaderCall = extractSsrLoaderCall(sourceOf(file));
+      const violations = FORBIDDEN.filter(({ re }) => re.test(loaderCall)).map(
+        ({ label }) => label
+      );
+      expect(
+        violations,
+        `${file} cached loader must not read session/cookie state ` +
+          `(found: ${violations.join(
+            ", "
+          )}). Defer per-user data to clientLoader.`
+      ).toEqual([]);
+    });
+  }
+});
+
+describe("extractSsrLoaderCall / FORBIDDEN sanity", () => {
+  it("flags a session read inside the loader", () => {
+    const call = extractSsrLoaderCall(
+      `export const loader = ssrLoader(async () => {
+         const tools = getSessionTools();
+         return { x: tools };
+       }, { cache: true });`
+    );
+    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(true);
+  });
+
+  it("allows an anonymous loader (sessionId: undefined)", () => {
+    const call = extractSsrLoaderCall(
+      `export const loader = ssrLoader(async () => {
+         const dapper = build({ sessionId: undefined });
+         return { x: 1 };
+       }, { cache: true });`
+    );
+    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(false);
+  });
+
+  it("does not scan the clientLoader (session reads there are fine)", () => {
+    const source = `export const loader = ssrLoader(async () => {
+        return { sessionId: undefined };
+      }, { cache: true });
+
+      export async function clientLoader() {
+        const tools = getSessionTools();
+        return { sessionId: tools.getConfig().sessionId };
+      }`;
+    const call = extractSsrLoaderCall(source);
+    expect(FORBIDDEN.some(({ re }) => re.test(call))).toBe(false);
+  });
+});

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedRoutes.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/cachedRoutes.ts
@@ -1,0 +1,67 @@
+// Shared route-source discovery for the SSR caching contract tests.
+//
+// Route source is read as raw strings via Vite so the tests run in the browser
+// test environment (Node's fs is unavailable there). Discovering cached routes
+// from the source — rather than a hand-maintained list — means a new
+// `cache: true` route is automatically held to the same contract (must export a
+// forwarding `headers`, must stay anonymous) without anyone remembering to add
+// it to a list. Keyed by path relative to this file.
+const routeSources = import.meta.glob("../../../app/**/*.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export interface RouteSource {
+  /** App-relative path, e.g. "app/p/packageListing.tsx". */
+  path: string;
+  source: string;
+  /** The full `ssrLoader( ... )` call expression, or null if the route has none. */
+  loaderCall: string | null;
+  /** True when the loader opts into caching (`cache: true` or a cache object). */
+  cached: boolean;
+}
+
+/**
+ * Extracts the full `ssrLoader( ... )` call expression (server loader + options)
+ * by matching balanced parentheses, so callers can inspect the server loader in
+ * isolation from the route's clientLoader and imports.
+ */
+export function extractSsrLoaderCall(source: string): string | null {
+  const marker = "ssrLoader(";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    return null;
+  }
+  let depth = 0;
+  for (let i = start + marker.length - 1; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "(") depth++;
+    else if (ch === ")" && --depth === 0) {
+      return source.slice(start, i + 1);
+    }
+  }
+  throw new Error("unbalanced ssrLoader( call");
+}
+
+function toRouteSource(key: string, source: string): RouteSource {
+  const loaderCall = extractSsrLoaderCall(source);
+  return {
+    path: key.replace("../../../", ""),
+    source,
+    loaderCall,
+    // `cache: true` or `cache: { ... }` in the ssrLoader options enables caching;
+    // `cache: false` (or omitted) does not.
+    cached: loaderCall !== null && /cache:\s*(true|\{)/.test(loaderCall),
+  };
+}
+
+export function allRouteSources(): RouteSource[] {
+  return Object.entries(routeSources)
+    .map(([key, source]) => toRouteSource(key, source))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function cachedRoutes(): RouteSource[] {
+  return allRouteSources().filter((r) => r.cached);
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/routeHeaders.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/routeHeaders.test.ts
@@ -1,43 +1,31 @@
 import { describe, expect, it } from "vitest";
 
-// Read route source as raw strings via Vite so this works in the browser test
-// environment (Node's fs is unavailable there). Keyed by path relative to this
-// file, e.g. "../../../app/communities/communities.tsx".
-const routeSources = import.meta.glob("../../../app/**/*.tsx", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
+import { allRouteSources, cachedRoutes } from "./cachedRoutes";
 
-function sourceOf(appRelativePath: string): string {
-  const key = `../../../${appRelativePath}`;
-  const content = routeSources[key];
-  if (content === undefined) {
-    throw new Error(
-      `Route source not found for ${appRelativePath} (key ${key})`
-    );
+const FORWARD_HEADERS_EXPORT =
+  'export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader"';
+
+const NO_STORE_HEADERS_EXPORT =
+  'export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader"';
+
+// Auto-discovered so the contract is enforced for future routes too: a route
+// that enables caching but forgets the headers export would otherwise silently
+// drop the header from its document response (caching no-ops with no signal).
+describe("every cached route forwards loader headers", () => {
+  const routes = cachedRoutes();
+
+  it("discovers the expected cached routes", () => {
+    // Sanity check that discovery is actually finding routes; if this drops to
+    // zero the per-route assertions below would vacuously pass.
+    expect(routes.length).toBeGreaterThanOrEqual(14);
+  });
+
+  for (const route of routes) {
+    it(route.path, () => {
+      expect(route.source).toContain(FORWARD_HEADERS_EXPORT);
+    });
   }
-  return content;
-}
-
-// Routes using ssrLoader with caching must forward loader headers (and prefer
-// error headers) on document requests.
-const cachedRouteFiles = [
-  "app/communities/communities.tsx",
-  "app/p/packageListing.tsx",
-  "app/p/packageListingVersion.tsx",
-  "app/p/dependants/Dependants.tsx",
-  "app/p/tabs/Wiki/WikiFirstPage.tsx",
-  "app/p/tabs/Wiki/WikiPage.tsx",
-  "app/p/tabs/Wiki/Wiki.tsx",
-  "app/p/tabs/Readme/PackageVersionReadme.tsx",
-  "app/p/tabs/Readme/Readme.tsx",
-  "app/p/tabs/Changelog/Changelog.tsx",
-  "app/p/tabs/Required/Required.tsx",
-  "app/p/tabs/Versions/Versions.tsx",
-  "app/p/tabs/Versions/PackageVersionVersions.tsx",
-  "app/c/Community.tsx",
-];
+});
 
 // Non-cached, server-rendered routes that sit under a cached parent route.
 // React Router makes a route with no `headers` export inherit its parent's
@@ -50,22 +38,14 @@ const noStoreRouteFiles = [
   "app/p/tabs/Wiki/WikiPageEdit.tsx",
 ];
 
-describe("routes using ssrLoader with cache export forwardLoaderHeaders as headers", () => {
-  for (const file of cachedRouteFiles) {
-    it(file, () => {
-      expect(sourceOf(file)).toContain(
-        'export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader"'
-      );
-    });
-  }
-});
-
 describe("non-cached routes under a cached parent export noStoreHeaders as headers", () => {
+  const byPath = new Map(allRouteSources().map((r) => [r.path, r.source]));
+
   for (const file of noStoreRouteFiles) {
     it(file, () => {
-      expect(sourceOf(file)).toContain(
-        'export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader"'
-      );
+      const source = byPath.get(file);
+      expect(source, `route source not found for ${file}`).toBeDefined();
+      expect(source).toContain(NO_STORE_HEADERS_EXPORT);
     });
   }
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/routeHeaders.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/routeHeaders.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+// Read route source as raw strings via Vite so this works in the browser test
+// environment (Node's fs is unavailable there). Keyed by path relative to this
+// file, e.g. "../../../app/communities/communities.tsx".
+const routeSources = import.meta.glob("../../../app/**/*.tsx", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+function sourceOf(appRelativePath: string): string {
+  const key = `../../../${appRelativePath}`;
+  const content = routeSources[key];
+  if (content === undefined) {
+    throw new Error(
+      `Route source not found for ${appRelativePath} (key ${key})`
+    );
+  }
+  return content;
+}
+
+// Routes using ssrLoader with caching must forward loader headers (and prefer
+// error headers) on document requests.
+const cachedRouteFiles = [
+  "app/communities/communities.tsx",
+  "app/p/packageListing.tsx",
+  "app/p/packageListingVersion.tsx",
+  "app/p/dependants/Dependants.tsx",
+  "app/p/tabs/Wiki/WikiFirstPage.tsx",
+  "app/p/tabs/Wiki/WikiPage.tsx",
+  "app/p/tabs/Wiki/Wiki.tsx",
+  "app/p/tabs/Readme/PackageVersionReadme.tsx",
+  "app/p/tabs/Readme/Readme.tsx",
+  "app/p/tabs/Changelog/Changelog.tsx",
+  "app/p/tabs/Required/Required.tsx",
+  "app/p/tabs/Versions/Versions.tsx",
+  "app/p/tabs/Versions/PackageVersionVersions.tsx",
+  "app/c/Community.tsx",
+];
+
+// Non-cached, server-rendered routes that sit under a cached parent route.
+// React Router makes a route with no `headers` export inherit its parent's
+// Cache-Control, so these must explicitly opt out with noStoreHeaders to avoid
+// leaking the parent's public CDN caching.
+const noStoreRouteFiles = [
+  "app/c/tabs/PackageSearch/PackageSearch.tsx",
+  "app/p/tabs/Source/Source.tsx",
+  "app/p/tabs/Wiki/WikiNewPage.tsx",
+  "app/p/tabs/Wiki/WikiPageEdit.tsx",
+];
+
+describe("routes using ssrLoader with cache export forwardLoaderHeaders as headers", () => {
+  for (const file of cachedRouteFiles) {
+    it(file, () => {
+      expect(sourceOf(file)).toContain(
+        'export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader"'
+      );
+    });
+  }
+});
+
+describe("non-cached routes under a cached parent export noStoreHeaders as headers", () => {
+  for (const file of noStoreRouteFiles) {
+    it(file, () => {
+      expect(sourceOf(file)).toContain(
+        'export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader"'
+      );
+    });
+  }
+});

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
@@ -256,6 +256,61 @@ describe("ssrLoader error Cache-Control", () => {
     const response = await thrownResponse(() => loader(fakeLoaderArgs()));
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
+
+  it("keeps a private route's 404 private (not public CDN-cacheable)", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(404, "Not Found");
+      },
+      { cache: { isPrivate: true } }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    const cacheControl = response.headers.get("Cache-Control") ?? "";
+    expect(cacheControl).toContain("private");
+    expect(cacheControl).not.toContain("public");
+    expect(cacheControl).not.toContain("s-maxage");
+  });
+
+  it("preserves caller browserMaxAge/cdnMaxAge on a 404", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(404, "Not Found");
+      },
+      { cache: { browserMaxAge: 120, cdnMaxAge: 30 } }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    const cacheControl = response.headers.get("Cache-Control") ?? "";
+    expect(cacheControl).toContain("max-age=120");
+    expect(cacheControl).toContain("s-maxage=30");
+  });
+
+  it("defaults a 404 to a short stale-while-revalidate, overridable by the caller", async () => {
+    const defaulted = ssrLoader(
+      async () => {
+        throw createApiError(404, "Not Found");
+      },
+      { cache: true }
+    );
+    const defaultedResponse = await thrownResponse(() =>
+      defaulted(fakeLoaderArgs())
+    );
+    expect(defaultedResponse.headers.get("Cache-Control")).toContain(
+      "stale-while-revalidate=60"
+    );
+
+    const overridden = ssrLoader(
+      async () => {
+        throw createApiError(404, "Not Found");
+      },
+      { cache: { staleWhileRevalidate: 300 } }
+    );
+    const overriddenResponse = await thrownResponse(() =>
+      overridden(fakeLoaderArgs())
+    );
+    expect(overriddenResponse.headers.get("Cache-Control")).toContain(
+      "stale-while-revalidate=300"
+    );
+  });
 });
 
 function headersArgs(overrides: Partial<HeadersArgs>): HeadersArgs {

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
@@ -1,9 +1,9 @@
-import type { LoaderFunctionArgs } from "react-router";
+import type { HeadersArgs, LoaderFunctionArgs } from "react-router";
 import { describe, expect, it } from "vitest";
 
 import { ApiError } from "@thunderstore/thunderstore-api";
 
-import { ssrLoader } from "../ssrLoader";
+import { forwardLoaderHeaders, noStoreHeaders, ssrLoader } from "../ssrLoader";
 
 function fakeLoaderArgs(
   overrides: Partial<LoaderFunctionArgs> = {}
@@ -189,5 +189,120 @@ describe("ssrLoader", () => {
       const body = await (thrown as Response).json();
       expect(body.url).toBe(apiUrl);
     }
+  });
+});
+
+async function thrownResponse(run: () => Promise<unknown>): Promise<Response> {
+  try {
+    await run();
+    expect.unreachable("should have thrown");
+  } catch (thrown) {
+    return thrown as Response;
+  }
+  throw new Error("unreachable");
+}
+
+describe("ssrLoader error Cache-Control", () => {
+  it("never caches 5xx responses (no-store)", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(500, "Internal Server Error");
+      },
+      { cache: true }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("briefly CDN-caches 404 on a cacheable route", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(404, "Not Found");
+      },
+      { cache: true }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    const cacheControl = response.headers.get("Cache-Control") ?? "";
+    expect(cacheControl).toContain("public");
+    expect(cacheControl).toContain("s-maxage=300");
+  });
+
+  it("briefly CDN-caches 410 on a cacheable route", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(410, "Gone");
+      },
+      { cache: true }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    expect(response.headers.get("Cache-Control")).toContain("public");
+  });
+
+  it("does not cache 404 on a non-cacheable route (no-store)", async () => {
+    const loader = ssrLoader(async () => {
+      throw createApiError(404, "Not Found");
+    });
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("never caches other 4xx even on a cacheable route (no-store)", async () => {
+    const loader = ssrLoader(
+      async () => {
+        throw createApiError(403, "Forbidden");
+      },
+      { cache: true }
+    );
+    const response = await thrownResponse(() => loader(fakeLoaderArgs()));
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+});
+
+function headersArgs(overrides: Partial<HeadersArgs>): HeadersArgs {
+  return {
+    loaderHeaders: new Headers(),
+    parentHeaders: new Headers(),
+    actionHeaders: new Headers(),
+    errorHeaders: undefined,
+    ...overrides,
+  } as HeadersArgs;
+}
+
+describe("forwardLoaderHeaders", () => {
+  it("forwards loader headers on success", () => {
+    const loaderHeaders = new Headers({
+      "Cache-Control": "public, max-age=60",
+    });
+    const result = forwardLoaderHeaders(headersArgs({ loaderHeaders }));
+    expect(new Headers(result).get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("prefers error headers (no-store) when an error bubbles up", () => {
+    const loaderHeaders = new Headers({
+      "Cache-Control": "public, max-age=60",
+    });
+    const errorHeaders = new Headers({ "Cache-Control": "no-store" });
+    const result = forwardLoaderHeaders(
+      headersArgs({ loaderHeaders, errorHeaders })
+    );
+    expect(new Headers(result).get("Cache-Control")).toBe("no-store");
+  });
+
+  it("falls back to loader headers when error headers carry no Cache-Control", () => {
+    const loaderHeaders = new Headers({
+      "Cache-Control": "public, max-age=60",
+    });
+    const errorHeaders = new Headers({ "X-Other": "1" });
+    const result = forwardLoaderHeaders(
+      headersArgs({ loaderHeaders, errorHeaders })
+    );
+    expect(new Headers(result).get("Cache-Control")).toBe("public, max-age=60");
+  });
+});
+
+describe("noStoreHeaders", () => {
+  it("always returns no-store", () => {
+    const result = noStoreHeaders(headersArgs({}));
+    expect(new Headers(result).get("Cache-Control")).toBe("no-store");
   });
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
@@ -5,14 +5,35 @@ export interface CacheControlOptions {
   isPrivate?: boolean;
 }
 
+// Cache-Control delta-seconds must be a non-negative integer (RFC 7234), so
+// clamp custom inputs to keep the emitted directive well-formed for any caller.
+function deltaSeconds(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 /**
  * Creates a Cache-Control header object for CDN and browser caching.
  *
- * @param options.browserMaxAge - How long browsers cache the response (seconds). Default: 60 (1 min)
- * @param options.cdnMaxAge - How long the CDN caches the response (seconds). Default: 300 (5 min)
- * @param options.staleWhileRevalidate - How long the CDN can serve stale content while
- *   fetching a fresh response in the background (seconds). Default: 600 (10 min)
- * @param options.isPrivate - If true, prevents CDN caching (e.g. for authenticated responses). Default: false
+ * Produces one of two directive sets:
+ * - Public (default): `public, max-age, s-maxage, stale-while-revalidate` —
+ *   honored by both shared (CDN) and private (browser) caches.
+ * - Private (`isPrivate: true`): `private, max-age` only. `cdnMaxAge` and
+ *   `staleWhileRevalidate` are intentionally dropped here — `s-maxage` is a
+ *   shared-cache directive, and we don't emit SWR on private responses (per
+ *   RFC 5861 it would be valid for private caches too, if ever wanted).
+ *
+ * @param options.browserMaxAge - `max-age`: how long any cache may reuse the
+ *   response without revalidating (seconds). Default: 60 (1 min)
+ * @param options.cdnMaxAge - `s-maxage`: shared-cache (CDN) freshness lifetime.
+ *   Public branch only (seconds). Default: 300 (5 min)
+ * @param options.staleWhileRevalidate - `stale-while-revalidate`: how long a
+ *   cache may serve stale content while revalidating in the background. Public
+ *   branch only. On a public response this also applies to browser caches, so
+ *   the effective browser staleness ceiling is `browserMaxAge +
+ *   staleWhileRevalidate` (660s with defaults), not `browserMaxAge` (seconds).
+ *   Default: 600 (10 min)
+ * @param options.isPrivate - If true, prevents shared/CDN caching (e.g. for
+ *   authenticated responses). Default: false
  */
 export function cacheControl(options?: CacheControlOptions): {
   "Cache-Control": string;
@@ -25,15 +46,17 @@ export function cacheControl(options?: CacheControlOptions): {
   } = options ?? {};
 
   if (isPrivate) {
-    return { "Cache-Control": `private, max-age=${browserMaxAge}` };
+    return {
+      "Cache-Control": `private, max-age=${deltaSeconds(browserMaxAge)}`,
+    };
   }
 
   return {
     "Cache-Control": [
       "public",
-      `max-age=${browserMaxAge}`,
-      `s-maxage=${cdnMaxAge}`,
-      `stale-while-revalidate=${staleWhileRevalidate}`,
+      `max-age=${deltaSeconds(browserMaxAge)}`,
+      `s-maxage=${deltaSeconds(cdnMaxAge)}`,
+      `stale-while-revalidate=${deltaSeconds(staleWhileRevalidate)}`,
     ].join(", "),
   };
 }

--- a/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
@@ -25,7 +25,7 @@ export function cacheControl(options?: CacheControlOptions): {
   } = options ?? {};
 
   if (isPrivate) {
-    return { "Cache-Control": `private, max-age=${browserMaxAge}, no-store` };
+    return { "Cache-Control": `private, max-age=${browserMaxAge}` };
   }
 
   return {

--- a/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/cache.ts
@@ -1,0 +1,39 @@
+export interface CacheControlOptions {
+  browserMaxAge?: number;
+  cdnMaxAge?: number;
+  staleWhileRevalidate?: number;
+  isPrivate?: boolean;
+}
+
+/**
+ * Creates a Cache-Control header object for CDN and browser caching.
+ *
+ * @param options.browserMaxAge - How long browsers cache the response (seconds). Default: 60 (1 min)
+ * @param options.cdnMaxAge - How long the CDN caches the response (seconds). Default: 300 (5 min)
+ * @param options.staleWhileRevalidate - How long the CDN can serve stale content while
+ *   fetching a fresh response in the background (seconds). Default: 600 (10 min)
+ * @param options.isPrivate - If true, prevents CDN caching (e.g. for authenticated responses). Default: false
+ */
+export function cacheControl(options?: CacheControlOptions): {
+  "Cache-Control": string;
+} {
+  const {
+    browserMaxAge = 60,
+    cdnMaxAge = 300,
+    staleWhileRevalidate = 600,
+    isPrivate = false,
+  } = options ?? {};
+
+  if (isPrivate) {
+    return { "Cache-Control": `private, max-age=${browserMaxAge}, no-store` };
+  }
+
+  return {
+    "Cache-Control": [
+      "public",
+      `max-age=${browserMaxAge}`,
+      `s-maxage=${cdnMaxAge}`,
+      `stale-while-revalidate=${staleWhileRevalidate}`,
+    ].join(", "),
+  };
+}

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -90,6 +90,14 @@ function errorCacheControl(
  * Loaders wrapped with `cache` MUST remain fully anonymous (no session/cookie
  * reads). Per-user data must be deferred to clientLoader.
  *
+ * Caching also propagates DOWN the route tree: React Router resolves a matched
+ * route's document headers from its own `headers` export, and a route that has
+ * none inherits its parent's accumulated headers. So an uncached child route
+ * under a cached parent (e.g. an editor page under a cached layout) is served
+ * with the parent's public Cache-Control unless it opts out explicitly:
+ *
+ *   export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+ *
  * @example
  * // No caching (default)
  * export const loader = ssrLoader(async ({ request }) => { ... });

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -54,10 +54,12 @@ export const noStoreHeaders: HeadersFunction = () => ({
 /**
  * Resolves the Cache-Control header for a thrown ApiError response.
  *
- * - 404/410 on a cacheable route are briefly CDN-cached so scrapers and bots
- *   hammering nonexistent resources are absorbed by the CDN instead of the
- *   origin. The short stale-while-revalidate window keeps newly-created
- *   resources from staying "missing" for long.
+ * - 404/410 on a cacheable route are briefly cached so scrapers and bots
+ *   hammering nonexistent resources are absorbed by the cache instead of the
+ *   origin. The caller's own CacheControlOptions are preserved (matching the
+ *   success path) — including `isPrivate`, so a private route's not-found stays
+ *   private rather than becoming a public CDN response — while defaulting to a
+ *   short stale-while-revalidate so a created/renamed resource surfaces quickly.
  * - Everything else (other 4xx, all 5xx, and any error on a non-cacheable
  *   route) is never stored by any cache.
  */
@@ -66,7 +68,11 @@ function errorCacheControl(
   cache: CacheControlOptions | boolean
 ): string {
   if (cache !== false && (status === 404 || status === 410)) {
-    return cacheControl({ staleWhileRevalidate: 60 })["Cache-Control"];
+    const cacheOptions = cache === true ? {} : cache;
+    // staleWhileRevalidate first so a caller-supplied value still overrides it.
+    return cacheControl({ staleWhileRevalidate: 60, ...cacheOptions })[
+      "Cache-Control"
+    ];
   }
   return "no-store";
 }

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -1,13 +1,74 @@
 import * as Sentry from "@sentry/react-router";
 import type { CacheControlOptions } from "cyberstorm/utils/cache";
 import { cacheControl } from "cyberstorm/utils/cache";
-import { type LoaderFunctionArgs, data } from "react-router";
+import {
+  type HeadersFunction,
+  type LoaderFunctionArgs,
+  data,
+} from "react-router";
 
 import { isApiError } from "@thunderstore/thunderstore-api";
 
 interface SsrLoaderOptions {
   /** Cache options. Set to true for default CDN caching, or pass an object to customize. Defaults to false (no caching). */
   cache?: CacheControlOptions | boolean;
+}
+
+/**
+ * Headers function to be exported from routes using ssrLoader with caching.
+ *
+ * Forwards Cache-Control headers from the loader on success. When an error
+ * bubbles up (e.g. a child route throws a 5xx), prefers the error's
+ * Cache-Control (no-store) to prevent CDN-caching error pages.
+ *
+ * @example
+ * export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
+ */
+export const forwardLoaderHeaders: HeadersFunction = ({
+  loaderHeaders,
+  errorHeaders,
+}) => {
+  if (errorHeaders && errorHeaders.has("Cache-Control")) {
+    return errorHeaders;
+  }
+  return loaderHeaders;
+};
+
+/**
+ * Headers function for routes that must never be CDN-cached but render under a
+ * cached parent route.
+ *
+ * React Router resolves document headers by walking the matched routes; a route
+ * that exports no `headers` function inherits its parent's Cache-Control. A
+ * non-cached child nested under a cached layout (e.g. an edit page under a
+ * cached wiki layout) would therefore leak the parent's public, s-maxage
+ * caching. Such routes must explicitly opt out by exporting this.
+ *
+ * @example
+ * export { noStoreHeaders as headers } from "cyberstorm/utils/ssrLoader";
+ */
+export const noStoreHeaders: HeadersFunction = () => ({
+  "Cache-Control": "no-store",
+});
+
+/**
+ * Resolves the Cache-Control header for a thrown ApiError response.
+ *
+ * - 404/410 on a cacheable route are briefly CDN-cached so scrapers and bots
+ *   hammering nonexistent resources are absorbed by the CDN instead of the
+ *   origin. The short stale-while-revalidate window keeps newly-created
+ *   resources from staying "missing" for long.
+ * - Everything else (other 4xx, all 5xx, and any error on a non-cacheable
+ *   route) is never stored by any cache.
+ */
+function errorCacheControl(
+  status: number,
+  cache: CacheControlOptions | boolean
+): string {
+  if (cache !== false && (status === 404 || status === 410)) {
+    return cacheControl({ staleWhileRevalidate: 60 })["Cache-Control"];
+  }
+  return "no-store";
 }
 
 /**
@@ -24,7 +85,10 @@ interface SsrLoaderOptions {
  * Routes with caching enabled must also export a `headers` function to forward
  * loader headers on document requests:
  *
- *   export const headers: Route.HeadersFunction = ({ loaderHeaders }) => loaderHeaders;
+ *   export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
+ *
+ * Loaders wrapped with `cache` MUST remain fully anonymous (no session/cookie
+ * reads). Per-user data must be deferred to clientLoader.
  *
  * @example
  * // No caching (default)
@@ -77,7 +141,10 @@ export function ssrLoader<A extends LoaderFunctionArgs, T>(
         throw new Response(JSON.stringify(payload), {
           status,
           statusText,
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": errorCacheControl(status, cache),
+          },
         });
       }
       throw error;

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-router";
 import type { CacheControlOptions } from "cyberstorm/utils/cache";
 import { cacheControl } from "cyberstorm/utils/cache";
 import { type LoaderFunctionArgs, data } from "react-router";
@@ -45,7 +46,7 @@ export function ssrLoader<A extends LoaderFunctionArgs, T>(
     try {
       const result = await fn(args);
 
-      if (cache === false) {
+      if (cache === false || result instanceof Response) {
         return result;
       }
 

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -1,27 +1,58 @@
-import * as Sentry from "@sentry/react-router";
-import type { LoaderFunctionArgs } from "react-router";
+import type { CacheControlOptions } from "cyberstorm/utils/cache";
+import { cacheControl } from "cyberstorm/utils/cache";
+import { type LoaderFunctionArgs, data } from "react-router";
 
 import { isApiError } from "@thunderstore/thunderstore-api";
 
+interface SsrLoaderOptions {
+  /** Cache options. Set to true for default CDN caching, or pass an object to customize. Defaults to false (no caching). */
+  cache?: CacheControlOptions | boolean;
+}
+
 /**
- * Wraps react-router's SSR loader to cast ApiErrors into Response objects.
+ * Wraps react-router's SSR loader to cast ApiErrors into Response objects
+ * and apply Cache-Control headers for CDN caching.
  *
  * React Router only serializes basic Error properties (message, stack) during
  * SSR hydration. Custom properties of ApiError are lost when the error is sent
  * from server to client, causing hydration mismatch errors. Convert ApiErrors
  * to Response objects to preserve all data across SSR/client boundary.
  *
- * 5xx ApiErrors are reported to Sentry before conversion because
- * sentryHandleError (handleError) filters out Response throws, which means
- * server-side API failures would otherwise be invisible in Sentry.
- * 4xx errors are intentional user-facing responses and are not captured.
+ * Caching is disabled by default. Pass `cache: true` for standard CDN settings,
+ * or provide a CacheControlOptions object to customize durations.
+ * Routes with caching enabled must also export a `headers` function to forward
+ * loader headers on document requests:
+ *
+ *   export const headers: Route.HeadersFunction = ({ loaderHeaders }) => loaderHeaders;
+ *
+ * @example
+ * // No caching (default)
+ * export const loader = ssrLoader(async ({ request }) => { ... });
+ *
+ * // Default CDN caching
+ * export const loader = ssrLoader(async ({ request }) => { ... }, { cache: true });
+ *
+ * // Custom cache durations
+ * export const loader = ssrLoader(async ({ request }) => { ... }, { cache: { cdnMaxAge: 60 } });
  */
 export function ssrLoader<A extends LoaderFunctionArgs, T>(
-  fn: (args: A) => Promise<T>
+  fn: (args: A) => Promise<T>,
+  options?: SsrLoaderOptions
 ): (args: A) => Promise<T> {
+  const { cache = false } = options ?? {};
+
   return async (args: A): Promise<T> => {
     try {
-      return await fn(args);
+      const result = await fn(args);
+
+      if (cache === false) {
+        return result;
+      }
+
+      const cacheOptions = cache === true ? {} : cache;
+      return data(result, {
+        headers: cacheControl(cacheOptions),
+      }) as unknown as T;
     } catch (error) {
       if (isApiError(error)) {
         const { status, statusText, url } = error.response;
@@ -42,14 +73,12 @@ export function ssrLoader<A extends LoaderFunctionArgs, T>(
         // Include only handpicked attributes to avoid sensitive information
         // ending up e.g. on logs.
         const payload = { status, statusText, url };
-
         throw new Response(JSON.stringify(payload), {
           status,
           statusText,
           headers: { "Content-Type": "application/json" },
         });
       }
-
       throw error;
     }
   };

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -88,7 +88,14 @@ function errorCacheControl(
  *   export { forwardLoaderHeaders as headers } from "cyberstorm/utils/ssrLoader";
  *
  * Loaders wrapped with `cache` MUST remain fully anonymous (no session/cookie
- * reads). Per-user data must be deferred to clientLoader.
+ * reads). Per-user data must be deferred to clientLoader. This invariant is
+ * load-bearing: the emitted Cache-Control is `public` with no `Vary`, and it is
+ * applied to BOTH the document HTML and the single-fetch `.data` responses
+ * (React Router runs `getDocumentHeaders` for both). The `.data` requests carry
+ * the session cookie, so if a cached loader ever rendered session-dependent
+ * output, the CDN would cross-serve one user's response to everyone. `Vary` is
+ * intentionally omitted (`Vary: Cookie` would key the cache per-user and negate
+ * caching entirely); the anonymity invariant is the protection instead.
  *
  * Caching also propagates DOWN the route tree: React Router resolves a matched
  * route's document headers from its own `headers` export, and a route that has


### PR DESCRIPTION
Implement cache control headers in selected Nimbus views. Implement a util for creating cache-control headers and integrate this into the ssrLoader which wraps the SSR loader() functions. The default behavior ignores caching, so caching has to be switched on if caching is rquired in selected route.

* Add util for building Cache-Control headers
* Integrate Cache-Control util in ssrLoader to enable cache
* Add cache to selected views