### PR TITLE
Fix logout 404

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
@@ -507,7 +507,7 @@ export function DesktopUserDropdown(props: {
       <NewDropDownItem asChild>
         <NewLink
           primitiveType="link"
-          href={buildLogoutUrl(domain)}
+          href={buildLogoutUrl()}
           rootClasses="dropdown__item navigation-header__dropdown-item"
         >
           <NewIcon csMode="inline" noWrapper csVariant="tertiary" csWidth="1em">
@@ -611,7 +611,7 @@ export function MobileUserMenu(props: {
         <section>
           <NewLink
             primitiveType="link"
-            href={buildLogoutUrl(domain)}
+            href={buildLogoutUrl()}
             rootClasses="mobile-navigation__popover-item mobile-navigation__popover--thick"
           >
             <NewIcon csMode="inline" noWrapper>

--- a/apps/cyberstorm-remix/cyberstorm/utils/ThunderstoreAuth.tsx
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ThunderstoreAuth.tsx
@@ -18,10 +18,16 @@ export function buildAuthLoginUrl(props: LoginProps) {
   }`;
 }
 
-export function buildLogoutUrl(domain?: string) {
-  const publicEnvVariables = getPublicEnvVariables(["VITE_AUTH_RETURN_URL"]);
+export function buildLogoutUrl() {
+  const publicEnvVariables = getPublicEnvVariables([
+    "VITE_AUTH_BASE_URL",
+    "VITE_AUTH_RETURN_URL",
+  ]);
+  const authBaseUrl = publicEnvVariables.VITE_AUTH_BASE_URL || "";
   const returnURL = publicEnvVariables.VITE_AUTH_RETURN_URL || "";
-  const logoutURL = domain ? `${domain}/logout/` : "/logout";
+  const logoutURL = authBaseUrl
+    ? `${authBaseUrl}/auth/logout/`
+    : "/auth/logout/";
   return `${logoutURL}?next=${encodeURIComponent(returnURL)}`;
 }
 


### PR DESCRIPTION
The logout link pointed to thunderstore.dev/logout/ which is not routed to Django, falling through to the React UI catch-all and returning a 404.

Update buildLogoutUrl() to use VITE_AUTH_BASE_URL + /auth/logout/ instead of VITE_API_URL + /logout/. This sends users to auth.thunderstore.dev/auth/logout/ which has a catch-all ingress to Django, and CommunitySiteMiddleware allows /auth/* paths on that host.

Refs. TS-3345