### PR TITLE
Add robots.txt to Nimbus

### DIFF
--- a/apps/cyberstorm-remix/app/__tests__/robotsTxt.test.ts
+++ b/apps/cyberstorm-remix/app/__tests__/robotsTxt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { loader } from "../robotsTxt";
+
+describe("robots.txt loader", () => {
+  it("responds with status 200", async () => {
+    const response = await loader();
+    expect(response.status).toBe(200);
+  });
+
+  it("serves a UTF-8 plain text body as required by RFC 9309", async () => {
+    const response = await loader();
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8"
+    );
+  });
+
+  it("allows caching with an explicit max-age", async () => {
+    const response = await loader();
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
+  });
+
+  it("serves the same crawler rules as the legacy Django site", async () => {
+    const response = await loader();
+    const body = await response.text();
+    expect(body).toBe(
+      "User-agent: *\n" +
+        "Disallow: /auth/\n" +
+        "Allow: /api/docs/\n" +
+        "Disallow: /api/\n"
+    );
+  });
+});

--- a/apps/cyberstorm-remix/app/robotsTxt.tsx
+++ b/apps/cyberstorm-remix/app/robotsTxt.tsx
@@ -1,0 +1,32 @@
+/**
+ * Resource route serving /robots.txt per the Robots Exclusion Protocol
+ * (RFC 9309).
+ *
+ * The rules are a snapshot (2026-06-11) of what the legacy Django site
+ * serves on thunderstore.io, where they live in an admin-editable
+ * DynamicHTML placement ("robots_txt") — rule changes now require a code
+ * change here. Crawlers are kept out of the API and auth endpoints, but
+ * allowed into the API docs. Per RFC 9309 the longest matching path takes
+ * precedence, so the "Allow: /api/docs/" exception applies regardless of
+ * rule order.
+ */
+
+const ROBOTS_TXT =
+  [
+    "User-agent: *",
+    "Disallow: /auth/",
+    "Allow: /api/docs/",
+    "Disallow: /api/",
+  ].join("\n") + "\n";
+
+export async function loader() {
+  return new Response(ROBOTS_TXT, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      // RFC 9309 allows crawlers to cache robots.txt for up to 24 hours;
+      // a shorter explicit max-age lets rule changes roll out faster.
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/apps/cyberstorm-remix/app/routes.ts
+++ b/apps/cyberstorm-remix/app/routes.ts
@@ -9,6 +9,7 @@ import {
 export default [
   index("./communities/communities.tsx", { id: "rootIndex" }),
   route("healthz", "./healthz.tsx"),
+  route("robots.txt", "./robotsTxt.tsx"),
 
   route("/communities", "./communities/communities.tsx"),
   route("/c/:communityId", "c/Community.tsx", [


### PR DESCRIPTION
## What

Adds a dedicated `/robots.txt` resource route to cyberstorm-remix (Nimbus) so crawlers receive explicit directives instead of falling through to the SPA.

## Why

The legacy Django site serves `robots.txt` from an admin-editable DynamicHTML placement (`robots_txt`). Nimbus had no equivalent, so crawlers got no directives. This ports the current rules so behaviour matches across both stacks.

## Details

- New resource route `route("robots.txt", "./robotsTxt.tsx")`; the loader returns RFC 9309 plain text:
  ```
  User-agent: *
  Disallow: /auth/
  Allow: /api/docs/
  Disallow: /api/
  ```
  (Per RFC 9309 the longest matching path wins, so `Allow: /api/docs/` applies regardless of rule order.)
- Response headers: `Content-Type: text/plain; charset=utf-8`, `Cache-Control: public, max-age=3600`.
- The rules are a snapshot (2026-06-11) of the Django placement. **Note:** they are now hardcoded here — future changes require a code change rather than an admin edit.
- Vitest coverage for status, headers, and the exact body.
