### PR TITLE
Pass through data() results in ssrLoader instead of re-wrapping

### DIFF
--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/ssrLoader.test.ts
@@ -1,4 +1,4 @@
-import type { HeadersArgs, LoaderFunctionArgs } from "react-router";
+import { type HeadersArgs, type LoaderFunctionArgs, data } from "react-router";
 import { describe, expect, it } from "vitest";
 
 import { ApiError } from "@thunderstore/thunderstore-api";
@@ -359,5 +359,48 @@ describe("noStoreHeaders", () => {
   it("always returns no-store", () => {
     const result = noStoreHeaders(headersArgs({}));
     expect(new Headers(result).get("Cache-Control")).toBe("no-store");
+  });
+});
+
+const isDataWithResponseInit = (value: unknown): boolean =>
+  typeof value === "object" &&
+  value !== null &&
+  "type" in value &&
+  "data" in value &&
+  "init" in value &&
+  (value as { type?: unknown }).type === "DataWithResponseInit";
+
+// gatedSsr404 returns a data() value (status 404), not a Response. ssrLoader
+// must pass it through; re-wrapping would drop the 404 and nest the payload.
+describe("ssrLoader with a data() result (e.g. gatedSsr404)", () => {
+  it("passes a DataWithResponseInit through without re-wrapping, preserving status and shape", async () => {
+    const gated = data(
+      { listing: undefined, __gatedSsr404: true },
+      { status: 404 }
+    );
+    const loader = ssrLoader(async () => gated, { cache: true });
+
+    const result = await loader(fakeLoaderArgs());
+
+    expect(result).toBe(gated);
+    expect(isDataWithResponseInit(result)).toBe(true);
+    // 404 preserved, payload not nested under .data.
+    expect((result as { init: { status?: number } }).init.status).toBe(404);
+    const inner = (result as { data: unknown }).data;
+    expect(isDataWithResponseInit(inner)).toBe(false);
+    expect((inner as { __gatedSsr404?: boolean }).__gatedSsr404).toBe(true);
+  });
+
+  it("still wraps a plain object result with public cache headers", async () => {
+    const loader = ssrLoader(async () => ({ hello: "world" }), { cache: true });
+    const result = await loader(fakeLoaderArgs());
+    expect(isDataWithResponseInit(result)).toBe(true);
+    const headers = new Headers(
+      (result as unknown as { init: { headers?: HeadersInit } }).init.headers
+    );
+    expect(headers.get("Cache-Control")).toContain("public");
+    expect((result as unknown as { data: { hello: string } }).data.hello).toBe(
+      "world"
+    );
   });
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/ssrLoader.ts
@@ -14,6 +14,21 @@ interface SsrLoaderOptions {
   cache?: CacheControlOptions | boolean;
 }
 
+// react-router doesn't export a predicate for its `data()` return value, so
+// duck-type the tag the way the framework does internally.
+function isDataWithResponseInit(
+  value: unknown
+): value is { type: "DataWithResponseInit"; data: unknown; init: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    "data" in value &&
+    "init" in value &&
+    (value as { type?: unknown }).type === "DataWithResponseInit"
+  );
+}
+
 /**
  * Headers function to be exported from routes using ssrLoader with caching.
  *
@@ -131,7 +146,14 @@ export function ssrLoader<A extends LoaderFunctionArgs, T>(
     try {
       const result = await fn(args);
 
-      if (cache === false || result instanceof Response) {
+      if (
+        cache === false ||
+        result instanceof Response ||
+        isDataWithResponseInit(result)
+      ) {
+        // gatedSsr404 (and any Response/data() result) already carries its own
+        // status and headers; re-wrapping would drop the status and nest the
+        // payload, since React Router unwraps only one level. Pass it through.
         return result;
       }
 


### PR DESCRIPTION
A cached route whose loader returns a react-router data() value — notably
gatedSsr404(), which carries its own 404 status — was being wrapped a
second time. ssrLoader's success branch only short-circuits on
`cache === false` or `result instanceof Response`, and a
DataWithResponseInit is neither, so it fell through to
`data(result, { headers: cacheControl() })`.

React Router unwraps a DataWithResponseInit exactly one level, so the
double wrap:
- dropped the inner 404 status (the outer init carried only headers), so
  the document and .data responses were served 200 and CDN-cached as a
  public, s-maxage "soft 404"; and
- nested the payload under .data, so useLoaderData() received the wrapper
  instead of the flat loader data (the gated sentinel and every field
  read as undefined).

This hit the three gated package routes (packageListing,
packageListingVersion, dependants), defeating gatedSsr's goal of
returning a real 404 document to anonymous/crawler direct entries for
hidden or nonexistent packages. The loaders stay anonymous
(sessionId: undefined) and the gated payload is public-only, so no user
data was cached — this is a status/SEO correctness regression, not a
data leak.

Fix: treat a DataWithResponseInit result like a Response in ssrLoader's
success branch and pass it through untouched. Such loaders own their own
status/headers and opt out of ssrLoader's cache wrapping, restoring the
pre-caching behavior (404 preserved, not publicly cached).

Tests:
- Add ssrLoader cases covering a data()/gatedSsr404-style result (status
  and flat shape preserved, not re-wrapped) and confirming a plain object
  result is still wrapped with public cache headers.

Refs. TS-3735