### PR TITLE
Add a slash to permissions fetch path

### DIFF
--- a/packages/thunderstore-api/src/get/package.ts
+++ b/packages/thunderstore-api/src/get/package.ts
@@ -10,7 +10,7 @@ export async function fetchPackagePermissions(
   props: ApiEndpointProps<PackagePermissionsRequestParams, object, object>
 ): Promise<PackagePermissionsResponseData> {
   const { config, params } = props;
-  const path = `api/cyberstorm/package/${params.community_id}/${params.namespace_id}/${params.package_name}/permissions`;
+  const path = `api/cyberstorm/package/${params.community_id}/${params.namespace_id}/${params.package_name}/permissions/`;
   const request = { cache: "no-store" as RequestCache };
 
   return await apiFetch({


### PR DESCRIPTION
Without it we're hitting a url which return a 301 to the url with the
slash. This eliminates one unneeded request.