### PR TITLE
TS-3957: Localize version upload-date timestamps

### DIFF
--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionVersions.tsx
@@ -10,6 +10,7 @@ import { useLoaderData } from "react-router";
 
 import {
   Heading,
+  LocalDateTime,
   NewLink,
   NewTable,
   NewTableSort,
@@ -140,7 +141,7 @@ export default function Versions() {
                     sortValue: v.version_number,
                   },
                   {
-                    value: new Date(v.datetime_created).toUTCString(),
+                    value: <LocalDateTime time={v.datetime_created} />,
                     sortValue: v.datetime_created,
                   },
                   {

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/PackageVersionWithoutCommunityVersions.tsx
@@ -9,6 +9,7 @@ import { useLoaderData } from "react-router";
 
 import {
   Heading,
+  LocalDateTime,
   NewLink,
   NewTable,
   NewTableSort,
@@ -126,7 +127,7 @@ export default function Versions() {
                     sortValue: v.version_number,
                   },
                   {
-                    value: new Date(v.datetime_created).toUTCString(),
+                    value: <LocalDateTime time={v.datetime_created} />,
                     sortValue: v.datetime_created,
                   },
                   {

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -11,6 +11,7 @@ import { useLoaderData } from "react-router";
 
 import {
   Heading,
+  LocalDateTime,
   NewLink,
   NewTable,
   type NewTableLabels,
@@ -133,7 +134,7 @@ export default function Versions() {
                     sortValue: v.version_number,
                   },
                   {
-                    value: new Date(v.datetime_created).toUTCString(),
+                    value: <LocalDateTime time={v.datetime_created} />,
                     sortValue: v.datetime_created,
                   },
                   {

--- a/packages/cyberstorm/src/components/LocalDateTime/LocalDateTime.tsx
+++ b/packages/cyberstorm/src/components/LocalDateTime/LocalDateTime.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+interface Props {
+  /** Time value to display (ISO string or Date). */
+  time: Date | string;
+  /** Intl date style; defaults to "medium" (e.g. "Jan 1, 2024"). */
+  dateStyle?: "full" | "long" | "medium" | "short";
+  /** Intl time style; defaults to "short". Pass null to render the date only. */
+  timeStyle?: "full" | "long" | "medium" | "short" | null;
+}
+
+function format(
+  dt: Date,
+  locales: string | string[] | undefined,
+  dateStyle: Props["dateStyle"],
+  timeStyle: Props["timeStyle"],
+  timeZone?: string
+): string {
+  return dt.toLocaleString(locales, {
+    dateStyle,
+    ...(timeStyle ? { timeStyle } : {}),
+    ...(timeZone ? { timeZone } : {}),
+  });
+}
+
+/**
+ * Display an absolute timestamp in the visitor's own locale and timezone.
+ *
+ * The server has no knowledge of the visitor's locale or timezone, so the first
+ * render (SSR + initial hydration) is pinned to a fixed "en-US" locale *and*
+ * UTC timezone to stay deterministic — without the fixed timezone the string
+ * would otherwise vary with the server's TZ and diverge from the client's first
+ * render, causing a hydration mismatch/flicker. After mount we re-render with
+ * `navigator.languages` and the visitor's local timezone. `suppressHydrationWarning`
+ * lets that post-mount value replace the server's string without a warning.
+ */
+export const LocalDateTime = (props: Props) => {
+  const { time, dateStyle = "medium", timeStyle = "short" } = props;
+  const dt = typeof time === "string" ? new Date(time) : time;
+
+  const [text, setText] = useState(() =>
+    format(dt, "en-US", dateStyle, timeStyle, "UTC")
+  );
+
+  useEffect(() => {
+    const d = typeof time === "string" ? new Date(time) : time;
+    const locales =
+      navigator.languages && navigator.languages.length > 0
+        ? [...navigator.languages]
+        : [navigator.language || "en-US"];
+    setText(format(d, locales, dateStyle, timeStyle));
+  }, [time, dateStyle, timeStyle]);
+
+  // dir="auto" lets the browser infer the reading direction from the rendered
+  // text, so localized timestamps display correctly under RTL locales.
+  return (
+    <span suppressHydrationWarning dir="auto" title={text}>
+      {text}
+    </span>
+  );
+};
+
+LocalDateTime.displayName = "LocalDateTime";

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -42,6 +42,7 @@ export {
   thunderstoreLinkProps,
 } from "./components/Links/LinkingProvider";
 export { CyberstormLink } from "./components/Links/Links";
+export { LocalDateTime } from "./components/LocalDateTime/LocalDateTime";
 export { RelativeTime } from "./components/RelativeTime/RelativeTime";
 export {
   TextAreaInput,


### PR DESCRIPTION
The Versions tab rendered upload dates with toUTCString(), always showing GMT
regardless of the viewer's timezone. Add a reusable, SSR-safe LocalDateTime
component that renders an absolute timestamp in the visitor's own locale and
timezone (server/first paint use a fixed locale for hydration stability, then
navigator.languages takes over after mount). Use it for the "Upload date" cell
in all three Versions routes; sorting still uses the raw ISO sortValue.