### PR TITLE
TS-3956: Add a version select to the package report form

### DIFF
--- a/apps/cyberstorm-remix/app/p/components/ReportPackage/ReportPackageForm.tsx
+++ b/apps/cyberstorm-remix/app/p/components/ReportPackage/ReportPackageForm.tsx
@@ -37,6 +37,10 @@ export interface ReportPackageFormProps {
   community: string;
   namespace: string;
   package: string;
+  // Available version_numbers (newest first) and the one to preselect (the
+  // version the user currently has open).
+  versions: string[];
+  defaultVersion: string;
 }
 
 interface ReportPackageFormFullProps extends ReportPackageFormProps {
@@ -66,8 +70,29 @@ export function ReportPackageForm(
     formInputs,
     updateFormInput,
     resetFormInputs,
+    versions,
+    defaultVersion,
     ...requestParams
   } = props;
+
+  const versionOptions: SelectOption<string>[] = versions.map((v) => ({
+    value: v,
+    label: v,
+  }));
+
+  // The version to submit (and, when the list loaded, the one the select shows
+  // as selected). With a loaded list, only submit a value that's a real option,
+  // so the displayed selection and the submitted value stay in sync. With no
+  // list — the versions fetch failed, so no selector is rendered — fall back to
+  // the seeded default (the version the user has open) so the report still
+  // records a version.
+  const selectedVersionNumber =
+    versions.length === 0
+      ? formInputs.version_number || defaultVersion || undefined
+      : formInputs.version_number &&
+          versions.includes(formInputs.version_number)
+        ? formInputs.version_number
+        : undefined;
 
   type SubmitorOutput = Awaited<ReturnType<typeof packageListingReport>>;
 
@@ -80,7 +105,11 @@ export function ReportPackageForm(
       config: config,
       params: requestParams,
       queryParams: {},
-      data: { reason: data.reason, description: data.description },
+      data: {
+        reason: data.reason,
+        description: data.description,
+        version_number: selectedVersionNumber,
+      },
     });
   }
 
@@ -126,6 +155,22 @@ export function ReportPackageForm(
   return (
     <>
       <Modal.Body>
+        {versionOptions.length > 0 && (
+          <div className="report-package__block">
+            {/* NewSelect doesn't forward id/name to a focusable element, so a
+                <label htmlFor> wouldn't associate — name it via aria-label. */}
+            <span className="report-package__label">Version</span>
+            <NewSelect
+              aria-label="Version"
+              options={versionOptions}
+              value={selectedVersionNumber}
+              onChange={(value) => {
+                updateFormInput("version_number", value);
+              }}
+              csSize="small"
+            />
+          </div>
+        )}
         <div className="report-package__block">
           <label htmlFor="reason" className="report-package__label">
             Reason

--- a/apps/cyberstorm-remix/app/p/components/ReportPackage/useReportPackage.tsx
+++ b/apps/cyberstorm-remix/app/p/components/ReportPackage/useReportPackage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type RequestConfig } from "@thunderstore/thunderstore-api";
 
@@ -11,13 +11,22 @@ import {
 import { ReportPackageModal } from "./ReportPackageModal";
 import { ReportPackageSubmitted } from "./ReportPackageSubmitted";
 
-const createInitialFormInputs = (): ReportPackageFormState => ({
+const createInitialFormInputs = (
+  defaultVersion?: string
+): ReportPackageFormState => ({
   reason: null,
   description: "",
+  // Only seed a version when we actually have one: the request schema requires
+  // a non-empty version_number (z.string().min(1)), so seeding "" would fail
+  // client-side validation — omit it instead.
+  ...(defaultVersion ? { version_number: defaultVersion } : {}),
 });
 
 export function useReportPackage(formProps: {
-  formPropsPromise: Promise<ReportPackageFormProps>;
+  // Factory (not an already-started promise) so the version list is fetched
+  // lazily — only when the modal first opens — and is keyed to the package
+  // identity: a new factory means a new package, which resets the cached props.
+  formPropsFactory: () => Promise<ReportPackageFormProps>;
   config: () => RequestConfig;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -45,21 +54,54 @@ export function useReportPackage(formProps: {
     }));
   }, []);
 
-  const resetFormInputs = useCallback(() => {
-    setFormInputs(createInitialFormInputs());
-  }, []);
+  const { formPropsFactory } = formProps;
 
   const [props, setProps] = useState<ReportPackageFormProps | null>(null);
 
-  async function awaitAndSetProps() {
-    if (!props) {
-      setProps(await formProps.formPropsPromise);
-    }
-  }
+  // Reseed the default version on reset so reopening the modal (after a submit
+  // or cancel) defaults to the current version again instead of an empty select.
+  const resetFormInputs = useCallback(() => {
+    setFormInputs(createInitialFormInputs(props?.defaultVersion));
+  }, [props?.defaultVersion]);
 
+  // Tracks which factory produced the current props so a new factory (i.e. a
+  // different package after client-side nav) discards stale props and refetches.
+  const loadedFactory = useRef<typeof formPropsFactory | null>(null);
+
+  // Fetch lazily: only when the modal opens, and only once per package. Keyed to
+  // the factory so navigating to another package refetches that package's
+  // versions; a cancellation guard avoids setting state after unmount or after
+  // the package changed mid-flight.
   useEffect(() => {
-    awaitAndSetProps();
-  }, [formProps, props, awaitAndSetProps]);
+    // The package changed (new factory): drop the previous package's props and
+    // form inputs so the form doesn't carry the old version list or a reason/
+    // description typed for a different package. The version is reseeded below
+    // once the new props resolve.
+    if (loadedFactory.current && loadedFactory.current !== formPropsFactory) {
+      loadedFactory.current = null;
+      setProps(null);
+      setFormInputs(createInitialFormInputs());
+    }
+    if (!isOpen || loadedFactory.current === formPropsFactory) {
+      return;
+    }
+    let cancelled = false;
+    void formPropsFactory().then((resolved) => {
+      if (cancelled) return;
+      loadedFactory.current = formPropsFactory;
+      setProps(resolved);
+      // Preselect the version the user has open once the version list resolves,
+      // but only if we have a real version and the user hasn't picked one yet.
+      setFormInputs((prev) =>
+        prev.version_number || !resolved.defaultVersion
+          ? prev
+          : { ...prev, version_number: resolved.defaultVersion }
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, formPropsFactory]);
 
   const button = <ReportPackageButton onClick={() => onOpenChange(true)} />;
 

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -8,6 +8,7 @@ import { faArrowUpRight, faLips } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { CommunityPromo } from "app/commonComponents/CommunityPromo/CommunityPromo";
 import { PageHeader } from "app/commonComponents/PageHeader/PageHeader";
+import type { ReportPackageFormProps } from "app/p/components/ReportPackage/ReportPackageForm";
 import { useReportPackage } from "app/p/components/ReportPackage/useReportPackage";
 import TeamMembers from "app/p/components/TeamMembers/TeamMembers";
 import { type OutletContextShape } from "app/root";
@@ -20,6 +21,7 @@ import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import {
   type ReactElement,
   Suspense,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -234,12 +236,36 @@ export default function PackageListing() {
   const [isLiked, setIsLiked] = useState(false);
   const toast = useToast();
 
+  // Lazily fetch the report form's version list: the factory runs only when the
+  // modal first opens, not on every package page view. It's memoized on the
+  // package identity so it stays stable across re-renders but is recreated (and
+  // the cached versions reset) when navigating to a different package. A failed
+  // versions fetch falls back to an empty list so the form still renders.
+  const latestVersionNumber = listing?.latest_version_number;
+  const formPropsFactory = useCallback(
+    async (): Promise<ReportPackageFormProps> => {
+      const versionsData = await dapper
+        .getPackageVersions(namespace_id, package_id)
+        .catch(() => []);
+      return {
+        community: community_identifier,
+        namespace: namespace_id,
+        package: package_id,
+        versions: versionsData.map((v) => v.version_number),
+        // On the package page the open version is the latest one.
+        defaultVersion:
+          latestVersionNumber ?? versionsData[0]?.version_number ?? "",
+      };
+    },
+    // Keyed on the package identity only. `dapper` is intentionally omitted: it
+    // is reconstructed on every root render (see App in root.tsx), so including
+    // it would recreate the factory every render and defeat the lazy/cached
+    // fetch. Its behavior is fixed by the config + the identity args listed here.
+    [community_identifier, namespace_id, package_id, latestVersionNumber]
+  );
+
   const { ReportPackageButton, ReportPackageModal } = useReportPackage({
-    formPropsPromise: Promise.resolve({
-      community: community_identifier,
-      namespace: namespace_id,
-      package: package_id,
-    }),
+    formPropsFactory,
     config: config,
   });
 

--- a/packages/thunderstore-api/src/schemas/requestSchemas.ts
+++ b/packages/thunderstore-api/src/schemas/requestSchemas.ts
@@ -471,7 +471,13 @@ export type PackageListingReportRequestParams = z.infer<
 >;
 
 export const packageListingReportRequestDataSchema = z.object({
-  version: z.number().optional(), // TODO: use SemVer string
+  // SemVer version_number of the reported version. Nonempty: the backend rejects
+  // an empty string during semver parsing, so the UI always sends a real version.
+  // Named `version_number` (not `version`): the previously deployed backend typed
+  // `version` as a PK and 400s on a semver string. A distinct field name lets an
+  // old backend ignore it (it drops unknown fields), so this frontend can deploy
+  // before the matching backend does.
+  version_number: z.string().min(1).optional(),
   reason: z.enum([
     "Spam",
     "Malware",


### PR DESCRIPTION
Package reports never included the version being reported. Add a Version
<NewSelect> to the report form, populated from the package's versions and
defaulting to the one the user has open (the latest on the package page). The
selected version_number is sent with the report, and the request schema now
types version as a SemVer string (matching backend TS-3956).