### PR TITLE
WIP: TS-3955: Reveal the filter sidebar scrollbar on hover

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/CheckboxList/CheckboxList.css
+++ b/apps/cyberstorm-remix/app/commonComponents/CheckboxList/CheckboxList.css
@@ -29,6 +29,13 @@
           opacity: 0;
           pointer-events: none;
         }
+
+        /* Keyboard focus must reveal it too — opacity: 0 alone leaves the
+           focused exclude button invisible. */
+        .checkbox-list__exclude-button:focus-visible {
+          opacity: 1;
+          pointer-events: auto;
+        }
       }
 
       &.checkbox-list__label--off {

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
@@ -1,29 +1,63 @@
 @layer nimbus-components {
+  /* Fixed sidebar + fluid content track. align-items: start preserves the
+     sticky sidebar (grid's default stretch breaks sticky); minmax(0, 1fr) guards
+     the content track against wide children blowing out the grid. */
   .package-search {
-    display: flex;
+    display: grid;
+    grid-template-columns: 15.5rem minmax(0, 1fr);
     gap: var(--gap-xl);
-    align-items: flex-start;
+    align-items: start;
     align-self: stretch;
   }
 
-  .package-search__sidebar {
+  /* Sticky wrapper, not the scroll box (.package-search__sidebar scrolls). The
+     OverlayScrollbar thumb is positioned against this box, so it stays put
+     instead of scrolling away with the filters. */
+  .package-search__sidebar-overlay {
     position: sticky;
     top: calc(var(--header-height) + 1rem);
+  }
+
+  /* Bounded scroll box for the filter list. OverlayScrollbar adds `cs-scroll`
+     after hydration to swap the native bar for a floating thumb; no-JS/touch keep
+     the native bar. min-height: 0 lets the max-height cap clip so it can scroll. */
+  .package-search__sidebar {
     display: flex;
     flex-direction: column;
     gap: var(--gap-sm);
-    align-items: flex-start;
-    min-width: 15.5rem;
+    min-height: 0;
     max-height: calc(100vh - var(--header-height) - 2rem);
     padding-top: var(--space-16);
     border-radius: var(--radius-md);
     overflow-y: auto;
-    scrollbar-width: none;
   }
 
-  .package-search__search {
-    flex: 1;
+  .package-search__filters {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+  }
+
+  .package-search__drawer-toggle {
+    display: none;
+  }
+
+  .package-search__filters--drawer {
     width: 100%;
+    padding-bottom: var(--space-32);
+  }
+
+  .package-search__drawer-sorting {
+    display: none;
+    width: 100%;
+  }
+
+  .package-search__content {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-24);
+    align-content: start;
+    padding-top: var(--space-16);
   }
 
   .package-search__search-wrapper {
@@ -33,37 +67,70 @@
     width: 100%;
   }
 
-  .package-search__filters {
+  .package-search__search {
+    flex: 1;
+  }
+
+  .package-search__search-params {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--gap-md);
+    min-width: 0;
+  }
+
+  .package-search__tags {
     display: flex;
-    flex-direction: column;
     gap: var(--gap-sm);
-    gap: 0.75rem;
-    align-items: stretch;
-    align-self: stretch;
-    width: 15.5rem;
+    align-items: center;
+    min-width: 0;
   }
 
-  .package-search__drawer-toggle {
-    display: none;
+  /* Sorting at the start, results count at the end. */
+  .package-search__tools {
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: var(--gap-xl);
+    align-items: center;
+    justify-content: space-between;
   }
 
-  .package-search__filters--drawer {
-    width: 100%;
-    padding-bottom: 2rem;
-  }
-
-  .package-search__drawer-sorting {
-    display: none;
-    width: 100%;
-  }
-
-  .package-search__content {
+  .package-search__listing-actions {
     display: flex;
-    flex: 0 1 100%;
+    align-items: center;
+  }
+
+  .package-search__sorting {
+    display: flex;
+    align-items: center;
+  }
+
+  .package-search__results {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    .skeleton {
+      width: 18ch;
+      height: 1rem;
+    }
+  }
+
+  .package-search__packages {
+    display: flex;
     flex-direction: column;
-    gap: var(--space-24);
-    align-items: flex-start;
-    padding-top: var(--space-16);
+    gap: var(--gap-md);
+    align-items: center;
+  }
+
+  .package-search__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+    gap: var(--gap-sm);
+    width: 100%;
+
+    > .skeleton {
+      height: 30rem;
+    }
   }
 
   .package-search__pagination {
@@ -71,7 +138,6 @@
     flex-direction: column;
     gap: var(--gap-xl);
     align-items: center;
-    align-self: stretch;
     justify-content: center;
     padding: var(--space-48) 0;
     color: var(--color-text-tertiary);
@@ -87,96 +153,13 @@
     }
   }
 
-  .package-search__search-params {
-    display: flex;
-    flex: 1 1 0;
-    flex-direction: column;
-    gap: var(--gap-md);
-    align-items: flex-start;
-    align-self: stretch;
-    justify-content: center;
-    min-width: 0;
-  }
-
-  .package-search__tags {
-    display: flex;
-    flex: 0 1 0;
-    gap: var(--gap-sm);
-    align-items: center;
-    min-width: 0;
-  }
-
-  .package-search__tools {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--gap-xl);
-    align-items: center;
-    align-self: stretch;
-  }
-
-  .package-search__listing-actions {
-    display: flex;
-    gap: var(--gap-md);
-    align-items: center;
-
-    /* > .__display {
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap-xs);
-      align-items: flex-start;
-    } */
-  }
-
-  .package-search__sorting {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .package-search__results {
-    display: flex;
-    flex: 1;
-    gap: var(--gap-2xs);
-    align-items: center;
-    justify-content: flex-end;
-
-    .skeleton {
-      width: 18ch;
-      height: 1rem;
-    }
-  }
-
-  .package-search__packages {
-    display: flex;
-    flex: 1 1 0;
-    flex-direction: column;
-    gap: var(--gap-md);
-    align-items: center;
-    align-self: stretch;
-  }
-
-  .package-search__grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
-    gap: var(--gap-sm);
-    width: 100%;
-
-    > .skeleton {
-      height: 30rem;
-    }
-  }
-
   @media (width <= 48rem) {
-    .package-search__results {
-      align-items: stretch;
-      justify-content: center;
+    /* Drop the sidebar; content spans the single remaining column. */
+    .package-search {
+      grid-template-columns: minmax(0, 1fr);
     }
 
-    .package-search__grid {
-      grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
-    }
-
-    .package-search__sidebar {
+    .package-search__sidebar-overlay {
       display: none;
     }
 
@@ -192,17 +175,25 @@
       display: flex;
     }
 
+    /* One column stacks sorting and the results count. */
     .package-search__tools {
-      flex-direction: column;
-      gap: 0.5rem;
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--space-8);
+    }
+
+    .package-search__results {
       align-items: stretch;
+      justify-content: center;
+    }
+
+    .package-search__grid {
+      grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
     }
   }
 
   @media (width <= 475px) {
-    .package-search__results {
-      align-items: stretch;
-      justify-content: center;
+    .package-search__content {
+      gap: var(--space-8);
     }
 
     .package-search__grid {
@@ -212,14 +203,9 @@
         height: 28rem;
       }
     }
-
-    .package-search__content {
-      gap: 0.5rem;
-      align-self: stretch;
-    }
   }
 
-  /* This is added for better grid on phones */
+  /* Tighter card grid on phones. */
   @media (width <= 416px) {
     .package-search__grid {
       grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.css
@@ -18,9 +18,11 @@
     top: calc(var(--header-height) + 1rem);
   }
 
-  /* Bounded scroll box for the filter list. OverlayScrollbar adds `cs-scroll`
-     after hydration to swap the native bar for a floating thumb; no-JS/touch keep
-     the native bar. min-height: 0 lets the max-height cap clip so it can scroll. */
+  /* Bounded scroll box for the filter list. `cs-scroll` is in the markup
+     statically, so the native bar is hidden from first paint; OverlayScrollbar's
+     floating thumb (post-hydration, fine pointers only) replaces it. no-JS/touch
+     get no visible bar, just wheel/keyboard. min-height: 0 lets the max-height
+     cap clip so it can scroll. */
   .package-search__sidebar {
     display: flex;
     flex-direction: column;

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -18,6 +18,7 @@ import {
   NewIcon,
   NewPagination,
   NewTextInput,
+  OverlayScrollbar,
   SkeletonBox,
 } from "@thunderstore/cyberstorm";
 import { PackageLikeAction } from "@thunderstore/cyberstorm-forms";
@@ -70,6 +71,9 @@ export function PackageSearch(props: Props) {
   const { listings, filters, config, currentUser, dapper, teamName } = props;
 
   const navigationType = useNavigationType();
+
+  // The sidebar is the scroll container; OverlayScrollbar floats a thumb over it.
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   // This exists to resolve insert the initial sections and categories on server-side
   // so that we don't have to await the clientLoader to get the options, to then be able to
@@ -355,9 +359,14 @@ export function PackageSearch(props: Props) {
 
   return (
     <div className="package-search">
-      <div className="package-search__sidebar">
-        <div className="package-search__filters">{filtersContent}</div>
-      </div>
+      <OverlayScrollbar
+        scrollRef={sidebarRef}
+        wrapperClassName="package-search__sidebar-overlay"
+      >
+        <div className="package-search__sidebar cs-scroll" ref={sidebarRef}>
+          <div className="package-search__filters">{filtersContent}</div>
+        </div>
+      </OverlayScrollbar>
 
       <div className="package-search__content">
         <div className="package-search__search-wrapper">

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -34,6 +34,7 @@ import {
   Container,
   LinkingProvider,
   ToastProvider,
+  WindowOverlayScrollbar,
 } from "@thunderstore/cyberstorm";
 import { DapperTs } from "@thunderstore/dapper-ts";
 import { type CurrentUser } from "@thunderstore/dapper/types";
@@ -273,7 +274,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
   }, [location.pathname, location.search]);
 
   return (
-    <html lang="en">
+    // cs-custom-scrollbars hides the native page scrollbar from the very first
+    // SSR paint (not on hydration), so the custom overlay thumb can take over
+    // with zero layout shift. No-JS keeps a scrollable (wheel/keyboard) page
+    // without a visible bar.
+    <html lang="en" className="cs-custom-scrollbars">
       <head>
         {/*
           We define CSS layers inline at the very top of the head to guarantee they are registered
@@ -386,6 +391,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
             </TooltipProvider>
           </ToastProvider>
         </LinkingProvider>
+        <WindowOverlayScrollbar />
         <ScrollRestoration />
         <Scripts />
       </body>

--- a/apps/cyberstorm-remix/app/styles/layout.css
+++ b/apps/cyberstorm-remix/app/styles/layout.css
@@ -22,6 +22,14 @@
     min-width: 0;
   }
 
+  /* #main-content is a tabindex=-1 target focused programmatically (skip link /
+     route changes) for screen-reader context, not a control the user tabs to —
+     so suppress the global focus ring that would otherwise outline the whole
+     content area. */
+  .layout__main:focus-visible {
+    outline: none;
+  }
+
   /* Right ad rail beside the content, ending above the full-width bottom ad
      row. The island spans the content row's height (background column); the
      stack inside is a sticky, viewport-fitted flex column: fishstick / dynamic

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -97,6 +97,10 @@ export {
 export { Menu } from "./newComponents/Menu/Menu";
 export { MetaItem as NewMetaItem } from "./newComponents/MetaItem/MetaItem";
 export { Modal, type ModalProps } from "./newComponents/Modal/Modal";
+export {
+  OverlayScrollbar,
+  WindowOverlayScrollbar,
+} from "./newComponents/OverlayScrollbar";
 export { Pagination as NewPagination } from "./newComponents/Pagination/Pagination";
 export type { PaginationProps } from "./newComponents/Pagination/Pagination";
 export {

--- a/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
+++ b/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
@@ -38,6 +38,23 @@
         background-color: var(--breadcrumb-item-bg-color--hover);
       }
     }
+
+    /* Segments are skewed parallelograms with rounded end-caps, so a default
+       rectangular outline sits askew of the visible shape. Use the hover
+       background as the keyboard-focus indicator instead — it follows the
+       skew and caps exactly. */
+    &:focus-visible {
+      background-color: var(--breadcrumb-item-bg-color--hover);
+      outline: none;
+
+      /* In forced-colors mode the system overrides the background, so the
+         indicator above vanishes. Restore an outline there — rectangular is
+         fine; visible focus matters more than following the skew. */
+      @media (forced-colors: active) {
+        outline: 2px solid;
+        outline-offset: -2px;
+      }
+    }
   }
 
   .breadcrumbs__item-content {
@@ -92,6 +109,11 @@
       &:hover::before {
         background-color: var(--breadcrumb-item-bg-color--hover);
       }
+    }
+
+    /* Keep the rounded home cap in sync with the focus background. */
+    &:focus-visible::before {
+      background-color: var(--breadcrumb-item-bg-color--hover);
     }
   }
 

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
@@ -12,7 +12,7 @@
   }
 
   .card-package:has(:focus-visible) {
-    outline: var(--card-package-focus-outline-offset);
+    outline: var(--card-package-focus-outline);
     outline-offset: var(--card-package-focus-outline-offset);
   }
 

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.css
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.css
@@ -11,8 +11,11 @@
     min-height: 0;
   }
 
-  /* Opt-in: hide the native bar + reclaim its gutter on a CONTAINER. Added by
-     <OverlayScrollbar> after hydration so SSR/no-JS keeps a real native bar.
+  /* Opt-in: hide the native bar + reclaim its gutter on a CONTAINER. The caller
+     puts this class in the markup statically (e.g. PackageSearch), so the native
+     bar is hidden from first paint — the floating thumb (rendered only after
+     hydration, fine pointers only) replaces it with zero layout shift. Trade-off:
+     no-JS / coarse-pointer scrollers get no visible bar, just wheel/keyboard.
      Scoped to this class so it never touches the repo's intentional
      scrollbar-width:none strips (Tabs, Drawer, markdown, etc.) or the global
      `* > * { scrollbar-width: thin }` rule. The element keeps overflow:auto. */
@@ -27,8 +30,10 @@
     height: 0;
   }
 
-  /* Opt-in: hide the native PAGE bar. Added to <html> by
-     <WindowOverlayScrollbar> after hydration. */
+  /* Opt-in: hide the native PAGE bar. Applied to <html> statically in root.tsx
+     markup (not on hydration), so the bar is hidden from first paint and the
+     fixed window thumb (post-hydration, fine pointers only) replaces it with no
+     layout shift. Trade-off: no-JS / coarse-pointer pages get no visible bar. */
   html.cs-custom-scrollbars,
   html.cs-custom-scrollbars body {
     scrollbar-width: none;
@@ -66,6 +71,17 @@
   }
 
   .cs-scrollbar-thumb.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Keep the container thumb visible while the scroll box is hovered or holds
+     keyboard focus, so it stays put even if the JS idle timer fires mid-hover
+     (TS-3955). Only renders when overflowing, so this can't show a thumb with no
+     overflow. Scoped to the container variant; the window thumb sits outside
+     .cs-scroll-overlay and uses its own edge hot-zone reveal. */
+  .cs-scroll-overlay:hover .cs-scrollbar-thumb--container,
+  .cs-scroll-overlay:focus-within .cs-scrollbar-thumb--container {
     opacity: 1;
     pointer-events: auto;
   }

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.css
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.css
@@ -1,0 +1,106 @@
+@layer components {
+  /* Non-scrolling positioned layer wrapping a scroll container. The thumb is an
+     absolute child of THIS element (which does not scroll), so it floats over
+     the content and stays pinned to the visible box instead of scrolling away
+     with the content. display:contents would collapse the positioning context,
+     so it is a real block that simply does not change the child's layout. */
+  .cs-scroll-overlay {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  /* Opt-in: hide the native bar + reclaim its gutter on a CONTAINER. Added by
+     <OverlayScrollbar> after hydration so SSR/no-JS keeps a real native bar.
+     Scoped to this class so it never touches the repo's intentional
+     scrollbar-width:none strips (Tabs, Drawer, markdown, etc.) or the global
+     `* > * { scrollbar-width: thin }` rule. The element keeps overflow:auto. */
+  .cs-scroll {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .cs-scroll::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  /* Opt-in: hide the native PAGE bar. Added to <html> by
+     <WindowOverlayScrollbar> after hydration. */
+  html.cs-custom-scrollbars,
+  html.cs-custom-scrollbars body {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  html.cs-custom-scrollbars::-webkit-scrollbar,
+  html.cs-custom-scrollbars body::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  /* The floating thumb. Hidden at rest; pointer-events off while invisible so
+     it never intercepts clicks/hover on the content underneath. Position +
+     height are written via JS (transform: translate3d / height) — the JS
+     `minThumb` clamp is the single source of truth for the floor, so NO CSS
+     min-height here (a CSS floor would desync the drag math). NEVER transition
+     transform/height — only opacity, and only when motion is allowed. */
+  .cs-scrollbar-thumb {
+    position: absolute;
+    top: 0;
+    right: var(--space-2);
+    z-index: 1;
+    width: var(--space-6);
+    border-radius: var(--radius-full);
+    background-color: var(--color-surface-a8);
+    opacity: 0;
+    pointer-events: none;
+    will-change: transform;
+  }
+
+  .cs-scrollbar-thumb:hover {
+    background-color: var(--color-surface-a10);
+  }
+
+  .cs-scrollbar-thumb.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Window variant: fixed to the viewport. z-index sits ABOVE the sticky nav
+     header (999) and page content, but BELOW the Radix Modal overlay/content
+     (1000, a portaled non-top-layer element) so the thumb never paints over an
+     open dialog. The Drawer/MobileNavigation use the native top layer and are
+     immune to z-index regardless. */
+  .cs-scrollbar-thumb--window {
+    position: fixed;
+    top: 0;
+    right: var(--space-2);
+    z-index: 990;
+  }
+
+  /* While dragging, never let the page select text under the cursor, and force
+     INSTANT scroll so the page can't smooth-animate behind the thumb (reset.css
+     sets `html:focus-within { scroll-behavior: smooth }`). */
+  html.cs-scrollbar-dragging {
+    scroll-behavior: auto !important;
+  }
+
+  html.cs-scrollbar-dragging,
+  html.cs-scrollbar-dragging * {
+    cursor: grabbing !important;
+    user-select: none !important;
+  }
+
+  /* Fade is additive and motion-gated: default is no transition (reduced-motion
+     safe — show/hide is instant), the tween only applies when the user allows
+     motion. Mirrors the reset.css idiom for scroll-behavior. */
+  @media (prefers-reduced-motion: no-preference) {
+    .cs-scrollbar-thumb {
+      transition: opacity 150ms ease;
+    }
+  }
+}

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.tsx
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/OverlayScrollbar.tsx
@@ -1,0 +1,148 @@
+import { type ReactNode, memo, useEffect, useState } from "react";
+
+import "./OverlayScrollbar.css";
+import {
+  type OverlayScrollbarApi,
+  useOverlayScrollbar,
+} from "./useOverlayScrollbar";
+
+/** True only on devices with a precise hovering pointer (mouse/trackpad).
+ *  Touch/coarse devices keep the native OS overlay bar. */
+function useFinePointer(): boolean {
+  const [fine, setFine] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(hover: hover) and (pointer: fine)");
+    setFine(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setFine(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return fine;
+}
+
+/** Mirrors remix-utils' useHydrated without the dependency (remix-utils is an
+ *  app dependency, not a cyberstorm one): false on server and first client
+ *  render, true after mount — so SSR and hydration match. */
+function useHydrated(): boolean {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return hydrated;
+}
+
+function Thumb(props: { api: OverlayScrollbarApi; className: string }) {
+  const { api, className } = props;
+  if (!api.overflowing) return null;
+  return (
+    <div
+      ref={api.thumbRef}
+      className={`${className}${api.visible ? " is-visible" : ""}`}
+      onPointerDown={api.onThumbPointerDown}
+      onPointerEnter={api.onThumbPointerEnter}
+      onPointerLeave={api.onThumbPointerLeave}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * Overlay scrollbar for an arbitrary VERTICAL scroll container.
+ *
+ * Wraps `children` (the scrolling element) in a non-scrolling, position:relative
+ * layer and renders an absolutely-positioned thumb as the wrapper's last child.
+ * The thumb therefore floats OVER the content and does NOT scroll with it
+ * (an absolute child of the scroll element itself would scroll away).
+ *
+ * The single child must be the scrolling element AND carry the `cs-scroll`
+ * class in its markup (which hides the native bar). Applying it statically —
+ * rather than on hydration — keeps the content the same width at SSR and on the
+ * client, so the floating thumb takes over with zero layout shift. Pass that
+ * element's ref as `scrollRef`; the hook reads it for geometry.
+ *
+ * Vertical only; horizontal overflow is not handled.
+ */
+export const OverlayScrollbar = memo(function OverlayScrollbar(props: {
+  /** Ref to the scrolling element (the single child). */
+  scrollRef: React.RefObject<HTMLElement | null>;
+  /** The scrolling element. */
+  children: ReactNode;
+  /** Optional extra classes on the non-scrolling wrapper. */
+  wrapperClassName?: string;
+}) {
+  const { scrollRef, children, wrapperClassName } = props;
+  const hydrated = useHydrated();
+  const fine = useFinePointer();
+  const enabled = hydrated && fine;
+
+  const api = useOverlayScrollbar({
+    target: { kind: "element", ref: scrollRef },
+    enabled,
+  });
+
+  return (
+    <div
+      className={`cs-scroll-overlay${
+        wrapperClassName ? ` ${wrapperClassName}` : ""
+      }`}
+    >
+      {children}
+      {enabled ? (
+        <Thumb
+          api={api}
+          className="cs-scrollbar-thumb cs-scrollbar-thumb--container"
+        />
+      ) : null}
+    </div>
+  );
+});
+
+OverlayScrollbar.displayName = "OverlayScrollbar";
+
+/**
+ * Overlay scrollbar for the document/page. Fixed thumb synced to window scroll,
+ * preserving native document scroll (so ScrollRestoration, back/forward, hash
+ * links and smooth-scroll all keep working). Render once near the end of <body>.
+ *
+ * Requires `<html class="cs-custom-scrollbars">` in the SSR markup (set in
+ * root.tsx) so the native page bar is hidden from first paint — that's what
+ * keeps the SSR->client transition shift-free.
+ *
+ * Vertical only; a horizontally-overflowing page keeps no custom bar (see
+ * remaining risks).
+ */
+export const WindowOverlayScrollbar = memo(function WindowOverlayScrollbar() {
+  const hydrated = useHydrated();
+  const fine = useFinePointer();
+  const enabled = hydrated && fine;
+  const [topInset, setTopInset] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // Measure the sticky header height (unit-agnostic) so the page thumb starts
+    // below the nav instead of hiding behind it. <html> carries
+    // cs-custom-scrollbars statically (set in root.tsx), so the native bar is
+    // already hidden at SSR and there is no hydration reflow to undo here.
+    const probe = document.createElement("div");
+    probe.style.cssText =
+      "position:absolute;visibility:hidden;height:var(--header-height);pointer-events:none;";
+    document.body.appendChild(probe);
+    setTopInset(probe.getBoundingClientRect().height);
+    probe.remove();
+  }, [enabled]);
+
+  const api = useOverlayScrollbar({
+    target: { kind: "window" },
+    enabled,
+    topInset,
+  });
+
+  if (!enabled) return null;
+  return (
+    <Thumb
+      api={api}
+      className="cs-scrollbar-thumb cs-scrollbar-thumb--window"
+    />
+  );
+});
+
+WindowOverlayScrollbar.displayName = "WindowOverlayScrollbar";

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/index.ts
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/index.ts
@@ -1,0 +1,7 @@
+export { OverlayScrollbar, WindowOverlayScrollbar } from "./OverlayScrollbar";
+export {
+  useOverlayScrollbar,
+  type OverlayScrollbarTarget,
+  type UseOverlayScrollbarOptions,
+  type OverlayScrollbarApi,
+} from "./useOverlayScrollbar";

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/useOverlayScrollbar.ts
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/useOverlayScrollbar.ts
@@ -302,6 +302,13 @@ export function useOverlayScrollbar(
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
       rafRef.current = null;
       hideTimerRef.current = null;
+      // If we unmount (or `enabled` flips false) mid-drag, pointerup never
+      // fires, so clear the drag flag + drag class here. Otherwise the global
+      // `user-select: none` / grabbing cursor stays stuck on <html> until reload.
+      if (draggingRef.current) {
+        draggingRef.current = false;
+        document.documentElement.classList.remove("cs-scrollbar-dragging");
+      }
     };
   }, [
     enabled,

--- a/packages/cyberstorm/src/newComponents/OverlayScrollbar/useOverlayScrollbar.ts
+++ b/packages/cyberstorm/src/newComponents/OverlayScrollbar/useOverlayScrollbar.ts
@@ -1,0 +1,406 @@
+import {
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type OverlayScrollbarTarget =
+  | { kind: "element"; ref: RefObject<HTMLElement | null> }
+  | { kind: "window" };
+
+export interface UseOverlayScrollbarOptions {
+  target: OverlayScrollbarTarget;
+  /** Master switch. Pass `isHydrated && isFinePointer` so the hook is inert
+   *  during SSR and on touch devices. Default true. */
+  enabled?: boolean;
+  /** Fade-out delay after the last scroll/hover/drag activity. Default 900ms. */
+  idleMs?: number;
+  /** Minimum thumb length in px (a11y pointer target). Default 32. */
+  minThumb?: number;
+  /** Window case only: px from the right edge that reveals the thumb on hover. */
+  edgeHotZone?: number;
+  /** Window case only: px to inset the thumb track from the top so it clears a
+   *  fixed/sticky header instead of hiding behind it. Element case insets by the
+   *  scroll box's own padding automatically. Default 0. */
+  topInset?: number;
+}
+
+export interface OverlayScrollbarApi {
+  thumbRef: RefObject<HTMLDivElement | null>;
+  visible: boolean;
+  overflowing: boolean;
+  onThumbPointerDown: (e: ReactPointerEvent) => void;
+  /** Spread onto the thumb so hover binding survives the thumb mounting late
+   *  (it only renders once `overflowing` flips true). */
+  onThumbPointerEnter: () => void;
+  onThumbPointerLeave: () => void;
+}
+
+interface Metrics {
+  /** Visible viewport length along the scroll axis. */
+  trackLength: number;
+  /** Total scrollable content length. */
+  scrollSize: number;
+  /** Current scroll offset. */
+  scrollPos: number;
+}
+
+/** Sub-pixel slack so fractional client/scroll heights (zoom, fractional DPR)
+ *  don't leave a phantom 1px overflow or a thumb that never reaches bottom. */
+const OVERFLOW_EPSILON = 1;
+
+/**
+ * Headless overlay-scrollbar engine for a single VERTICAL scroller — either an
+ * arbitrary element or the document/window. Horizontal overflow is out of scope.
+ *
+ * Returns the state + handlers a thumb element needs; positions the thumb by
+ * writing transform/height directly to `thumbRef` inside a coalesced rAF (no
+ * per-frame React re-render). Everything that reads/writes layout lives in
+ * effects, so the server renders nothing geometry-derived and there is no
+ * hydration mismatch.
+ */
+export function useOverlayScrollbar(
+  options: UseOverlayScrollbarOptions
+): OverlayScrollbarApi {
+  const {
+    target,
+    enabled = true,
+    idleMs = 900,
+    minThumb = 32,
+    edgeHotZone = 28,
+    topInset = 0,
+  } = options;
+  const isWindow = target.kind === "window";
+  const elementRef = target.kind === "element" ? target.ref : undefined;
+
+  const thumbRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  // Mutable state kept in refs so listeners never go stale and never re-bind.
+  const rafRef = useRef<number | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoveringThumbRef = useRef(false);
+  const draggingRef = useRef(false);
+  // Mirror of `visible` so onScroll only triggers a re-render on the false->true
+  // edge instead of every scroll tick.
+  const visibleRef = useRef(false);
+  const maxTravelRef = useRef(0);
+  const maxScrollRef = useRef(0);
+  // Drag snapshot.
+  const dragStartPointerRef = useRef(0);
+  const dragStartThumbTopRef = useRef(0);
+
+  const setVisibleBoth = useCallback((next: boolean) => {
+    if (visibleRef.current === next) return;
+    visibleRef.current = next;
+    setVisible(next);
+  }, []);
+
+  // Resolve the live scroll element + metric source for the current target.
+  const readMetrics = useCallback((): Metrics | null => {
+    if (isWindow) {
+      if (typeof window === "undefined") return null;
+      const doc = document.scrollingElement || document.documentElement;
+      return {
+        trackLength: window.innerHeight,
+        scrollSize: doc.scrollHeight,
+        scrollPos: window.scrollY,
+      };
+    }
+    const el = elementRef?.current;
+    if (!el) return null;
+    return {
+      trackLength: el.clientHeight,
+      scrollSize: el.scrollHeight,
+      scrollPos: el.scrollTop,
+    };
+  }, [isWindow, elementRef]);
+
+  const setScrollPos = useCallback(
+    (pos: number) => {
+      // behavior:"auto" forces an INSTANT jump, overriding the global
+      // `html:focus-within { scroll-behavior: smooth }` (reset.css) that would
+      // otherwise make every drag step animate and lag behind the thumb.
+      if (isWindow) {
+        window.scrollTo({ top: pos, behavior: "auto" });
+      } else if (elementRef?.current) {
+        elementRef.current.scrollTo({ top: pos, behavior: "auto" });
+      }
+    },
+    [isWindow, elementRef]
+  );
+
+  // Single source of truth: read layout + write thumb transform in one frame.
+  const update = useCallback(() => {
+    rafRef.current = null;
+    const m = readMetrics();
+    if (!m) return;
+    const thumb = thumbRef.current;
+
+    const maxScroll = m.scrollSize - m.trackLength;
+    if (maxScroll <= OVERFLOW_EPSILON) {
+      maxScrollRef.current = 0;
+      maxTravelRef.current = 0;
+      // Start hidden so a later remount (content grows back) never flashes a
+      // stale is-visible thumb before the next rAF repositions it.
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+      setVisibleBoth(false);
+      setOverflowing(false);
+      return;
+    }
+    setOverflowing(true);
+
+    // Inset the visual track from the top (and bottom) so the thumb clears a
+    // fixed header (window) or the scroll box's own padding (element) instead of
+    // floating in the empty gap above the first item. maxTravel stays 0-based
+    // within the visual track; the inset is added only to the displayed offset,
+    // so the drag math (which reads maxTravelRef) is unaffected.
+    let insetTop = 0;
+    let insetBottom = 0;
+    if (isWindow) {
+      insetTop = topInset;
+    } else {
+      const el = elementRef?.current;
+      if (el) {
+        const cs = getComputedStyle(el);
+        insetTop = parseFloat(cs.paddingTop) || 0;
+        insetBottom = parseFloat(cs.paddingBottom) || 0;
+      }
+    }
+    const visualTrack = Math.max(m.trackLength - insetTop - insetBottom, 0);
+
+    const rawThumb = (m.trackLength / m.scrollSize) * visualTrack;
+    const thumbLen = Math.min(Math.max(rawThumb, minThumb), visualTrack);
+    const maxTravel = Math.max(visualTrack - thumbLen, 0);
+    const ratio = maxScroll > 0 ? m.scrollPos / maxScroll : 0;
+    const thumbTravel = Math.min(Math.max(ratio * maxTravel, 0), maxTravel);
+
+    maxTravelRef.current = maxTravel;
+    maxScrollRef.current = maxScroll;
+
+    if (thumb) {
+      thumb.style.height = `${thumbLen}px`;
+      thumb.style.transform = `translate3d(0, ${insetTop + thumbTravel}px, 0)`;
+    }
+  }, [readMetrics, minThumb, setVisibleBoth, isWindow, elementRef, topInset]);
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(update);
+  }, [update]);
+
+  // --- idle fade ---------------------------------------------------------
+  const armHideTimer = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    if (draggingRef.current || hoveringThumbRef.current) return;
+    hideTimerRef.current = setTimeout(() => setVisibleBoth(false), idleMs);
+  }, [idleMs, setVisibleBoth]);
+
+  const showThumb = useCallback(() => {
+    setVisibleBoth(true);
+    armHideTimer();
+  }, [armHideTimer, setVisibleBoth]);
+
+  // --- listeners ---------------------------------------------------------
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onScroll = () => {
+      scheduleUpdate();
+      showThumb();
+    };
+
+    const onResize = () => scheduleUpdate();
+
+    // Hover reveal. Element case: pointer anywhere over the box. Window case:
+    // only a hot zone near the right edge, so the bar doesn't flash on every
+    // mouse twitch across the page.
+    const onPointerMove = (e: PointerEvent) => {
+      if (isWindow) {
+        if (e.clientX >= window.innerWidth - edgeHotZone) showThumb();
+      } else {
+        showThumb();
+      }
+    };
+
+    const scrollEventTarget: Window | HTMLElement | null = isWindow
+      ? window
+      : elementRef?.current ?? null;
+    const moveTarget: Window | HTMLElement | null = isWindow
+      ? window
+      : elementRef?.current ?? null;
+
+    scrollEventTarget?.addEventListener("scroll", onScroll, { passive: true });
+    moveTarget?.addEventListener(
+      "pointermove",
+      onPointerMove as EventListener,
+      {
+        passive: true,
+      }
+    );
+    if (isWindow)
+      window.addEventListener("resize", onResize, { passive: true });
+
+    // ResizeObserver on the box AND its content so async/expandable content
+    // (CollapsibleMenu, Suspense-resolved grids, ad slots, route changes)
+    // recompute thumb size even when the box itself doesn't resize.
+    let ro: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(() => scheduleUpdate());
+      if (isWindow) {
+        // Observe <body>: its height grows with content, so the page thumb
+        // recomputes when async content (ads, Suspense, route changes) lengthens
+        // the document. documentElement's box stays at viewport height and would
+        // miss that growth. The thumb is position: fixed (out of flow), so this
+        // can't feed back into a resize loop. Viewport resizes are covered by the
+        // window "resize" listener above.
+        ro.observe(document.body);
+      } else if (elementRef?.current) {
+        const el = elementRef.current;
+        ro.observe(el);
+        // Observe every element child so content-size changes from any wrapper
+        // recompute the thumb — no fragile "firstElementChild is the content"
+        // assumption.
+        for (const child of Array.from(el.children)) {
+          ro.observe(child);
+        }
+      }
+    }
+
+    // Lost-pointer fallbacks: if a drag is interrupted (alt-tab, context menu,
+    // OS gesture) without firing pointerup/lostpointercapture, clear the drag
+    // flag so auto-hide isn't suppressed forever.
+    const onWindowBlur = () => {
+      if (draggingRef.current) {
+        draggingRef.current = false;
+        document.documentElement.classList.remove("cs-scrollbar-dragging");
+        armHideTimer();
+      }
+    };
+    window.addEventListener("blur", onWindowBlur);
+
+    // First geometry read after mount (also flips `overflowing`).
+    scheduleUpdate();
+
+    return () => {
+      scrollEventTarget?.removeEventListener("scroll", onScroll);
+      moveTarget?.removeEventListener(
+        "pointermove",
+        onPointerMove as EventListener
+      );
+      if (isWindow) window.removeEventListener("resize", onResize);
+      window.removeEventListener("blur", onWindowBlur);
+      ro?.disconnect();
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+      rafRef.current = null;
+      hideTimerRef.current = null;
+    };
+  }, [
+    enabled,
+    isWindow,
+    elementRef,
+    edgeHotZone,
+    scheduleUpdate,
+    showThumb,
+    armHideTimer,
+  ]);
+
+  // The thumb only renders once `overflowing` flips true, which happens inside
+  // the rAF update() — a frame where thumbRef is still null, so its geometry
+  // isn't written. Re-run after the thumb has mounted so a hover-first reveal
+  // (no prior scroll) shows it correctly sized instead of as a 0-height flash.
+  useEffect(() => {
+    if (enabled && overflowing) scheduleUpdate();
+  }, [enabled, overflowing, scheduleUpdate]);
+
+  // Hover state on the thumb itself: suspend the hide timer while hovered.
+  // Wired via React props (onThumbPointerEnter/Leave) rather than manual
+  // addEventListener so binding survives the thumb mounting late.
+  const onThumbPointerEnter = useCallback(() => {
+    hoveringThumbRef.current = true;
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    setVisibleBoth(true);
+  }, [setVisibleBoth]);
+
+  const onThumbPointerLeave = useCallback(() => {
+    hoveringThumbRef.current = false;
+    armHideTimer();
+  }, [armHideTimer]);
+
+  // --- drag (pointer capture) -------------------------------------------
+  const onThumbPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      if (e.button !== 0) return;
+      const thumb = thumbRef.current;
+      if (!thumb) return;
+      e.preventDefault();
+      thumb.setPointerCapture(e.pointerId);
+      draggingRef.current = true;
+      dragStartPointerRef.current = e.clientY;
+      // Current thumbTop derived from live scroll so the grab point stays fixed.
+      const ratio =
+        maxScrollRef.current > 0
+          ? (readMetrics()?.scrollPos ?? 0) / maxScrollRef.current
+          : 0;
+      dragStartThumbTopRef.current = ratio * maxTravelRef.current;
+      document.documentElement.classList.add("cs-scrollbar-dragging");
+      setVisibleBoth(true);
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+
+      const onMove = (ev: PointerEvent) => {
+        const delta = ev.clientY - dragStartPointerRef.current;
+        const maxTravel = maxTravelRef.current;
+        const maxScroll = maxScrollRef.current;
+        if (maxTravel <= 0) return;
+        const newTop = Math.min(
+          Math.max(dragStartThumbTopRef.current + delta, 0),
+          maxTravel
+        );
+        setScrollPos((newTop / maxTravel) * maxScroll);
+        // The resulting scroll event drives the thumb via scheduleUpdate.
+      };
+      const onUp = (ev: PointerEvent) => {
+        draggingRef.current = false;
+        try {
+          thumb.releasePointerCapture(ev.pointerId);
+        } catch {
+          /* capture already released */
+        }
+        document.documentElement.classList.remove("cs-scrollbar-dragging");
+        thumb.removeEventListener("pointermove", onMove);
+        thumb.removeEventListener("pointerup", onUp);
+        thumb.removeEventListener("pointercancel", onUp);
+        thumb.removeEventListener("lostpointercapture", onUp);
+        armHideTimer();
+      };
+      thumb.addEventListener("pointermove", onMove);
+      thumb.addEventListener("pointerup", onUp);
+      thumb.addEventListener("pointercancel", onUp);
+      thumb.addEventListener("lostpointercapture", onUp);
+    },
+    [readMetrics, setScrollPos, armHideTimer, setVisibleBoth]
+  );
+
+  return {
+    thumbRef,
+    visible,
+    overflowing,
+    onThumbPointerDown,
+    onThumbPointerEnter,
+    onThumbPointerLeave,
+  };
+}


### PR DESCRIPTION
The categories/sections/filters sidebar scrolls when its content overflows but
hid the scrollbar entirely (scrollbar-width: none), giving no affordance that
it scrolls. Keep it hidden at rest and show a thin scrollbar on hover and
keyboard focus-within.