### PR TITLE
TS-3954: Disable bottom ad row, re-enable rail video ad

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
@@ -264,31 +264,30 @@ export const RIGHT_COLUMN_SLOTS: RenderedAdSlot[] = [
     sizes: FISHSTICK_SIZES,
     mediaQuery: RIGHT_COLUMN_MQ,
   }),
-  // Video ad disabled — was causing issues. Re-add this slot to restore it;
-  // RAIL_VIDEO_ID, the onNavigateNimbusAds guard, and the layout.css rule are
-  // left in place so it's a one-spot revert.
-  // {
-  //   containerId: RAIL_VIDEO_ID,
-  //   sizeVariant: "video",
-  //   options: {
-  //     format: "video-nc",
-  //     demo: AD_DEMO_MODE,
-  //     refreshLimit: 0,
-  //     // 300s (5 min) auto-refresh: longer dwell for better viewability/CTR.
-  //     refreshTime: 300,
-  //     onNavigateMin: ON_NAVIGATE_MIN,
-  //     video: {
-  //       // The rail keeps the player on screen; never detach into the floating
-  //       // (docked) player, which otherwise covers the footer on tall layouts.
-  //       float: "never",
-  //     },
-  //     report: {
-  //       ...TOP_LEFT_REPORT,
-  //       icon: true,
-  //     },
-  //     mediaQuery: RIGHT_COLUMN_MQ,
-  //   },
-  // },
+  // In-content video player at the rail's bottom. Re-enabled (TS-3954) after
+  // NitroPay blocked the rubiconproject requests that were causing issues.
+  {
+    containerId: RAIL_VIDEO_ID,
+    sizeVariant: "video",
+    options: {
+      format: "video-nc",
+      demo: AD_DEMO_MODE,
+      refreshLimit: 0,
+      // 300s (5 min) auto-refresh: longer dwell for better viewability/CTR.
+      refreshTime: 300,
+      onNavigateMin: ON_NAVIGATE_MIN,
+      video: {
+        // The rail keeps the player on screen; never detach into the floating
+        // (docked) player, which otherwise covers the footer on tall layouts.
+        float: "never",
+      },
+      report: {
+        ...TOP_LEFT_REPORT,
+        icon: true,
+      },
+      mediaQuery: RIGHT_COLUMN_MQ,
+    },
+  },
   displaySlot({
     containerId: "nimbus-right-column-narrow",
     sizeVariant: "narrow-dynamic",

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -64,6 +64,11 @@ import { Seo } from "./commonComponents/Seo/Seo";
 
 config.autoAddCss = false;
 
+// Bottom ad row disabled (TS-3954) due to poor viewability, pending
+// reassessment. Flip to true to bring the full-width bottom banner + its
+// companions back; the slot config and CSS are left intact for an easy revert.
+const BOTTOM_ADS_ENABLED = false;
+
 // REMIX TODO: https://remix.run/docs/en/main/route/links
 // export const links: LinksFunction = () => [{ rel: "stylesheet", href: styles }];
 
@@ -355,7 +360,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     </Island>
                   )}
                 </IslandContainer>
-                {shouldShowAds ? (
+                {shouldShowAds && BOTTOM_ADS_ENABLED ? (
                   <Island rootClasses="flex--x layout__bottom-ads">
                     <div className="layout__bottom-ads-banners">
                       {BOTTOM_BANNER_AD_SLOTS.map((slot) => (


### PR DESCRIPTION
Bottom banner ads have poor viewability, so gate the bottom-ads Island behind
a BOTTOM_ADS_ENABLED flag (default off) until we reassess; the slot config and
CSS stay intact for an easy revert, and with no container divs rendered the
in-view auction creation simply skips them.

Re-enable the rail video ad that was disabled in 5f54d944 — NitroPay has
blocked the rubiconproject requests that were causing the issue.