### PR TITLE
TS-3952: Add a staff-only Django Admin link to the nav

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
@@ -7,6 +7,7 @@ import {
   faGamepad,
   faLongArrowLeft,
   faUpload,
+  faUserShield,
   faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -536,6 +537,22 @@ export function DesktopUserDropdown(props: {
           </NewLink>
         </NewDropDownItem>
       )}
+      {/* Django admin, only for staff users — mirrors the legacy nav's
+          {% if request.user.is_staff %} Admin link (TS-3952). */}
+      {user.is_staff ? (
+        <NewDropDownItem asChild>
+          <NewLink
+            primitiveType="link"
+            href="/djangoadmin/"
+            rootClasses="dropdown__item navigation-header__dropdown-item"
+          >
+            <NewIcon csMode="inline" noWrapper csVariant="tertiary">
+              <FontAwesomeIcon icon={faUserShield} />
+            </NewIcon>
+            Admin
+          </NewLink>
+        </NewDropDownItem>
+      ) : null}
       <NewDropDownItem asChild>
         <NewLink
           primitiveType="link"
@@ -641,6 +658,19 @@ export function MobileUserMenu(props: {
         </section>
         <div className="mobile-navigation__divider" />
         <section>
+          {/* Django admin, staff only — mirrors the legacy nav (TS-3952). */}
+          {user.is_staff ? (
+            <NewLink
+              primitiveType="link"
+              href="/djangoadmin/"
+              rootClasses="mobile-navigation__popover-item mobile-navigation__popover--thick"
+            >
+              <NewIcon csMode="inline" noWrapper>
+                <FontAwesomeIcon icon={faUserShield} />
+              </NewIcon>
+              Admin
+            </NewLink>
+          ) : null}
           <NewLink
             primitiveType="link"
             href={buildLogoutUrl()}

--- a/apps/cyberstorm-remix/cyberstorm/session/__tests__/SessionContext.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/session/__tests__/SessionContext.test.ts
@@ -102,6 +102,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: [],
         teams_full: [],
+        is_staff: false,
       };
       storeCurrentUser(storage, testUser);
 
@@ -239,6 +240,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: ["team1"],
         teams_full: [],
+        is_staff: false,
       };
 
       storeCurrentUser(storage, testUser);
@@ -259,6 +261,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: [],
         teams_full: [],
+        is_staff: false,
       };
       storeCurrentUser(storage, testUser);
       assert.isNotNull(storage.safeGetJsonValue(CURRENT_USER_KEY));
@@ -306,6 +309,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: [],
         teams_full: [],
+        is_staff: false,
       };
       storeCurrentUser(storage, testUser);
 
@@ -328,6 +332,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: [],
         teams_full: [],
+        is_staff: false,
       };
       storeCurrentUser(storage, testUser);
 
@@ -463,6 +468,7 @@ describe("SessionContext", () => {
         subscription: { expires: null },
         teams: ["team1"],
         teams_full: [],
+        is_staff: false,
       };
       storeCurrentUser(storage, testUser);
       setSessionStale(storage, false);
@@ -472,6 +478,28 @@ describe("SessionContext", () => {
       assert.strictEqual(result.username, "storedUser");
       assert.deepEqual(result.capabilities, ["cap1"]);
       assert.deepEqual(result.teams, ["team1"]);
+    });
+
+    it("should default is_staff to false for a legacy cached user missing the field", async () => {
+      const storage = new StorageManager(SESSION_STORAGE_KEY);
+      // Simulate a session cached before is_staff existed: the object is valid
+      // except that it lacks the is_staff field entirely.
+      const legacyUser = {
+        username: "legacyUser",
+        capabilities: ["cap1"],
+        connections: [],
+        subscription: { expires: null },
+        teams: ["team1"],
+        teams_full: [],
+      };
+      storage.setJsonValue(CURRENT_USER_KEY, legacyUser);
+      setSessionStale(storage, false);
+
+      const result = await getSessionCurrentUser(storage, false);
+
+      // Compatibility guarantee: the missing field is backfilled, not rejected.
+      assert.strictEqual(result.username, "legacyUser");
+      assert.strictEqual(result.is_staff, false);
     });
 
     it("should return empty user and clear storage when stored user is invalid", async () => {

--- a/packages/dapper-fake/src/fakers/user.ts
+++ b/packages/dapper-fake/src/fakers/user.ts
@@ -34,6 +34,7 @@ export const getFakeCurrentUser = async () => {
         member_count: faker.number.int({ min: 1, max: 100 }),
       },
     ],
+    is_staff: true,
   };
 };
 

--- a/packages/dapper/src/types/user.ts
+++ b/packages/dapper/src/types/user.ts
@@ -13,6 +13,7 @@ export interface CurrentUser {
     role: string;
     member_count: number;
   }[];
+  is_staff: boolean;
 }
 
 export interface User {

--- a/packages/thunderstore-api/src/schemas/objectSchemas.ts
+++ b/packages/thunderstore-api/src/schemas/objectSchemas.ts
@@ -355,6 +355,10 @@ export const emptyUserSchema = z.object({
   }),
   teams: z.array(z.string()),
   teams_full: z.array(userTeamSchema),
+  // Optional w/ default so previously-cached sessions (pre-is_staff) still parse.
+  // TODO: tighten to `z.boolean()` once the backend always returns is_staff and
+  // every cached pre-is_staff session has expired.
+  is_staff: z.boolean().optional().default(false),
 });
 
 export type EmptyUser = z.infer<typeof emptyUserSchema>;
@@ -368,6 +372,10 @@ export const userSchema = z.object({
   }),
   teams: z.array(z.string()),
   teams_full: z.array(userTeamSchema),
+  // Optional w/ default so previously-cached sessions (pre-is_staff) still parse.
+  // TODO: tighten to `z.boolean()` once the backend always returns is_staff and
+  // every cached pre-is_staff session has expired.
+  is_staff: z.boolean().optional().default(false),
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/packages/ts-api-react/src/SessionContext.tsx
+++ b/packages/ts-api-react/src/SessionContext.tsx
@@ -237,6 +237,7 @@ const emptyCurrentUser: EmptyUser = {
   },
   teams: [],
   teams_full: [],
+  is_staff: false,
 };
 
 export const getSessionCurrentUser = async (


### PR DESCRIPTION
The backend already returns is_staff on the current-user payload, but zod
stripped it before the UI saw it. Carry is_staff through the user type and
both user schemas (optional + default false so cached sessions still parse),
the empty-user literal, and the fake user. Then render an "Admin" link to
/djangoadmin/ in the desktop dropdown and mobile user menu, gated on
user.is_staff — mirroring the legacy Django nav.