### PR TITLE
TS-3949: Keep modals within the viewport at large display scaling

### DIFF
--- a/packages/cyberstorm/src/newComponents/Modal/Modal.css
+++ b/packages/cyberstorm/src/newComponents/Modal/Modal.css
@@ -28,9 +28,15 @@
     min-width: 15rem;
     max-width: 39rem;
 
+    /* Never taller than the viewport (leave a vertical top/bottom margin), so
+       the title and footer stay on screen at any display/font scaling; the
+       body scrolls within (TS-3949). */
+    max-height: calc(100vh - 4rem);
+
     /* padding: var(--modal-content-padding); */
     border: var(--modal-border);
     border-radius: var(--modal-border-radius);
+    overflow: hidden;
     color: var(--modal-color);
     background: var(--modal-background);
 
@@ -71,6 +77,10 @@
     gap: var(--gap-md);
     align-items: flex-start;
     align-self: stretch;
+
+    /* min-height:0 lets the body shrink below its content height inside the
+       viewport-capped content, so it (not the whole modal) is what scrolls. */
+    min-height: 0;
     max-height: 800px;
     padding: var(--space-32);
     overflow-y: auto;


### PR DESCRIPTION
.modal__content was viewport-centered but had no max-height, and only the body
had a fixed 800px cap. At high Windows display/font scaling the title + body +
footer exceeded the screen and spilled equally above and below, pushing the
footer (e.g. a moderator's reject button) off-screen with no way to scroll.
Cap the content at the viewport height with a small margin and let the body
shrink (min-height: 0) so it, not the whole modal, scrolls.