### PR TITLE
WIP: TS-3948: Make package sub-tab browser titles descriptive

### DIFF
--- a/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Changelog/Changelog.tsx
@@ -48,12 +48,9 @@ export const loader = ssrLoader(
 
     return {
       changelog,
-      seo: createSeo({
-        descriptors: [
-          { title: `Changelog for ${params.packageId} | Thunderstore` },
-          { name: "description", content: `Changelog for ${params.packageId}` },
-        ],
-      }),
+      // Inherit the package page's descriptive title; just prefix the tab name
+      // (the old title dropped the author, colliding across packages) (TS-3948).
+      seo: createSeo({ prefix: "Changelog", descriptors: [] }),
     };
   },
   { cache: true }
@@ -74,6 +71,14 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 
   return {
     changelog: fetchChangelogSafe(dapper, params.namespaceId, params.packageId),
+    // Mirror the loader's SEO so the tab title survives client-side navigation
+    // and hydration.
+    seo: createSeo({
+      descriptors: [
+        { title: `Changelog for ${params.packageId} | Thunderstore` },
+        { name: "description", content: `Changelog for ${params.packageId}` },
+      ],
+    }),
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Required/Required.tsx
@@ -67,15 +67,9 @@ export const loader = ssrLoader(
         version,
         getPageFromUrl(request.url)
       ),
-      seo: createSeo({
-        descriptors: [
-          { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
-          {
-            name: "description",
-            content: `Dependencies for ${namespaceId}-${packageId}`,
-          },
-        ],
-      }),
+      // Inherit the package page's descriptive title; just prefix the tab name
+      // so it reads e.g. "Required | Mod | Thunderstore - ..." (TS-3948).
+      seo: createSeo({ prefix: "Required", descriptors: [] }),
     };
   },
   { cache: true }
@@ -115,6 +109,17 @@ export async function clientLoader({
       version,
       getPageFromUrl(request.url)
     ),
+    // Mirror the loader's SEO so the tab title survives client-side navigation
+    // and hydration (clientLoader.hydrate is true).
+    seo: createSeo({
+      descriptors: [
+        { title: `${namespaceId}-${packageId} Dependencies | Thunderstore` },
+        {
+          name: "description",
+          content: `Dependencies for ${namespaceId}-${packageId}`,
+        },
+      ],
+    }),
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -37,17 +37,9 @@ export async function loader({ params }: Route.LoaderArgs) {
       status: null,
       source: undefined,
       message: undefined,
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${params.namespaceId}-${params.packageId} Source | Thunderstore`,
-          },
-          {
-            name: "description",
-            content: `Source code for ${params.namespaceId}-${params.packageId}`,
-          },
-        ],
-      }),
+      // Inherit the package page's descriptive title; just prefix the tab name
+      // (the tab is labelled "Analysis" in the UI) (TS-3948).
+      seo: createSeo({ prefix: "Analysis", descriptors: [] }),
     };
   }
   return {
@@ -71,10 +63,27 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
         sessionId: tools.getConfig().sessionId,
       };
     });
+    // Mirror the loader's SEO so the tab title stays consistent on client-side
+    // navigation and after hydration (clientLoader.hydrate is true).
+    const okSeo = createSeo({
+      descriptors: [
+        {
+          title: `${params.namespaceId}-${params.packageId} Source | Thunderstore`,
+        },
+        {
+          name: "description",
+          content: `Source code for ${params.namespaceId}-${params.packageId}`,
+        },
+      ],
+    });
+    const errorSeo = createSeo({
+      descriptors: [{ title: "Source Not Found" }],
+    });
     let result: ResultType = {
       status: null,
       source: undefined,
       message: undefined,
+      seo: okSeo,
     };
     try {
       const source = dapper.getPackageSource(
@@ -85,12 +94,14 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
         status: null,
         source: source,
         message: undefined,
+        seo: okSeo,
       };
     } catch (error) {
       result = {
         status: "error",
         source: undefined,
         message: "Analysis not available",
+        seo: errorSeo,
       };
       throw error;
     }
@@ -100,6 +111,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     status: "error",
     message: "Analysis not available",
     source: undefined,
+    seo: createSeo({ descriptors: [{ title: "Source Not Found" }] }),
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Versions/Versions.tsx
@@ -40,17 +40,10 @@ export const loader = ssrLoader(
           params.namespaceId,
           params.packageId
         ),
-        seo: createSeo({
-          descriptors: [
-            {
-              title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
-            },
-            {
-              name: "description",
-              content: `Versions for ${params.namespaceId}-${params.packageId}`,
-            },
-          ],
-        }),
+        // Inherit the package page's descriptive title and just prefix the tab
+        // name, so the browser tab reads e.g. "Versions | Mod | Thunderstore -
+        // The X Mod Database" instead of a generic slug-based title (TS-3948).
+        seo: createSeo({ prefix: "Versions", descriptors: [] }),
       };
     }
     return {
@@ -79,12 +72,27 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
       namespaceId: params.namespaceId,
       packageId: params.packageId,
       versions: dapper.getPackageVersions(params.namespaceId, params.packageId),
+      // Mirror the loader's SEO so the tab title stays consistent on client-side
+      // navigation and after hydration (clientLoader.hydrate would otherwise
+      // drop it).
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${params.namespaceId}-${params.packageId} Versions | Thunderstore - The ${params.communityId} Mod Database`,
+          },
+          {
+            name: "description",
+            content: `Versions for ${params.namespaceId}-${params.packageId}`,
+          },
+        ],
+      }),
     };
   }
   return {
     status: "error",
     message: "Failed to load versions",
     versions: [],
+    seo: createSeo({ descriptors: [{ title: "Versions Not Found" }] }),
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Wiki/Wiki.tsx
@@ -63,17 +63,9 @@ export const loader = ssrLoader(
         packageId: params.packageId,
         slug: params.slug,
         permissions: undefined,
-        seo: createSeo({
-          descriptors: [
-            {
-              title: `${params.namespaceId}-${params.packageId} Wiki | Thunderstore`,
-            },
-            {
-              name: "description",
-              content: `Wiki for ${params.namespaceId}-${params.packageId}`,
-            },
-          ],
-        }),
+        // Inherit the package page's descriptive title; just prefix the tab
+        // name so it reads e.g. "Wiki | Mod | Thunderstore - ..." (TS-3948).
+        seo: createSeo({ prefix: "Wiki", descriptors: [] }),
       };
     } else {
       throw new Error("Namespace ID or Package ID is missing");
@@ -116,6 +108,19 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
       packageId: params.packageId,
       slug: params.slug,
       permissions: permissions,
+      // Mirror the loader's SEO so the tab title survives client-side
+      // navigation and hydration.
+      seo: createSeo({
+        descriptors: [
+          {
+            title: `${params.namespaceId}-${params.packageId} Wiki | Thunderstore`,
+          },
+          {
+            name: "description",
+            content: `Wiki for ${params.namespaceId}-${params.packageId}`,
+          },
+        ],
+      }),
     };
   } else {
     throw new Error("Namespace ID or Package ID is missing");


### PR DESCRIPTION
The non-default package tabs overrode the descriptive page title with a generic
one built from raw URL slugs (and Changelog even dropped the author, colliding
across packages). Switch each to the existing seo `prefix` mechanism with empty
descriptors, so they inherit the package page's "<Mod> | Thunderstore - The
<Community> Mod Database" title and just prepend the tab name, e.g.
"Versions | lovely injector | Thunderstore - The Risk of Rain 2 Mod Database".