### PR TITLE
WIP: TS-3947: Don't dismiss the select menu when clicking a scrollbar

### DIFF
--- a/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
+++ b/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
@@ -26,8 +26,9 @@ export function getSelectSearchOptionId(menuId: string, index: number): string {
   return `${menuId}-option-${index}`;
 }
 
-// A mousedown on an element's scrollbar reports offsetX/offsetY beyond the
-// content box (clientWidth/clientHeight). When the select menu opens inside a
+// clientWidth/clientHeight span the padding box but exclude the scrollbar
+// gutter (and borders), so a mousedown on an element's scrollbar reports
+// offsetX/offsetY past them. When the select menu opens inside a
 // scrolling container (e.g. a modal body), that container's scrollbar sits
 // outside the select's containerRef, so without this check dragging it would
 // be treated as an outside click and dismiss the menu (TS-3947). The cyberstorm

--- a/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
+++ b/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
@@ -30,10 +30,13 @@ export function getSelectSearchOptionId(menuId: string, index: number): string {
 // content box (clientWidth/clientHeight). When the select menu opens inside a
 // scrolling container (e.g. a modal body), that container's scrollbar sits
 // outside the select's containerRef, so without this check dragging it would
-// be treated as an outside click and dismiss the menu (TS-3947).
+// be treated as an outside click and dismiss the menu (TS-3947). The cyberstorm
+// OverlayScrollbar renders its thumb as a separate floating element the offset
+// check can't see, so match it by class too.
 function isScrollbarMouseDown(event: MouseEvent): boolean {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return false;
+  if (target.closest(".cs-scrollbar-thumb")) return true;
   const onVerticalScrollbar =
     target.clientWidth > 0 && event.offsetX > target.clientWidth;
   const onHorizontalScrollbar =

--- a/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
+++ b/packages/cyberstorm/src/newComponents/SelectSearch/useSelectSearch.ts
@@ -26,6 +26,21 @@ export function getSelectSearchOptionId(menuId: string, index: number): string {
   return `${menuId}-option-${index}`;
 }
 
+// A mousedown on an element's scrollbar reports offsetX/offsetY beyond the
+// content box (clientWidth/clientHeight). When the select menu opens inside a
+// scrolling container (e.g. a modal body), that container's scrollbar sits
+// outside the select's containerRef, so without this check dragging it would
+// be treated as an outside click and dismiss the menu (TS-3947).
+function isScrollbarMouseDown(event: MouseEvent): boolean {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return false;
+  const onVerticalScrollbar =
+    target.clientWidth > 0 && event.offsetX > target.clientWidth;
+  const onHorizontalScrollbar =
+    target.clientHeight > 0 && event.offsetY > target.clientHeight;
+  return onVerticalScrollbar || onHorizontalScrollbar;
+}
+
 export function mergeRefs<T>(
   ...refs: Array<React.Ref<T> | undefined>
 ): React.RefCallback<T> {
@@ -217,7 +232,8 @@ export function useSelectSearch({
         containerRef.current &&
         !containerRef.current.contains(event.target as Node) &&
         isVisible &&
-        !disabled
+        !disabled &&
+        !isScrollbarMouseDown(event)
       ) {
         closeMenu();
       }


### PR DESCRIPTION
When the categories SelectSearch menu opens inside a scrolling container (the
Manage Package modal body), that container's scrollbar sits outside the
select's containerRef, so the document mousedown outside-click handler treated
grabbing it as an outside click and closed the menu — making the scrollbar
unusable. Ignore mousedowns that land on an element's scrollbar gutter
(offsetX/offsetY beyond the content box) before dismissing.

Note: classic (gutter) scrollbars only — verified the dropdown still opens
inside the modal; the headless test browser uses 0px overlay scrollbars so the
gutter interaction itself can't be reproduced there.