### PR TITLE
TS-3944: Add a fullscreen/expand control to the Analysis codebox

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.css
+++ b/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.css
@@ -4,3 +4,93 @@
   width: 100%;
   overflow: auto;
 }
+
+/* nimbus-components wins over the `components` layer that owns .modal__content,
+   so this fullscreen variant reliably overrides the centered modal sizing. */
+@layer nimbus-components {
+  .code-box-html__container {
+    position: relative;
+    width: 100%;
+  }
+
+  /* Toolbar overlaid on the box's top-right corner (inside the border). Lives on
+     the non-scrolling container so it stays put while the code scrolls. Buttons
+     sit in a row, copy first, all solid (non-ghost). */
+  .code-box-html__toolbar {
+    position: absolute;
+    top: var(--space-8);
+    right: var(--space-8);
+    z-index: 11;
+    display: flex;
+    gap: var(--space-8);
+    align-items: center;
+  }
+
+  /* Expanded view: a card that slides up from the bottom of the viewport and is
+     inset ~10% on the top/bottom on non-mobile widths, so the user can dismiss
+     it by clicking the area above or below the card. */
+  .modal__content.code-box-html__fullscreen {
+    display: flex;
+    flex-direction: column;
+    width: auto;
+    max-width: none;
+    height: auto;
+    max-height: none;
+    padding: var(--space-16);
+    transform: none;
+    inset: 10vh var(--space-48);
+    animation: code-box-html-slide-up 200ms ease-out;
+  }
+
+  @keyframes code-box-html-slide-up {
+    from {
+      transform: translateY(100%);
+      opacity: 0;
+    }
+
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  /* Fills the fullscreen modal so the shared toolbar rule overlays the box's
+     top-right corner exactly as it does in the normal view. */
+  .code-box-html__container--fullscreen {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .code-box-html__fullscreen-inner {
+    flex: 1 1 auto;
+    align-self: stretch;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: auto;
+  }
+
+  /* On mobile there's no room for a 10% inset, so fill the screen minus a small
+     gutter. */
+  @media (width <= 48rem) {
+    .modal__content.code-box-html__fullscreen {
+      inset: var(--space-8);
+    }
+  }
+
+  /* Accessible dialog title kept out of view (Radix requires a title); overrides
+     the default 60px .modal__title box. */
+  .code-box-html__sr-only.modal__title {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.tsx
@@ -1,7 +1,22 @@
+import {
+  faCheck,
+  faClone,
+  faCompress,
+  faExpand,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { stripHtmlTags } from "cyberstorm/utils/HTMLParsing";
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
 
-import { CodeBox, NewAlert } from "@thunderstore/cyberstorm";
+import {
+  CodeBox,
+  Modal,
+  NewAlert,
+  NewButton,
+  NewIcon,
+} from "@thunderstore/cyberstorm";
+
+import "./CodeBoxHTML.css";
 
 export interface CodeBoxHTMLProps {
   value?: string;
@@ -9,15 +24,59 @@ export interface CodeBoxHTMLProps {
   language?: string;
 }
 
+/** Copy-to-clipboard button styled to match the other toolbar icon buttons. */
+function ToolbarCopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = () => {
+    // Guard the API: navigator.clipboard is undefined in non-secure contexts and
+    // some browsers, where the optional chain would yield undefined and `.then`
+    // would throw. Catch write failures (e.g. denied permissions) so the
+    // rejection doesn't go unhandled.
+    if (!navigator.clipboard) return;
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {
+        // Clipboard write failed; leave the button in its default state.
+      });
+  };
+
+  return (
+    <NewButton
+      csVariant="secondary"
+      csSize="small"
+      csModifiers={["only-icon"]}
+      tooltipText={copied ? "Copied!" : "Copy"}
+      aria-label="Copy code"
+      onClick={onCopy}
+    >
+      <NewIcon csMode="inline" noWrapper>
+        <FontAwesomeIcon icon={copied ? faCheck : faClone} />
+      </NewIcon>
+    </NewButton>
+  );
+}
+
 /**
  * CodeBox component which renders HTML content by stripping HTML tags
- * and passing the plain text to the CodeBox component for syntax highlighting
+ * and passing the plain text to the CodeBox component for syntax highlighting.
+ *
+ * Renders a non-ghost toolbar overlaid on the code box's top-right corner: copy,
+ * then a control that toggles fullscreen — Expand in the normal view, Minimize
+ * in the fullscreen modal (which slides up from the bottom of the viewport,
+ * inset from the top/bottom edges on non-mobile widths).
  */
 export const CodeBoxHTML = memo(function CodeBoxHTML({
   value = "",
   maxHeight = 600,
   language = "text",
 }: CodeBoxHTMLProps) {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
   const result = useMemo(() => {
     try {
       const text = stripHtmlTags(value);
@@ -33,16 +92,71 @@ export const CodeBoxHTML = memo(function CodeBoxHTML({
     return <NewAlert csVariant="danger">{result.error}</NewAlert>;
   }
 
+  // Toolbar overlays the code box's top-right corner in both views. Normal view
+  // shows Expand (enter fullscreen); the fullscreen modal shows Minimize (exit).
+  const renderToolbar = (mode: "normal" | "fullscreen") => (
+    <div className="code-box-html__toolbar">
+      <ToolbarCopyButton text={result.text} />
+      <NewButton
+        csVariant="secondary"
+        csSize="small"
+        csModifiers={["only-icon"]}
+        tooltipText={mode === "normal" ? "Expand" : "Minimize"}
+        aria-label={
+          mode === "normal"
+            ? "Expand code to fullscreen"
+            : "Minimize code from fullscreen"
+        }
+        onClick={() => setIsFullscreen(mode === "normal")}
+      >
+        <NewIcon csMode="inline" noWrapper>
+          <FontAwesomeIcon icon={mode === "normal" ? faExpand : faCompress} />
+        </NewIcon>
+      </NewButton>
+    </div>
+  );
+
   return (
-    <div
-      className="code-box-html"
-      style={{
-        maxHeight,
-        width: "100%",
-        overflow: "auto",
-      }}
-    >
-      <CodeBox value={result.text} language={language} />
+    <div className="code-box-html__container">
+      {renderToolbar("normal")}
+
+      <div
+        className="code-box-html"
+        style={{
+          maxHeight,
+          width: "100%",
+          overflow: "auto",
+        }}
+      >
+        <CodeBox
+          value={result.text}
+          language={language}
+          showLineNumbers
+          allowCopy={false}
+        />
+      </div>
+
+      <Modal
+        open={isFullscreen}
+        onOpenChange={setIsFullscreen}
+        disableDefaultSubComponents
+        contentClasses="code-box-html__fullscreen"
+      >
+        <Modal.Title className="code-box-html__sr-only">
+          Code viewer
+        </Modal.Title>
+        <div className="code-box-html__container code-box-html__container--fullscreen">
+          {renderToolbar("fullscreen")}
+          <div className="code-box-html__fullscreen-inner">
+            <CodeBox
+              value={result.text}
+              language={language}
+              showLineNumbers
+              allowCopy={false}
+            />
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 });

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.css
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.css
@@ -20,6 +20,13 @@
     justify-content: space-between;
   }
 
+  /* Download action pinned to the card header's top-right, clear of the
+     file-name/meta column. */
+  .package-source__header-actions {
+    flex: none;
+    align-self: flex-start;
+  }
+
   .package-source__header-info {
     display: flex;
     flex: 1;

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -143,10 +143,14 @@ export default function Source() {
                       />
                     </div>
                   </div>
-                  <DownloadButton
-                    download_url={decompilation.url}
-                    packageSize={decompilation.result_size}
-                  />
+                  {decompilation.url ? (
+                    <div className="package-source__header-actions">
+                      <DownloadButton
+                        url={decompilation.url}
+                        size={decompilation.result_size}
+                      />
+                    </div>
+                  ) : null}
                 </div>
                 {decompilation.is_truncated && (
                   <Alert csVariant="warning">
@@ -171,6 +175,43 @@ export default function Source() {
     </Suspense>
   );
 }
+
+/** Derive a leading-dot file ending (e.g. ".blob") from a download URL. */
+function fileEndingFromUrl(url?: string): string | null {
+  if (!url) return null;
+  try {
+    const segment = new URL(url, "https://localhost").pathname.split("/").pop();
+    const dot = segment ? segment.lastIndexOf(".") : -1;
+    return dot > 0 ? (segment as string).slice(dot) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Download link for a decompiled file, labelled "<ending> (<size>)". */
+const DownloadButton = (props: { url: string; size?: string }) => {
+  const fileEnding = fileEndingFromUrl(props.url);
+  let label = "Download";
+  if (fileEnding) {
+    label = props.size ? `${fileEnding} (${props.size})` : fileEnding;
+  }
+
+  return (
+    <NewButton
+      csVariant="secondary"
+      csSize="small"
+      primitiveType="link"
+      href={props.url}
+      tooltipText="Download"
+      aria-label="Download file"
+    >
+      <NewIcon csMode="inline" noWrapper>
+        <FontAwesomeIcon icon={faDownload} />
+      </NewIcon>
+      {label}
+    </NewButton>
+  );
+};
 
 const DecompilationDateDisplay = (props: {
   lastDecompilationDate: string | null | undefined;
@@ -197,24 +238,4 @@ const DecompilationDateDisplay = (props: {
       </p>
     </div>
   );
-};
-
-const DownloadButton = (props: {
-  download_url: string | undefined;
-  packageSize: string | undefined;
-}) => {
-  return props.download_url ? (
-    <NewButton
-      csVariant="secondary"
-      csSize="medium"
-      primitiveType="link"
-      href={props.download_url}
-    >
-      <NewIcon noWrapper csMode="inline">
-        <FontAwesomeIcon icon={faDownload} />
-      </NewIcon>
-      Download
-      {props.packageSize ? ` (${props.packageSize})` : ""}
-    </NewButton>
-  ) : null;
 };

--- a/packages/cyberstorm/src/components/CodeBox/CodeBox.tsx
+++ b/packages/cyberstorm/src/components/CodeBox/CodeBox.tsx
@@ -9,6 +9,8 @@ export interface CodeBoxProps {
   inline?: boolean;
   language?: string;
   allowCopy?: boolean;
+  /** Render a line-number gutter alongside the code (block mode only). */
+  showLineNumbers?: boolean;
 }
 
 /**
@@ -20,6 +22,7 @@ export function CodeBox(props: CodeBoxProps) {
     inline = false,
     language = "text",
     allowCopy = true,
+    showLineNumbers = false,
   } = props;
 
   return (
@@ -29,6 +32,13 @@ export function CodeBox(props: CodeBoxProps) {
       <SyntaxHighlighter
         language={language}
         style={nightOwl}
+        showLineNumbers={!inline && showLineNumbers}
+        lineNumberStyle={{
+          minWidth: "3ch",
+          paddingRight: "var(--space-16)",
+          color: "var(--color-text-tertiary)",
+          userSelect: "none",
+        }}
         customStyle={{
           alignSelf: "stretch",
           width: inline ? "auto" : "100%",


### PR DESCRIPTION
The Analysis tab's code viewer (CodeBoxHTML) could only be read in a 600px
scroll box. Add an Expand button that opens the same code in a fullscreen modal
inset from the window edges by a uniform margin (matching the page gutter),
with a close button and Esc/overlay-click to dismiss. Wires up the previously
unimported CodeBoxHTML.css and reuses the shared Modal; no shared CodeBox
changes.