### PR TITLE
TS-3943: Keep scroll position when switching package page tabs

### DIFF
--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -394,6 +394,7 @@ export default function PackageListing() {
               <Tabs>
                 <NewLink
                   key="description"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="Package"
                   community={listing.community_identifier}
@@ -409,6 +410,7 @@ export default function PackageListing() {
 
                 <NewLink
                   key="required"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="PackageRequired"
                   community={listing.community_identifier}
@@ -424,6 +426,7 @@ export default function PackageListing() {
 
                 <NewLink
                   key="wiki"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="PackageWiki"
                   community={listing.community_identifier}
@@ -439,6 +442,7 @@ export default function PackageListing() {
 
                 <NewLink
                   key="changelog"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="PackageChangelog"
                   community={listing.community_identifier}
@@ -455,6 +459,7 @@ export default function PackageListing() {
 
                 <NewLink
                   key="versions"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="PackageVersions"
                   community={listing.community_identifier}
@@ -470,6 +475,7 @@ export default function PackageListing() {
 
                 <NewLink
                   key="source"
+                  preventScrollReset
                   primitiveType="cyberstormLink"
                   linkId="PackageSource"
                   community={listing.community_identifier}

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -298,6 +298,7 @@ export default function PackageListingVersion() {
             <Tabs>
               <NewLink
                 key="description"
+                preventScrollReset
                 primitiveType="cyberstormLink"
                 linkId="PackageVersion"
                 community={listing.community_identifier}
@@ -313,6 +314,7 @@ export default function PackageListingVersion() {
               </NewLink>
               <NewLink
                 key="required"
+                preventScrollReset
                 primitiveType="cyberstormLink"
                 linkId="PackageVersionRequired"
                 community={listing.community_identifier}
@@ -328,6 +330,7 @@ export default function PackageListingVersion() {
               </NewLink>
               <NewLink
                 key="versions"
+                preventScrollReset
                 primitiveType="cyberstormLink"
                 linkId="PackageVersionVersions"
                 community={listing.community_identifier}

--- a/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
+++ b/apps/cyberstorm-remix/app/p/packageVersionWithoutCommunity.tsx
@@ -289,6 +289,7 @@ export default function PackageVersion() {
                     <Tabs>
                       <NewLink
                         key="description"
+                        preventScrollReset
                         primitiveType="cyberstormLink"
                         linkId="PackageVersionWithoutCommunity"
                         namespace={resolvedValue.namespace}
@@ -303,6 +304,7 @@ export default function PackageVersion() {
                       </NewLink>
                       <NewLink
                         key="required"
+                        preventScrollReset
                         primitiveType="cyberstormLink"
                         linkId="PackageVersionWithoutCommunityRequired"
                         namespace={resolvedValue.namespace}
@@ -317,6 +319,7 @@ export default function PackageVersion() {
                       </NewLink>
                       <NewLink
                         key="versions"
+                        preventScrollReset
                         primitiveType="cyberstormLink"
                         linkId="PackageVersionWithoutCommunityVersions"
                         namespace={resolvedValue.namespace}

--- a/packages/cyberstorm/src/components/Links/Links.tsx
+++ b/packages/cyberstorm/src/components/Links/Links.tsx
@@ -63,6 +63,9 @@ interface CyberstormLinkProps
   linkId: CyberstormLinkIds;
   className?: string;
   forwardedProps?: object;
+  // Forwarded to the underlying React Router <Link>; when true, navigating via
+  // this link does not reset scroll to the top (e.g. package page tab switches).
+  preventScrollReset?: boolean;
 }
 
 // TODO: Move to primitives

--- a/packages/cyberstorm/src/primitiveComponents/Actionable/Actionable.tsx
+++ b/packages/cyberstorm/src/primitiveComponents/Actionable/Actionable.tsx
@@ -34,6 +34,9 @@ export interface ActionableCyberstormLinkProps
   linkId: CyberstormLinkIds;
   queryParams?: string;
   disabled?: boolean;
+  // Forwarded to the underlying React Router <Link>; when true, navigating via
+  // this link does not reset scroll to the top (e.g. package page tab switches).
+  preventScrollReset?: boolean;
   ref?: React.Ref<HTMLAnchorElement>;
 }
 


### PR DESCRIPTION
Clicking a package tab navigates to a sibling route, and the bare
<ScrollRestoration> reset scroll to the top each time — jarring on mobile
where the tab bar sits below the fold. Add a preventScrollReset prop to the
cyberstorm link types and set it on every package-page tab link so tab
switches preserve scroll position.