### PR TITLE
TS-3942: Name DatHost in the Valheim promo and soften its hover

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/CommunityPromo/CommunityPromo.css
+++ b/apps/cyberstorm-remix/app/commonComponents/CommunityPromo/CommunityPromo.css
@@ -14,10 +14,17 @@
     border-radius: var(--radius-md);
     text-decoration: none;
     background-color: var(--color-accent-purple-1);
+    transition: border-color 120ms ease;
   }
 
-  .community-promo:hover {
-    border-color: var(--color-cyber-green-7);
+  /* Subtle hover: lighten the purple border instead of flipping it to a loud
+     cyber-green, keeping the click affordance without shouting (TS-3942).
+     Guarded so touch devices don't get a sticky hover state. */
+  @media (hover: hover) and (pointer: fine) {
+    .community-promo:hover {
+      border-color: var(--color-accent-purple-7);
+      color: inherit;
+    }
   }
 
   /* The "AD" marker hangs on the container's top-left corner (the container's

--- a/apps/cyberstorm-remix/app/commonComponents/CommunityPromo/CommunityPromo.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/CommunityPromo/CommunityPromo.tsx
@@ -31,13 +31,13 @@ const COMMUNITY_PROMOS: Record<string, CommunityPromoConfig> = {
     // Community landing, between the header and the package search (≤90 chars).
     bar: {
       href: "https://dathost.net/r/thunderstore2026/valheim?c=21631a00",
-      copy: "Valheim server hosting",
+      copy: "DatHost Valheim server hosting",
       tag: "30% off!",
     },
     // Package sidebar, between the actions and the meta table (≤30 chars).
     pill: {
       href: "https://dathost.net/r/thunderstore2026/valheim?c=8913193b",
-      copy: "Valheim server hosting",
+      copy: "DatHost Valheim hosting",
       tag: "30% off!",
     },
   },


### PR DESCRIPTION
The affiliate promo never told users the host is DatHost — it appeared only in
a comment and the href. Lead both the bar and pill copy with "DatHost" (within
their char budgets). Also tone down the hover: instead of flipping the whole
border to a loud cyber-green, lighten the purple border with a short
transition, scoped to hover-capable pointers so touch doesn't get a sticky
state.