### PR TITLE
TS-3940: Stop the ad slot from clipping the "Report Ad" chip

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
@@ -114,9 +114,9 @@ const ON_NAVIGATE_MIN = MIN_AD_LIFETIME_MS;
 // so the layout can be inspected without dashboard-configured slots.
 const AD_DEMO_MODE = false;
 
-// Report-button placements overlay the ad's corner (inside the slot box) so
-// the button is always visible and clickable — never rendered outside the box
-// above/below the creative, where the containers would clip it.
+// Report-button placements overlay the ad's corner. The slot container no
+// longer clips its box (AdContainer.css, TS-3940), so the chip stays visible
+// and clickable at the corner instead of being cut off by the box edge.
 const DISPLAY_REPORT: NitroReport = {
   enabled: true,
   wording: "Report Ad",

--- a/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.css
+++ b/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.css
@@ -14,13 +14,15 @@
     display: inline-flex;
     flex-direction: column;
     border: 1px solid #1f1f42;
-    overflow: hidden;
 
-    /* Layout + paint containment: whatever the ad script renders or positions
-       (oversized iframes, absolutely/fixed-positioned helpers) stays clipped
-       inside the slot's box and can never overlap site content. Also isolates
-       the slot's layout/paint work from the rest of the page. */
-    contain: layout paint;
+    /* Don't clip to the slot box: NitroPay draws the "Report Ad" chip over the
+       creative's corner, and overflow:hidden / contain:paint cut it off because
+       the box is sized exactly to the creative (TS-3940). Keep `contain: layout`
+       to isolate the slot's layout work; the iframe max-size cap below keeps the
+       creative's dimensions within the slot box (it does not constrain absolute
+       positioning/transforms, which NitroPay does not use here). */
+    overflow: visible;
+    contain: layout;
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-body-md);
     line-height: var(--line-height-lg);
@@ -111,6 +113,15 @@
     justify-content: center;
     width: 100%;
     height: 100%;
+  }
+
+  /* Now that the slot no longer clips (see .ad-container), cap the creative's
+     dimensions to the reserved box so an oversized iframe doesn't grow past it,
+     while the report chip (a sibling overlay) stays free to show at the corner.
+     (This caps size only, not absolute positioning/transforms.) */
+  .ad-container__content iframe {
+    max-width: 100%;
+    max-height: 100%;
   }
 
   /* Slim and narrow slots can't fit the adblock notice — show only the heart


### PR DESCRIPTION
.ad-container clipped to its box via overflow:hidden + contain:paint, and the
box is sized exactly to the creative, so NitroPay's corner "Report Ad" chip was
cut off. Drop the clipping (keep contain:layout for isolation) and instead cap
the creative iframe to the box so an oversized ad still can't overlap the page,
while the report chip is free to show at the corner.

Note: this dev environment only serves the adblock fallback (no real NitroPay
creatives), so the chip should be re-verified against live served ads.