### PR TITLE
TS-3939: Show a deprecation banner on the package detail page

### DIFF
--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -37,6 +37,7 @@ import {
   CopyButton,
   Drawer,
   Heading,
+  NewAlert,
   NewIcon,
   NewLink,
   NewTag,
@@ -315,6 +316,13 @@ export default function PackageListing() {
 
         <div className="package-listing__main">
           <section className="package-listing__package-content-section">
+            {listing.is_deprecated ? (
+              <NewAlert csVariant="warning">
+                This package has been deprecated and may no longer be
+                maintained. We recommend looking for an alternative.
+              </NewAlert>
+            ) : null}
+
             <PageHeader
               headingLevel="1"
               headingSize="3"


### PR DESCRIPTION
The package detail page only surfaced deprecation as a small sidebar tag; the
legacy site's deprecation banner was never carried over. Render a warning
NewAlert at the top of the content section (after the community hero) when the
listing is deprecated, mirroring the version page's alert pattern and the
legacy copy.