### PR TITLE
WIP: TS-3938: Use section/category slug (not UUID/id) for package search filters

### DIFF
--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -26,8 +26,15 @@ export const loader = ssrLoader(
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
       const search = searchParams.get("search");
-      const includedCategories = searchParams.get("includedCategories");
-      const excludedCategories = searchParams.get("excludedCategories");
+      // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+      // repeated-key form (?includedCategories=a&includedCategories=b) so the
+      // initial load filters correctly, matching searchParamsToBlob.
+      const includedCategories = searchParams
+        .getAll("includedCategories")
+        .flatMap((v) => v.split(","));
+      const excludedCategories = searchParams
+        .getAll("excludedCategories")
+        .flatMap((v) => v.split(","));
       const section = searchParams.get("section");
       const nsfw = searchParams.get("nsfw");
       const deprecated = searchParams.get("deprecated");
@@ -50,8 +57,8 @@ export const loader = ssrLoader(
           ordering ?? "",
           page === null ? undefined : Number(page),
           search ?? "",
-          includedCategories?.split(",") ?? undefined,
-          excludedCategories?.split(",") ?? undefined,
+          includedCategories,
+          excludedCategories,
           finalSection,
           nsfw === "true" ? true : false,
           deprecated === "true" ? true : false
@@ -94,8 +101,15 @@ export async function clientLoader({
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
     const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
+    // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+    // repeated-key form (?includedCategories=a&includedCategories=b) so the
+    // initial load filters correctly, matching searchParamsToBlob.
+    const includedCategories = searchParams
+      .getAll("includedCategories")
+      .flatMap((v) => v.split(","));
+    const excludedCategories = searchParams
+      .getAll("excludedCategories")
+      .flatMap((v) => v.split(","));
     const section = searchParams.get("section");
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
@@ -116,8 +130,8 @@ export async function clientLoader({
         ordering ?? "",
         page === null ? undefined : Number(page),
         search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
+        includedCategories,
+        excludedCategories,
         finalSection,
         nsfw === "true" ? true : false,
         deprecated === "true" ? true : false

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -123,7 +123,7 @@ export function PackageSearch(props: Props) {
       setSortedSections(sections);
       if (sections.length !== 0) {
         setSearchParamsBlob((prev) =>
-          prev.section === "" ? { ...prev, section: sections[0].uuid } : prev
+          prev.section === "" ? { ...prev, section: sections[0].slug } : prev
         );
       }
       setCategories(
@@ -148,12 +148,12 @@ export function PackageSearch(props: Props) {
     categories
   );
 
-  const updateCatSelection = (catId: string, v: TRISTATE) => {
+  const updateCatSelection = (catSlug: string, v: TRISTATE) => {
     setParamsBlobCategories(
       setSearchParamsBlob,
       searchParamsBlob,
       parsedCategories.map((uc) => {
-        if (uc.id === catId) {
+        if (uc.slug === catSlug) {
           return {
             ...uc,
             selection: v,
@@ -169,11 +169,11 @@ export function PackageSearch(props: Props) {
       state: c.selection,
       setStateFunc: (v: boolean | TRISTATE) =>
         updateCatSelection(
-          c.id,
+          c.slug,
           typeof v === "string" ? v : v ? "include" : "off"
         ),
       label: c.name,
-      value: c.id,
+      value: c.slug,
     };
   });
   // Categories end
@@ -305,7 +305,7 @@ export function PackageSearch(props: Props) {
             selected={
               searchParamsBlob.section === "" || sortedSections.length === 0
                 ? sortedSections.length > 0
-                  ? sortedSections[0].uuid
+                  ? sortedSections[0].slug
                   : "all"
                 : searchParamsBlob.section
             }

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearchLogic.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearchLogic.ts
@@ -31,8 +31,15 @@ export const searchParamsToBlob = (
   const initialDeprecated = searchParams.get("deprecated");
   const initialNsfw = searchParams.get("nsfw");
   const initialPage = searchParams.get("page");
-  const initialIncludedCategories = searchParams.get("includedCategories");
-  const initialExcludedCategories = searchParams.get("excludedCategories");
+  // Accept both our comma-joined form (?includedCategories=a,b) and Django's
+  // repeated-key form (?includedCategories=a&includedCategories=b) so URLs
+  // round-trip when switching between the legacy site and Nimbus.
+  const initialIncludedCategories = searchParams
+    .getAll("includedCategories")
+    .join(",");
+  const initialExcludedCategories = searchParams
+    .getAll("excludedCategories")
+    .join(",");
 
   return {
     search: initialSearch,
@@ -63,10 +70,8 @@ export const searchParamsToBlob = (
       Number.isSafeInteger(Number.parseInt(initialPage))
         ? Math.max(1, Number.parseInt(initialPage))
         : 1,
-    includedCategories:
-      initialIncludedCategories !== null ? initialIncludedCategories : "",
-    excludedCategories:
-      initialExcludedCategories !== null ? initialExcludedCategories : "",
+    includedCategories: initialIncludedCategories,
+    excludedCategories: initialExcludedCategories,
   };
 };
 
@@ -79,9 +84,9 @@ export function parseCategories(
   const iCArr = includedCategories.split(",");
   const eCArr = excludedCategories.split(",");
   return categories.map((c) =>
-    iCArr.includes(c.id)
+    iCArr.includes(c.slug)
       ? { ...c, selection: "include" }
-      : eCArr.includes(c.id)
+      : eCArr.includes(c.slug)
         ? { ...c, selection: "exclude" }
         : c
   );
@@ -111,7 +116,7 @@ export const setParamsBlobCategories = (
   const newSearchParams = { ...oldBlob };
   const includedCategories = v
     .filter((c) => c.selection === "include")
-    .map((c) => c.id);
+    .map((c) => c.slug);
   if (includedCategories.length === 0) {
     newSearchParams.includedCategories = "";
   } else {
@@ -119,7 +124,7 @@ export const setParamsBlobCategories = (
   }
   const excludedCategories = v
     .filter((c) => c.selection === "exclude")
-    .map((c) => c.id);
+    .map((c) => c.slug);
   if (excludedCategories.length === 0) {
     newSearchParams.excludedCategories = "";
   } else {
@@ -200,7 +205,7 @@ export function synchronizeSearchParams(
     if (
       debouncedSearchParamsBlob.section === "" ||
       sortedSections.length === 0 ||
-      debouncedSearchParamsBlob.section === sortedSections[0]?.uuid
+      debouncedSearchParamsBlob.section === sortedSections[0]?.slug
     ) {
       searchParams.delete("section");
     } else {

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/__tests__/PackageSearch.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/__tests__/PackageSearch.test.ts
@@ -20,13 +20,13 @@ describe("searchParamsToBlob", () => {
       uuid: "section-1",
       name: "Section 1",
       priority: 1,
-      slug: "",
+      slug: "section-1",
     },
     {
       uuid: "section-2",
       name: "Section 2",
       priority: 0,
-      slug: "",
+      slug: "section-2",
     },
   ];
 
@@ -69,6 +69,18 @@ describe("searchParamsToBlob", () => {
       includedCategories: "cat1",
       excludedCategories: "cat2,cat3",
     });
+  });
+
+  test("accepts Django-style repeated category params", () => {
+    const params = new URLSearchParams();
+    params.append("includedCategories", "cat1");
+    params.append("includedCategories", "cat2");
+    params.append("excludedCategories", "cat3");
+
+    const result = searchParamsToBlob(params);
+
+    expect(result.includedCategories).toBe("cat1,cat2");
+    expect(result.excludedCategories).toBe("cat3");
   });
 
   test("combines multiple search queries into a single space-separated string", () => {
@@ -142,21 +154,21 @@ describe("parseCategories", () => {
   });
 
   test("maps inclusion strings to selection: 'include'", () => {
-    const result = parseCategories("1", "", categories);
+    const result = parseCategories("cat-1", "", categories);
     expect(result.find((c) => c.id === "1")?.selection).toBe("include");
     expect(result.find((c) => c.id === "2")?.selection).toBe("off");
     expect(result.find((c) => c.id === "3")?.selection).toBe("off");
   });
 
   test("maps exclusion strings to selection: 'exclude'", () => {
-    const result = parseCategories("", "2,3", categories);
+    const result = parseCategories("", "cat-2,cat-3", categories);
     expect(result.find((c) => c.id === "1")?.selection).toBe("off");
     expect(result.find((c) => c.id === "2")?.selection).toBe("exclude");
     expect(result.find((c) => c.id === "3")?.selection).toBe("exclude");
   });
 
   test("maps both inclusion and exclusion alongside each other", () => {
-    const result = parseCategories("1", "3", categories);
+    const result = parseCategories("cat-1", "cat-3", categories);
     expect(result.find((c) => c.id === "1")?.selection).toBe("include");
     expect(result.find((c) => c.id === "2")?.selection).toBe("off");
     expect(result.find((c) => c.id === "3")?.selection).toBe("exclude");
@@ -212,18 +224,18 @@ describe("setParamsBlobCategories", () => {
   test("sets included and excluded categories by joining with commas", () => {
     const setter = vi.fn();
     const categories: CategorySelection[] = [
-      { id: "1", name: "", slug: "", selection: "include" },
-      { id: "2", name: "", slug: "", selection: "include" },
-      { id: "3", name: "", slug: "", selection: "exclude" },
-      { id: "4", name: "", slug: "", selection: "off" },
+      { id: "1", name: "", slug: "cat-1", selection: "include" },
+      { id: "2", name: "", slug: "cat-2", selection: "include" },
+      { id: "3", name: "", slug: "cat-3", selection: "exclude" },
+      { id: "4", name: "", slug: "cat-4", selection: "off" },
     ];
 
     setParamsBlobCategories(setter, baseBlob, categories);
 
     expect(setter).toHaveBeenCalledWith({
       ...baseBlob,
-      includedCategories: "1,2",
-      excludedCategories: "3",
+      includedCategories: "cat-1,cat-2",
+      excludedCategories: "cat-3",
     });
   });
 
@@ -267,13 +279,13 @@ describe("synchronizeSearchParams", () => {
       uuid: "default-section",
       name: "Default",
       priority: 1,
-      slug: "",
+      slug: "default-section",
     },
     {
       uuid: "other-section",
       name: "Other",
       priority: 0,
-      slug: "",
+      slug: "other-section",
     },
   ];
 
@@ -488,7 +500,7 @@ describe("resetParams", () => {
         uuid: "section-X",
         name: "Sec X",
         priority: 1,
-        slug: "",
+        slug: "section-X",
       },
     ];
 

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/components/CategoryTagCloud/CategoryTagCloud.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/components/CategoryTagCloud/CategoryTagCloud.tsx
@@ -35,9 +35,9 @@ export const CategoryTagCloud = memo(function CategoryTagCloud(props: Props) {
     return null;
   }
 
-  const clearCategory = (id: string) =>
+  const clearCategory = (slug: string) =>
     setCategories(
-      categories.map((c) => (c.id === id ? { ...c, selection: OFF } : c))
+      categories.map((c) => (c.slug === slug ? { ...c, selection: OFF } : c))
     );
 
   return (
@@ -59,7 +59,7 @@ export const CategoryTagCloud = memo(function CategoryTagCloud(props: Props) {
         <NewTag
           csMode="button"
           key={c.slug}
-          onClick={() => clearCategory(c.id)}
+          onClick={() => clearCategory(c.slug)}
           csVariant={c.selection === "exclude" ? "red" : "primary"}
           csSize="medium"
           csModifiers={

--- a/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.tsx
@@ -26,13 +26,13 @@ export const RadioGroup = memo(function RadioGroup(props: Props) {
           key={s.slug}
           className={classnames(
             "radio-group__label",
-            s.uuid === selected
+            s.slug === selected
               ? "radio-group__label--selected"
               : "radio-group__label--unselected"
           )}
         >
-          <RadixRadioGroup.Item value={s.uuid} className="radio-group__radio">
-            {s.uuid !== selected ? (
+          <RadixRadioGroup.Item value={s.slug} className="radio-group__radio">
+            {s.slug !== selected ? (
               <NewIcon csMode="inline" noWrapper>
                 <FontAwesomeIcon icon={faCircle} />
               </NewIcon>

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -38,8 +38,15 @@ export const loader = ssrLoader(
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
       const search = searchParams.get("search");
-      const includedCategories = searchParams.get("includedCategories");
-      const excludedCategories = searchParams.get("excludedCategories");
+      // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+      // repeated-key form (?includedCategories=a&includedCategories=b) so the
+      // initial load filters correctly, matching searchParamsToBlob.
+      const includedCategories = searchParams
+        .getAll("includedCategories")
+        .flatMap((v) => v.split(","));
+      const excludedCategories = searchParams
+        .getAll("excludedCategories")
+        .flatMap((v) => v.split(","));
       const section = searchParams.get("section");
       const nsfw = searchParams.get("nsfw");
       const deprecated = searchParams.get("deprecated");
@@ -85,8 +92,8 @@ export const loader = ssrLoader(
           ordering ?? "",
           page === null ? undefined : Number(page),
           search ?? "",
-          includedCategories?.split(",") ?? undefined,
-          excludedCategories?.split(",") ?? undefined,
+          includedCategories,
+          excludedCategories,
           finalSection,
           nsfw === "true" ? true : false,
           deprecated === "true" ? true : false
@@ -151,8 +158,15 @@ export async function clientLoader({
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
     const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
+    // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+    // repeated-key form (?includedCategories=a&includedCategories=b) so the
+    // initial load filters correctly, matching searchParamsToBlob.
+    const includedCategories = searchParams
+      .getAll("includedCategories")
+      .flatMap((v) => v.split(","));
+    const excludedCategories = searchParams
+      .getAll("excludedCategories")
+      .flatMap((v) => v.split(","));
     const section = searchParams.get("section");
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
@@ -183,8 +197,8 @@ export async function clientLoader({
         ordering ?? "",
         page === null ? undefined : Number(page),
         search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
+        includedCategories,
+        excludedCategories,
         finalSection,
         nsfw === "true" ? true : false,
         deprecated === "true" ? true : false

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -540,11 +540,11 @@ function packageTags(
   return listing.categories.map((category) => {
     return (
       <NewTag
-        key={category.name}
+        key={category.slug}
         csMode="cyberstormLink"
         linkId="Community"
         community={community.identifier}
-        queryParams={`includedCategories=${category.id}`}
+        queryParams={`includedCategories=${encodeURIComponent(category.slug)}`}
         csSize="small"
         csVariant="primary"
       >

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -30,8 +30,15 @@ export const loader = ssrLoader(
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
       const search = searchParams.get("search");
-      const includedCategories = searchParams.get("includedCategories");
-      const excludedCategories = searchParams.get("excludedCategories");
+      // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+      // repeated-key form (?includedCategories=a&includedCategories=b) so the
+      // initial load filters correctly, matching searchParamsToBlob.
+      const includedCategories = searchParams
+        .getAll("includedCategories")
+        .flatMap((v) => v.split(","));
+      const excludedCategories = searchParams
+        .getAll("excludedCategories")
+        .flatMap((v) => v.split(","));
       const section = searchParams.get("section");
       const nsfw = searchParams.get("nsfw");
       const deprecated = searchParams.get("deprecated");
@@ -58,8 +65,8 @@ export const loader = ssrLoader(
           ordering ?? "",
           page === null ? undefined : Number(page),
           search ?? "",
-          includedCategories?.split(",") ?? undefined,
-          excludedCategories?.split(",") ?? undefined,
+          includedCategories,
+          excludedCategories,
           finalSection,
           nsfw === "true" ? true : false,
           deprecated === "true" ? true : false
@@ -114,8 +121,15 @@ export async function clientLoader({
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
     const search = searchParams.get("search");
-    const includedCategories = searchParams.get("includedCategories");
-    const excludedCategories = searchParams.get("excludedCategories");
+    // Accept both the comma-joined form (?includedCategories=a,b) and Django's
+    // repeated-key form (?includedCategories=a&includedCategories=b) so the
+    // initial load filters correctly, matching searchParamsToBlob.
+    const includedCategories = searchParams
+      .getAll("includedCategories")
+      .flatMap((v) => v.split(","));
+    const excludedCategories = searchParams
+      .getAll("excludedCategories")
+      .flatMap((v) => v.split(","));
     const section = searchParams.get("section");
     const nsfw = searchParams.get("nsfw");
     const deprecated = searchParams.get("deprecated");
@@ -138,8 +152,8 @@ export async function clientLoader({
         ordering ?? "",
         page === null ? undefined : Number(page),
         search ?? "",
-        includedCategories?.split(",") ?? undefined,
-        excludedCategories?.split(",") ?? undefined,
+        includedCategories,
+        excludedCategories,
         finalSection,
         nsfw === "true" ? true : false,
         deprecated === "true" ? true : false

--- a/apps/cyberstorm-remix/cyberstorm/utils/section.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/section.ts
@@ -1,9 +1,9 @@
-// Calculates the final section UUID based on an optionally requested section
+// Calculates the final section slug based on an optionally requested section
 // and the community filters, defaulting to the highest priority section or
 // an empty string if "all" is explicitly passed.
 export function getSectionDefault(
   section: string | null,
-  sections?: { uuid: string; priority: number }[]
+  sections?: { slug: string; priority: number }[]
 ): string {
   if (section) {
     return section === "all" ? "" : section;
@@ -16,7 +16,7 @@ export function getSectionDefault(
         maxPrioritySection = sections[i];
       }
     }
-    return maxPrioritySection.uuid;
+    return maxPrioritySection.slug;
   }
 
   return "";

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
@@ -72,11 +72,13 @@ export function CardPackage(props: Props) {
   const tags = (
     <div className="card-package__tags">
       {packageData.categories.length
-        ? packageData.categories.map((c, index) => (
+        ? packageData.categories.map((c) => (
             <NewTag
               csMode="link"
-              href={`/c/${packageData.community_identifier}/?includedCategories=${c.id}`}
-              key={`category_${c}_${index}`}
+              href={`/c/${
+                packageData.community_identifier
+              }/?includedCategories=${encodeURIComponent(c.slug)}`}
+              key={`category_${c.slug}`}
               csVariant="primary"
               csSize="xsmall"
               csModifiers={["dark", "hoverable"]}


### PR DESCRIPTION
The package search used the section UUID and category id as filter values in
state, URL params, and API calls. Switch to slugs end-to-end: section default
+ RadioGroup value, category parse/serialize, the category tag-cloud, and the
category links on CardPackage and the package detail page. The Cyberstorm API
now expects slugs (see backend TS-3938). Unit tests updated to slug values.