### PR TITLE
Wiki and Analysis tabs are disabled by default and enabled once content exists

### DIFF
--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -50,6 +50,7 @@ import {
 } from "@thunderstore/cyberstorm";
 import { PackageLikeAction } from "@thunderstore/cyberstorm-forms";
 import { DapperTs, type DapperTsInterface } from "@thunderstore/dapper-ts";
+import { isApiError } from "@thunderstore/thunderstore-api";
 
 import type { Route } from "./+types/packageListing";
 import { PackageActions } from "./components/PackageListing/PackageActions";
@@ -106,6 +107,8 @@ export const loader = ssrLoader(
         listingStatus: undefined,
         team,
         permissions: undefined,
+        wiki: undefined,
+        source: undefined,
         community_identifier: communityId,
         namespace_id: namespaceId,
         package_id: packageId,
@@ -113,9 +116,11 @@ export const loader = ssrLoader(
       });
     }
 
-    const [community, team] = await Promise.all([
+    const [community, team, wiki, source] = await Promise.all([
       dapper.getCommunity(communityId),
       dapper.getTeamDetails(namespaceId),
+      dapper.getPackageWiki(namespaceId, packageId).catch(() => undefined),
+      dapper.getPackageSource(namespaceId, packageId).catch(() => undefined),
     ]);
 
     return {
@@ -124,6 +129,8 @@ export const loader = ssrLoader(
       listingStatus: undefined,
       team,
       permissions: undefined,
+      wiki,
+      source,
       community_identifier: communityId,
       namespace_id: namespaceId,
       package_id: packageId,
@@ -189,6 +196,17 @@ export async function clientLoader({
     packageId
   );
 
+  const wiki = dapper
+    .getPackageWiki(namespaceId, packageId)
+    .catch((error: unknown) => {
+      if (isApiError(error) && error.response.status === 404) {
+        return undefined;
+      }
+      throw error;
+    });
+
+  const source = dapper.getPackageSource(namespaceId, packageId);
+
   return {
     community: dapper.getCommunity(communityId),
     listing: listing,
@@ -202,6 +220,8 @@ export async function clientLoader({
     ),
     team: dapper.getTeamDetails(namespaceId),
     permissions,
+    wiki,
+    source,
     community_identifier: communityId,
     namespace_id: namespaceId,
     package_id: packageId,
@@ -217,6 +237,8 @@ export default function PackageListing() {
     listingStatus,
     team,
     permissions,
+    wiki,
+    source,
     community_identifier,
     namespace_id,
     package_id,
@@ -268,9 +290,6 @@ export default function PackageListing() {
   const [firstUploaded, setFirstUploaded] = useState<
     ReactElement | undefined
   >();
-  const [hasWiki, setHasWiki] = useState(false);
-  const [hasWikiEditPermissions, setHasWikiEditPermissions] = useState(false);
-  const [hasSource, setHasSource] = useState(false);
 
   // This will be loaded 2 times in development because of:
   // https://react.dev/reference/react/StrictMode
@@ -286,42 +305,7 @@ export default function PackageListing() {
     setFirstUploaded(
       <RelativeTime time={listing.datetime_created} suppressHydrationWarning />
     );
-
-    const tools = getSessionTools();
-    const dapper = new DapperTs(() => {
-      return {
-        apiHost: tools?.getConfig().apiHost,
-        sessionId: tools?.getConfig().sessionId,
-      };
-    });
-
-    dapper
-      .getPackagePermissions(
-        listing.community_identifier,
-        listing.namespace,
-        listing.name
-      )
-      .then((res) => {
-        setHasWikiEditPermissions(res?.permissions.can_manage_wiki || false);
-      })
-      .catch(() => setHasWikiEditPermissions(false));
-
-    dapper
-      .getPackageWiki(listing.namespace, listing.name)
-      .then((res) => {
-        setHasWiki(res.pages.length > 0);
-      })
-      .catch(() => setHasWiki(false));
-
-    dapper
-      .getPackageSource(listing.namespace, listing.name)
-      .then((res) => {
-        setHasSource((res?.decompilations?.length ?? 0) > 0);
-      })
-      .catch(() => setHasSource(false));
   }, []);
-
-
   // END: For sidebar meta dates
 
   const currentTab = location.pathname.split("/")[6] || "details";
@@ -338,6 +322,42 @@ export default function PackageListing() {
   if (!listing) {
     return <SkeletonBox />;
   }
+
+  const wikiTabLink = (disabled: boolean) => (
+    <NewLink
+      key="wiki"
+      primitiveType="cyberstormLink"
+      linkId="PackageWiki"
+      community={listing.community_identifier}
+      namespace={listing.namespace}
+      package={listing.name}
+      aria-current={currentTab === "wiki"}
+      disabled={disabled}
+      rootClasses={`tabs-item${
+        currentTab === "wiki" ? " tabs-item--current" : ""
+      }`}
+    >
+      Wiki
+    </NewLink>
+  );
+
+  const sourceTabLink = (disabled: boolean) => (
+    <NewLink
+      key="source"
+      primitiveType="cyberstormLink"
+      linkId="PackageSource"
+      community={listing.community_identifier}
+      namespace={listing.namespace}
+      package={listing.name}
+      aria-current={currentTab === "source"}
+      disabled={disabled}
+      rootClasses={`tabs-item${
+        currentTab === "source" ? " tabs-item--current" : ""
+      }`}
+    >
+      Analysis
+    </NewLink>
+  );
 
   // TODO: some variables are available in props (communityId, namespaceId, packageId)
   return (
@@ -460,21 +480,30 @@ export default function PackageListing() {
                   Required ({listing.dependency_count})
                 </NewLink>
 
-                <NewLink
-                  key="wiki"
-                  primitiveType="cyberstormLink"
-                  linkId="PackageWiki"
-                  community={listing.community_identifier}
-                  namespace={listing.namespace}
-                  package={listing.name}
-                  aria-current={currentTab === "wiki"}
-                  disabled={!(hasWiki || hasWikiEditPermissions)}
-                  rootClasses={`tabs-item${
-                    currentTab === "wiki" ? " tabs-item--current" : ""
-                  }`}
-                >
-                  Wiki
-                </NewLink>
+                <Suspense fallback={wikiTabLink(true)}>
+                  <Await resolve={wiki} errorElement={wikiTabLink(true)}>
+                    {(resolvedWiki) => (
+                      <Suspense fallback={wikiTabLink(true)}>
+                        <Await
+                          resolve={permissions}
+                          errorElement={wikiTabLink(
+                            !((resolvedWiki?.pages.length ?? 0) > 0)
+                          )}
+                        >
+                          {(resolvedPermissions) =>
+                            wikiTabLink(
+                              !(
+                                (resolvedWiki?.pages.length ?? 0) > 0 ||
+                                !!resolvedPermissions?.permissions
+                                  .can_manage_wiki
+                              )
+                            )
+                          }
+                        </Await>
+                      </Suspense>
+                    )}
+                  </Await>
+                </Suspense>
 
                 <NewLink
                   key="changelog"
@@ -507,21 +536,15 @@ export default function PackageListing() {
                   Versions
                 </NewLink>
 
-                <NewLink
-                  key="source"
-                  primitiveType="cyberstormLink"
-                  linkId="PackageSource"
-                  community={listing.community_identifier}
-                  namespace={listing.namespace}
-                  package={listing.name}
-                  aria-current={currentTab === "source"}
-                  disabled={!hasSource}
-                  rootClasses={`tabs-item${
-                    currentTab === "source" ? " tabs-item--current" : ""
-                  }`}
-                >
-                  Analysis
-                </NewLink>
+                <Suspense fallback={sourceTabLink(true)}>
+                  <Await resolve={source} errorElement={sourceTabLink(true)}>
+                    {(resolvedSource) =>
+                      sourceTabLink(
+                        (resolvedSource?.decompilations?.length ?? 0) === 0
+                      )
+                    }
+                  </Await>
+                </Suspense>
               </Tabs>
 
               <div className="package-listing__content">

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -268,6 +268,9 @@ export default function PackageListing() {
   const [firstUploaded, setFirstUploaded] = useState<
     ReactElement | undefined
   >();
+  const [hasWiki, setHasWiki] = useState(false);
+  const [hasWikiEditPermissions, setHasWikiEditPermissions] = useState(false);
+  const [hasSource, setHasSource] = useState(false);
 
   // This will be loaded 2 times in development because of:
   // https://react.dev/reference/react/StrictMode
@@ -283,7 +286,42 @@ export default function PackageListing() {
     setFirstUploaded(
       <RelativeTime time={listing.datetime_created} suppressHydrationWarning />
     );
+
+    const tools = getSessionTools();
+    const dapper = new DapperTs(() => {
+      return {
+        apiHost: tools?.getConfig().apiHost,
+        sessionId: tools?.getConfig().sessionId,
+      };
+    });
+
+    dapper
+      .getPackagePermissions(
+        listing.community_identifier,
+        listing.namespace,
+        listing.name
+      )
+      .then((res) => {
+        setHasWikiEditPermissions(res?.permissions.can_manage_wiki || false);
+      })
+      .catch(() => setHasWikiEditPermissions(false));
+
+    dapper
+      .getPackageWiki(listing.namespace, listing.name)
+      .then((res) => {
+        setHasWiki(res.pages.length > 0);
+      })
+      .catch(() => setHasWiki(false));
+
+    dapper
+      .getPackageSource(listing.namespace, listing.name)
+      .then((res) => {
+        setHasSource((res?.decompilations?.length ?? 0) > 0);
+      })
+      .catch(() => setHasSource(false));
   }, []);
+
+
   // END: For sidebar meta dates
 
   const currentTab = location.pathname.split("/")[6] || "details";
@@ -430,6 +468,7 @@ export default function PackageListing() {
                   namespace={listing.namespace}
                   package={listing.name}
                   aria-current={currentTab === "wiki"}
+                  disabled={!(hasWiki || hasWikiEditPermissions)}
                   rootClasses={`tabs-item${
                     currentTab === "wiki" ? " tabs-item--current" : ""
                   }`}
@@ -476,6 +515,7 @@ export default function PackageListing() {
                   namespace={listing.namespace}
                   package={listing.name}
                   aria-current={currentTab === "source"}
+                  disabled={!hasSource}
                   rootClasses={`tabs-item${
                     currentTab === "source" ? " tabs-item--current" : ""
                   }`}


### PR DESCRIPTION
Note: I'm unable to test package analysis locally because it doesn't run in dev.

If we have a setup, please try to verify it.

# Screenshots

## User has no edit permission and wiki doesn't exist

<img width="514" height="56" alt="image" src="https://github.com/user-attachments/assets/1e659af2-27cd-47d4-bb20-3994714a000c" />

## User has edit permissions and wiki does not exist

<img width="1153" height="199" alt="image" src="https://github.com/user-attachments/assets/21608cf1-fce1-413b-b8fd-489daccf3754" />

## User has no edit permissions and wiki exists

<img width="523" height="47" alt="image" src="https://github.com/user-attachments/assets/e3caddd4-56b4-4ab0-83f4-6f8c045943e8" />

## User has edit permissions and wiki exists

<img width="509" height="49" alt="image" src="https://github.com/user-attachments/assets/b96ad1e3-72b3-4908-aeae-3f5efd1ec810" />
