### PR TITLE
Pagination behaviour(TS-3378 )

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -263,7 +263,11 @@ export function PackageSearch(props: Props) {
           }
 
           if (isOnlyPageChange) {
-            window.scrollTo({ top: 0, behavior: "instant" });
+            const root = document.documentElement;
+            const previousScrollBehavior = root.style.scrollBehavior;
+            root.style.scrollBehavior = "auto";
+            window.scrollTo(0, 0);
+            root.style.scrollBehavior = previousScrollBehavior;
           }
         }
         searchParamsBlobRef.current = debouncedSearchParamsBlob;

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -249,15 +249,21 @@ export function PackageSearch(props: Props) {
           )
         ) {
           const isOnlyPageChange = !resetPage && newPage !== currentPage;
-          const preventScrollReset = !isOnlyPageChange;
 
+          // Suppress ScrollRestoration on every navigation; on a page change we
+          // scroll to the top ourselves so it's instant instead of being
+          // animated by the global `scroll-behavior: smooth`.
           if (useReplace) {
             setSearchParams(searchParams, {
               replace: true,
-              preventScrollReset,
+              preventScrollReset: true,
             });
           } else {
-            setSearchParams(searchParams, { preventScrollReset });
+            setSearchParams(searchParams, { preventScrollReset: true });
+          }
+
+          if (isOnlyPageChange) {
+            window.scrollTo({ top: 0, behavior: "instant" });
           }
         }
         searchParamsBlobRef.current = debouncedSearchParamsBlob;

--- a/packages/cyberstorm/src/newComponents/Pagination/Pagination.css
+++ b/packages/cyberstorm/src/newComponents/Pagination/Pagination.css
@@ -28,3 +28,9 @@
   font-weight: var(--pagination-item-font-weight);
   background: var(--pagination-item-background);
 }
+
+/* Skipped-pages indicator: looks like an item but isn't interactive. */
+.pagination__item--ellipsis {
+  background: none;
+  pointer-events: none;
+}

--- a/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
+++ b/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
@@ -15,6 +15,13 @@ export interface PaginationProps {
   siblingCount: number;
 }
 
+interface PageButtonProps {
+  page: number;
+  onClick: () => void;
+  isCurrent?: boolean;
+  label?: React.ReactNode;
+}
+
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
   (props: PaginationProps, forwardedRef) => {
     const {
@@ -33,100 +40,59 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
       totalCount / (pageSize > 0 ? pageSize : 1)
     );
 
-    const buttons = [];
-
+    // The window of pages rendered around the current page.
     const leftmostSibling = Math.max(currentPage - siblingCount, 1);
     const rightmostSibling = Math.min(
       currentPage + siblingCount,
       totalPageCount
     );
 
-    // START Add buttons
-    if (currentPage > 1) {
-      buttons.push(
-        <Actionable
-          key="page-previous"
-          primitiveType="button"
-          onClick={() => onPageChange(decreaseCurrentPage(currentPage))}
-          rootClasses="pagination__item"
-        >
-          <NewIcon csMode="inline" noWrapper>
-            <FontAwesomeIcon icon={faArrowLeft} />
-          </NewIcon>
-          Prev
-        </Actionable>
-      );
-    }
-    if (leftmostSibling > 1) {
-      buttons.push(
-        <Actionable
-          key="page-1"
-          primitiveType="button"
-          onClick={() => onPageChange(1)}
-          rootClasses="pagination__item"
-        >
-          1
-        </Actionable>
-      );
-    }
-    range(leftmostSibling, rightmostSibling).forEach((pageNumber) => {
-      buttons.push(
-        <Actionable
-          key={`page-${pageNumber}`}
-          primitiveType="button"
-          onClick={() => onPageChange(pageNumber)}
-          rootClasses={classnames(
-            "pagination__item",
-            currentPage === pageNumber
-              ? "pagination__item--selected"
-              : undefined
-          )}
-        >
-          {(pageNumber === leftmostSibling &&
-            currentPage !== leftmostSibling &&
-            leftmostSibling > 1) ||
-          (pageNumber === rightmostSibling &&
-            currentPage !== rightmostSibling &&
-            rightmostSibling < totalPageCount)
-            ? "…"
-            : pageNumber}
-        </Actionable>
-      );
-    });
-    if (rightmostSibling < totalPageCount) {
-      buttons.push(
-        <Actionable
-          key={`page-${totalPageCount}`}
-          primitiveType="button"
-          onClick={() => onPageChange(totalPageCount)}
-          rootClasses="pagination__item"
-        >
-          {totalPageCount}
-        </Actionable>
-      );
-    }
-    if (currentPage !== totalPageCount) {
-      buttons.push(
-        <Actionable
-          key="page-next"
-          primitiveType="button"
-          onClick={() =>
-            onPageChange(increaseCurrentPage(currentPage, totalPageCount))
-          }
-          rootClasses="pagination__item"
-        >
-          Next
-          <NewIcon csMode="inline" noWrapper>
-            <FontAwesomeIcon icon={faArrowRight} />
-          </NewIcon>
-        </Actionable>
-      );
-    }
-    // END Add buttons
+    // The first/last page get their own buttons when they fall outside the window.
+    const showFirstPage = leftmostSibling > 1;
+    const showLastPage = rightmostSibling < totalPageCount;
 
     return (
       <nav aria-label="Pagination" ref={forwardedRef} className="pagination">
-        {buttons}
+        {currentPage > 1 && (
+          <NavButton
+            direction="previous"
+            onClick={() => onPageChange(currentPage - 1)}
+          />
+        )}
+
+        {showFirstPage && (
+          <PageButton page={1} onClick={() => onPageChange(1)} />
+        )}
+
+        {range(leftmostSibling, rightmostSibling).map((page) => (
+          <PageButton
+            key={`page-${page}`}
+            page={page}
+            isCurrent={page === currentPage}
+            label={getSiblingLabel({
+              page,
+              currentPage,
+              leftmostSibling,
+              rightmostSibling,
+              totalPageCount,
+            })}
+            onClick={() => onPageChange(page)}
+          />
+        ))}
+
+        {showLastPage && (
+          <PageButton
+            page={totalPageCount}
+            onClick={() => onPageChange(totalPageCount)}
+          />
+        )}
+
+        {currentPage < totalPageCount && (
+          <NavButton
+            direction="next"
+            onClick={() => onPageChange(currentPage + 1)}
+          />
+        )}
       </nav>
     );
   }
@@ -134,12 +100,75 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
 
 Pagination.displayName = "Pagination";
 
-function decreaseCurrentPage(currentPage: number) {
-  const newPage = currentPage - 1;
-  return newPage > 0 ? newPage : 1;
+function PageButton({ page, onClick, isCurrent, label }: PageButtonProps) {
+  return (
+    <Actionable
+      primitiveType="button"
+      onClick={onClick}
+      rootClasses={classnames(
+        "pagination__item",
+        isCurrent ? "pagination__item--selected" : undefined
+      )}
+    >
+      {label ?? page}
+    </Actionable>
+  );
 }
 
-function increaseCurrentPage(currentPage: number, totalPageCount: number) {
-  const newPage = currentPage + 1;
-  return newPage <= totalPageCount ? newPage : totalPageCount;
+interface NavButtonProps {
+  direction: "previous" | "next";
+  onClick: () => void;
+}
+
+function NavButton({ direction, onClick }: NavButtonProps) {
+  const isPrevious = direction === "previous";
+  const icon = (
+    <NewIcon csMode="inline" noWrapper>
+      <FontAwesomeIcon icon={isPrevious ? faArrowLeft : faArrowRight} />
+    </NewIcon>
+  );
+
+  return (
+    <Actionable
+      primitiveType="button"
+      onClick={onClick}
+      rootClasses="pagination__item"
+    >
+      {isPrevious && icon}
+      {isPrevious ? "Prev" : "Next"}
+      {!isPrevious && icon}
+    </Actionable>
+  );
+}
+
+/**
+ * Preserves the existing label behaviour: the sibling that borders a hidden
+ * range is shown as an ellipsis instead of its page number.
+ */
+function getSiblingLabel(args: {
+  page: number;
+  currentPage: number;
+  leftmostSibling: number;
+  rightmostSibling: number;
+  totalPageCount: number;
+}): React.ReactNode {
+  const {
+    page,
+    currentPage,
+    leftmostSibling,
+    rightmostSibling,
+    totalPageCount,
+  } = args;
+
+  const isLeftBoundary =
+    page === leftmostSibling &&
+    currentPage !== leftmostSibling &&
+    leftmostSibling > 1;
+
+  const isRightBoundary =
+    page === rightmostSibling &&
+    currentPage !== rightmostSibling &&
+    rightmostSibling < totalPageCount;
+
+  return isLeftBoundary || isRightBoundary ? "…" : page;
 }

--- a/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
+++ b/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
@@ -19,7 +19,6 @@ interface PageButtonProps {
   page: number;
   onClick: () => void;
   isCurrent?: boolean;
-  label?: React.ReactNode;
 }
 
 export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
@@ -51,6 +50,12 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
     const showFirstPage = leftmostSibling > 1;
     const showLastPage = rightmostSibling < totalPageCount;
 
+    // An ellipsis is shown when one or more pages are skipped between the
+    // first/last page and the window. When the window sits right next to the
+    // first/last page (no gap), no ellipsis is rendered.
+    const showLeftEllipsis = leftmostSibling > 2;
+    const showRightEllipsis = rightmostSibling < totalPageCount - 1;
+
     return (
       <nav aria-label="Pagination" ref={forwardedRef} className="pagination">
         {currentPage > 1 && (
@@ -64,21 +69,18 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
           <PageButton page={1} onClick={() => onPageChange(1)} />
         )}
 
+        {showLeftEllipsis && <Ellipsis />}
+
         {range(leftmostSibling, rightmostSibling).map((page) => (
           <PageButton
             key={`page-${page}`}
             page={page}
             isCurrent={page === currentPage}
-            label={getSiblingLabel({
-              page,
-              currentPage,
-              leftmostSibling,
-              rightmostSibling,
-              totalPageCount,
-            })}
             onClick={() => onPageChange(page)}
           />
         ))}
+
+        {showRightEllipsis && <Ellipsis />}
 
         {showLastPage && (
           <PageButton
@@ -100,7 +102,7 @@ export const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
 
 Pagination.displayName = "Pagination";
 
-function PageButton({ page, onClick, isCurrent, label }: PageButtonProps) {
+function PageButton({ page, onClick, isCurrent }: PageButtonProps) {
   return (
     <Actionable
       primitiveType="button"
@@ -110,7 +112,7 @@ function PageButton({ page, onClick, isCurrent, label }: PageButtonProps) {
         isCurrent ? "pagination__item--selected" : undefined
       )}
     >
-      {label ?? page}
+      {page}
     </Actionable>
   );
 }
@@ -141,34 +143,14 @@ function NavButton({ direction, onClick }: NavButtonProps) {
   );
 }
 
-/**
- * Preserves the existing label behaviour: the sibling that borders a hidden
- * range is shown as an ellipsis instead of its page number.
- */
-function getSiblingLabel(args: {
-  page: number;
-  currentPage: number;
-  leftmostSibling: number;
-  rightmostSibling: number;
-  totalPageCount: number;
-}): React.ReactNode {
-  const {
-    page,
-    currentPage,
-    leftmostSibling,
-    rightmostSibling,
-    totalPageCount,
-  } = args;
-
-  const isLeftBoundary =
-    page === leftmostSibling &&
-    currentPage !== leftmostSibling &&
-    leftmostSibling > 1;
-
-  const isRightBoundary =
-    page === rightmostSibling &&
-    currentPage !== rightmostSibling &&
-    rightmostSibling < totalPageCount;
-
-  return isLeftBoundary || isRightBoundary ? "…" : page;
+/** Non-interactive indicator for a range of skipped pages. */
+function Ellipsis() {
+  return (
+    <span
+      className="pagination__item pagination__item--ellipsis"
+      aria-hidden="true"
+    >
+      …
+    </span>
+  );
 }

--- a/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
+++ b/packages/cyberstorm/src/newComponents/Pagination/Pagination.tsx
@@ -107,6 +107,7 @@ function PageButton({ page, onClick, isCurrent }: PageButtonProps) {
     <Actionable
       primitiveType="button"
       onClick={onClick}
+      aria-current={isCurrent ? "page" : undefined}
       rootClasses={classnames(
         "pagination__item",
         isCurrent ? "pagination__item--selected" : undefined


### PR DESCRIPTION
- Refactor: replace the imperative buttons.push() array with declarative
  JSX and small PageButton/NavButton sub-components. No behavior change.
- Ellipsis: sibling buttons now always show their real page number, and
  "…" is a separate, non-clickable indicator shown only when pages are
  actually skipped — previously a button labeled "…" would jump to a
  specific adjacent page, and could appear even with no real gap.
- Scroll: page changes now jump to the top instantly instead of being
  animated by the global smooth-scroll.