### PR TITLE
Fix keyboard-focus / tab highlight issues

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/CheckboxList/CheckboxList.css
+++ b/apps/cyberstorm-remix/app/commonComponents/CheckboxList/CheckboxList.css
@@ -29,6 +29,13 @@
           opacity: 0;
           pointer-events: none;
         }
+
+        /* Keyboard focus must reveal it too — opacity: 0 alone leaves the
+           focused exclude button invisible. */
+        .checkbox-list__exclude-button:focus-visible {
+          opacity: 1;
+          pointer-events: auto;
+        }
       }
 
       &.checkbox-list__label--off {

--- a/apps/cyberstorm-remix/app/styles/layout.css
+++ b/apps/cyberstorm-remix/app/styles/layout.css
@@ -22,6 +22,14 @@
     min-width: 0;
   }
 
+  /* #main-content is a tabindex=-1 target focused programmatically (skip link /
+     route changes) for screen-reader context, not a control the user tabs to —
+     so suppress the global focus ring that would otherwise outline the whole
+     content area. */
+  .layout__main:focus-visible {
+    outline: none;
+  }
+
   /* Right ad rail beside the content, ending above the full-width bottom ad
      row. The island spans the content row's height (background column); the
      stack inside is a sticky, viewport-fitted flex column: fishstick / dynamic

--- a/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
+++ b/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
@@ -38,6 +38,15 @@
         background-color: var(--breadcrumb-item-bg-color--hover);
       }
     }
+
+    /* Segments are skewed parallelograms with rounded end-caps, so a default
+       rectangular outline sits askew of the visible shape. Use the hover
+       background as the keyboard-focus indicator instead — it follows the
+       skew and caps exactly. */
+    &:focus-visible {
+      background-color: var(--breadcrumb-item-bg-color--hover);
+      outline: none;
+    }
   }
 
   .breadcrumbs__item-content {
@@ -92,6 +101,11 @@
       &:hover::before {
         background-color: var(--breadcrumb-item-bg-color--hover);
       }
+    }
+
+    /* Keep the rounded home cap in sync with the focus background. */
+    &:focus-visible::before {
+      background-color: var(--breadcrumb-item-bg-color--hover);
     }
   }
 

--- a/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
+++ b/packages/cyberstorm/src/newComponents/BreadCrumbs/BreadCrumbs.css
@@ -46,6 +46,14 @@
     &:focus-visible {
       background-color: var(--breadcrumb-item-bg-color--hover);
       outline: none;
+
+      /* In forced-colors mode the system overrides the background, so the
+         indicator above vanishes. Restore an outline there — rectangular is
+         fine; visible focus matters more than following the skew. */
+      @media (forced-colors: active) {
+        outline: 2px solid;
+        outline-offset: -2px;
+      }
     }
   }
 

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
@@ -12,7 +12,7 @@
   }
 
   .card-package:has(:focus-visible) {
-    outline: var(--card-package-focus-outline-offset);
+    outline: var(--card-package-focus-outline);
     outline-offset: var(--card-package-focus-outline-offset);
   }
 


### PR DESCRIPTION
- CardPackage: the :focus-visible rule set the outline to the *offset* token
  (a bare length is an invalid outline shorthand, so it was dropped) — use the
  outline token so tab-focused cards show the green ring.
- CheckboxList: reveal the per-category exclude button on :focus-visible too,
  not just on hover — keyboard focus was landing on an opacity:0 button.
- BreadCrumbs: segments are skewed parallelograms with rounded caps, so the
  rectangular focus outline sat askew of the shape; use the hover background
  (which follows the skew + caps) as the keyboard-focus indicator instead.
- layout: suppress the global focus ring on #main-content (.layout__main), a
  tabindex=-1 skip-link/route-focus target rather than a control, so focusing
  it programmatically no longer outlines the whole content area.