### PR TITLE
Fix: Table Fix

### DIFF
--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -1,6 +1,5 @@
 @layer nimbus-utils {
   .markdown-wrapper {
-    display: flex;
     max-width: 100%;
     overflow-x: scroll;
     scrollbar-width: none;
@@ -12,7 +11,6 @@
     font: var(--font-body);
     font-weight: var(--font-weight-regular);
     line-height: 160%;
-    word-break: break-word;
 
     a {
       color: var(--color-text-a--default);


### PR DESCRIPTION
This commit fixes the table issue seen in the Cyberstorm version of the site that causes tables to make the entire markdown render shift on horizontal scroll

<img width="588" height="499" alt="image" src="https://github.com/user-attachments/assets/01b96775-afd6-4e3b-a1e2-e0760b037f01" />

<img width="643" height="674" alt="image" src="https://github.com/user-attachments/assets/17d2701d-cc28-40a9-a35c-71ebb910e383" />


This will make the tables look like the above rather than the current below

<img width="586" height="705" alt="image" src="https://github.com/user-attachments/assets/532d3685-b251-474c-9a18-485bf8876fc0" />

Do note its not perfect but it does fix major UX issues when looking at a packages README. Main thing I'd still want fixed regarding this is wider column text width. 

Reference Page: https://thunderstore.io/c/inscryption/p/creator/inscryption_augmented_to_base/

If this does not match conventions feel free to rebase or squash merge this into the repository.