### PR TITLE
Markdown Table Fixes | (Fix Headers, Fix Width, Fix Scroll, Fix Overflow, Header Centering, and a bit more)

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
@@ -1,6 +1,5 @@
 @layer nimbus-utils {
   .markdown-wrapper {
-    display: flex;
     max-width: 100%;
     overflow-x: scroll;
     scrollbar-width: none;
@@ -12,7 +11,6 @@
     font: var(--font-body);
     font-weight: var(--font-weight-regular);
     line-height: 160%;
-    word-break: break-word;
 
     a {
       color: var(--color-text-a--default);
@@ -179,7 +177,7 @@
       width: 100%;
       border-collapse: separate;
       border-spacing: 0;
-      overflow: auto;
+      overflow-x: scroll;
     }
 
     tbody tr:nth-child(even) {
@@ -202,9 +200,9 @@
       border-top: solid var(--border-width--px) var(--color-surface-a8);
       color: var(--color-text-tertiary);
       white-space: nowrap;
-      text-align: left;
       background: var(--color-surface-5);
-
+      min-width: 15em;
+      
       * {
         white-space: inherit;
       }

--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -177,7 +177,7 @@
       width: 100%;
       border-collapse: separate;
       border-spacing: 0;
-      overflow: auto;
+      overflow-x: scroll;
     }
 
     tbody tr:nth-child(even) {
@@ -194,13 +194,13 @@
       border-right: var(--border-width--px) solid var(--color-surface-a8);
       border-bottom: var(--border-width--px) solid var(--color-surface-a8);
       color: var(--color-text-primary);
+      min-width: 15em;
     }
 
     table tr th {
       border-top: solid var(--border-width--px) var(--color-surface-a8);
       color: var(--color-text-tertiary);
       white-space: nowrap;
-      text-align: left;
       background: var(--color-surface-5);
 
       * {

--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -194,7 +194,6 @@
       border-right: var(--border-width--px) solid var(--color-surface-a8);
       border-bottom: var(--border-width--px) solid var(--color-surface-a8);
       color: var(--color-text-primary);
-      min-width: 15em;
     }
 
     table tr th {
@@ -202,7 +201,8 @@
       color: var(--color-text-tertiary);
       white-space: nowrap;
       background: var(--color-surface-5);
-
+      min-width: 15em;
+      
       * {
         white-space: inherit;
       }

--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -1,6 +1,5 @@
 @layer nimbus-utils {
   .markdown-wrapper {
-    display: flex;
     max-width: 100%;
     overflow-x: scroll;
     scrollbar-width: none;
@@ -12,7 +11,6 @@
     font: var(--font-body);
     font-weight: var(--font-weight-regular);
     line-height: 160%;
-    word-break: break-word;
 
     a {
       color: var(--color-text-a--default);


### PR DESCRIPTION
For a visual explanation of this PR see:

[![Hover Text](https://markdown-videos-api.jorgenkh.no/youtube/zeJMUWvvX-I)](https://youtu.be/zeJMUWvvX-I)

(Click on it and it will launch in YouTube.)

This PR does the following:
* Removes force left-align from the Table Header
* Converts Overflow (auto) to Overflow-X (scroll) on the Table
* Disables Flex on the Markdown Wrapper
* Removes the forced Break-Word from the Markdown
* If either of the last points are needed for an element, it is recommended to put it on that elements type rather than universally.
* Sets a fixed Minimum Width on the Head so that Tables present themselves much nicer for the user
* Applies the above changes to the other Markdown.css associated with Cyberstorm as well.

If you have any questions feel free to reach out but this will work universally now!

<img width="751" height="957" alt="image" src="https://github.com/user-attachments/assets/f3bf2289-7e68-4602-8c96-a3d2cdc3841e" />

<img width="702" height="856" alt="image" src="https://github.com/user-attachments/assets/30aba1fb-a1a6-48ce-b02e-c49a34f93844" />

<img width="711" height="788" alt="image" src="https://github.com/user-attachments/assets/f7cd566e-99af-4238-bdc6-250dfbdb4d49" />

<img width="714" height="877" alt="image" src="https://github.com/user-attachments/assets/8f084785-8932-43f9-b96d-034c61ecbaf2" />

<img width="696" height="796" alt="image" src="https://github.com/user-attachments/assets/4dc9460f-cc54-4c29-bb74-46b5fc6135ab" />

<img width="689" height="307" alt="image" src="https://github.com/user-attachments/assets/a95af2e9-d342-4f6d-922f-856632905065" />


This was tested via the Developer Console. This has also been tested with several tables across different Inscryption Packages