### PR TITLE
Ad layout changes

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
@@ -3,19 +3,22 @@ import type { AdContainerSizeVariant } from "@thunderstore/cyberstorm";
 /**
  * NitroPay integration config + SPA lifecycle helpers for Nimbus.
  *
- * The ad surface (publisher 785): a right-column rail — a slim "fishstick"
- * banner above and below one dynamic display slot that fills whatever rail
- * height is left (max 600px, the tallest unit in the inventory), with an
- * in-content video player (`video-nc`) at the rail's bottom — plus a
- * responsive bottom banner row. The rail is 336px wide (the widest unit
- * NitroPay serves) on large viewports and 160px on mid-width ones, and its
- * sticky stack keeps the video on screen while scrolling. NitroPay measures
- * the slot's container and only loads sizes that fit it, so the dynamic
- * slot's creative is picked by the CSS-driven container height. Slot ids are
- * `nimbus`-prefixed and must be configured in the NitroPay dashboard before
- * they fill. Each slot's `mediaQuery` mirrors a reveal breakpoint in
- * `app/styles/layout.css` so NitroPay never instantiates a slot CSS hides —
- * keep the two in sync.
+ * The ad surface (publisher 785): a right-column rail plus a responsive bottom
+ * banner row. The rail's CONFIGURATION is chosen by HEIGHT via CSS container
+ * queries (see `app/styles/layout.css`): shortest to tallest, 2 fishsticks ->
+ * fishstick + square -> + fishstick -> double -> + fishstick -> + square ->
+ * + double, with the video in every config and always pinned to the
+ * bottom. Each configuration owns its OWN fixed-size slots (ids
+ * `nimbus-v<AD_SLOT_VERSION>-<config>-<position>-<type>`), so a slot is never reused at
+ * two sizes. The rail is 336px wide on large viewports and a single 160px fill
+ * slot on mid-width ones. NitroPay measures each slot's container and only loads
+ * sizes that fit it. Because the reveal is a CSS container query (not a viewport
+ * media query), each rail slot is created lazily — only once its container is
+ * actually on-screen (see createNimbusAdsInView) — so a slot the current config
+ * hides is never instantiated. Each rail slot's `mediaQuery` carries the width
+ * regime (full 336px vs 160px narrow rail) AND its config's window-height band,
+ * so NitroPay also gates each config by viewport height. All slot ids must be
+ * configured in the NitroPay dashboard before they fill.
  *
  * Types are derived from the NitroPay API docs (api-docs.nitropay.com):
  * `createAd` returns a `NitroAd` (or a promise of one/an array), whose
@@ -181,9 +184,12 @@ function sizesThatFit(maxWidth: number, maxHeight: number): string[][] {
   );
 }
 
-// Right rail: the slim fishstick boxes and the viewport-sized dynamic slot.
+// Right rail: the slim fishstick boxes, the two display boxes — "square"
+// (336x300) and "double" (336x600, twice as tall) — and the 160-wide
+// narrow-rail fill slot.
 const FISHSTICK_SIZES = sizesThatFit(336, 60);
-const RIGHT_DYNAMIC_SIZES = sizesThatFit(336, 600);
+const RIGHT_SQUARE_SIZES = sizesThatFit(336, 300);
+const RIGHT_DOUBLE_SIZES = sizesThatFit(336, 600);
 const RIGHT_NARROW_SIZES = sizesThatFit(160, 600);
 
 // Bottom row: capped at 980 wide (there is almost no bidding pressure above
@@ -201,18 +207,47 @@ const BOTTOM_RIGHT_SIZES = BOTTOM_VERY_WIDE_SIZES;
 
 // --- Slot inventory ---
 
-// Rail bands (mirror the reveal breakpoints in layout.css): the full 336px
-// rail down to 1484px viewports (the old Django site's rail breakpoint), then
-// a 160px narrow rail down to 1214px; below that the bottom banner row is the
-// only ad surface.
-const RIGHT_COLUMN_MQ = "(min-width: 1484px) and (min-height: 600px)";
-const RIGHT_COLUMN_NARROW_MQ =
-  "(min-width: 1214px) and (max-width: 1483.98px) and (min-height: 600px)";
+// Rail WIDTH regimes: full 336px rail at >= 1484px (the old Django site's rail
+// breakpoint); a 160px narrow rail from 1214px to 1483.98px; below 1214px the
+// bottom banner row is the only ad surface.
+const RIGHT_COLUMN_MQ = "(min-width: 1484px)";
+const RIGHT_COLUMN_NARROW_MQ = "(min-width: 1214px) and (max-width: 1483.98px)";
 
-// The in-content video player at the rail's bottom. Excluded from onNavigate
+// Chrome reserved above + below the sticky rail stack (mirrors the height calc
+// in layout.css: header + gap-2xs top + gap-2xs bottom). layout.css reveals a
+// config by the rail's own (container) height; NitroPay's mediaQuery is a
+// viewport query, so viewport height = rail (container) height + this.
+const RAIL_CHROME_PX = 64;
+
+// A config's NitroPay mediaQuery: the 336px-rail width regime plus that config's
+// rail-height band expressed as VIEWPORT height, so NitroPay only serves the
+// config's slots at the window heights where layout.css shows them. These bands
+// MUST mirror the @container bands in layout.css.
+function railHeightMq(minRail: number, maxRail: number | null): string {
+  const parts = [
+    RIGHT_COLUMN_MQ,
+    `(min-height: ${minRail + RAIL_CHROME_PX}px)`,
+  ];
+  if (maxRail !== null) {
+    parts.push(`(max-height: ${maxRail + RAIL_CHROME_PX - 0.02}px)`);
+  }
+  return parts.join(" and ");
+}
+
+// Per-config rail mediaQueries; all of a config's slots share one.
+const RAIL_MQ_1 = railHeightMq(331, 571);
+const RAIL_MQ_2 = railHeightMq(571, 641);
+const RAIL_MQ_3 = railHeightMq(641, 871);
+const RAIL_MQ_4 = railHeightMq(871, 941);
+const RAIL_MQ_5 = railHeightMq(941, 1181);
+const RAIL_MQ_6 = railHeightMq(1181, 1481);
+const RAIL_MQ_7 = railHeightMq(1481, null);
+
+// Rail video slot ids all end with this suffix (one per configuration that
+// includes a video — see RIGHT_COLUMN_SLOTS). They're excluded from onNavigate
 // refreshes (see onNavigateNimbusAds) so an in-progress impression isn't torn
 // down on every route change — the rail persists across navigations.
-export const RAIL_VIDEO_ID = "nimbus-right-column-video";
+const RAIL_VIDEO_ID_SUFFIX = "-video";
 
 // Shared knobs for every display placement; per-slot config is just the box
 // (sizes), the reveal breakpoint, and the report-button corner.
@@ -242,32 +277,44 @@ function displaySlot(slot: {
   };
 }
 
-// Top-to-bottom rail order: fishstick, dynamic display, fishstick, video. The
-// bottom fishstick + video pin to the sticky stack's end (see layout.css).
-// The narrow slot is the 160px rail band's only placement.
-export const RIGHT_COLUMN_SLOTS: RenderedAdSlot[] = [
-  displaySlot({
-    containerId: "nimbus-right-column-fishstick-top",
+// Bump AD_SLOT_VERSION whenever the ad slot layout or inventory changes: every
+// slot id (rail + bottom row) is `nimbus-v<N>-...`, so analytics can cleanly
+// filter each iteration by the id prefix. This is the ONLY place to change it —
+// layout.css matches slots by their version-independent suffix, not the prefix.
+const AD_SLOT_VERSION = 1;
+const AD_PREFIX = `nimbus-v${AD_SLOT_VERSION}`;
+
+// Rail slot builders — each configuration owns fixed-size slots (see the
+// progression + breakpoints in layout.css). Each takes its config's mediaQuery
+// (width regime + the config's window-height band) so all of a config's slots
+// share the same reveal condition.
+
+function railFishstick(id: string, mediaQuery: string): RenderedAdSlot {
+  return displaySlot({
+    containerId: id,
     sizeVariant: "fishstick",
     sizes: FISHSTICK_SIZES,
-    mediaQuery: RIGHT_COLUMN_MQ,
-  }),
-  displaySlot({
-    containerId: "nimbus-right-column-dynamic",
-    sizeVariant: "dynamic",
-    sizes: RIGHT_DYNAMIC_SIZES,
-    mediaQuery: RIGHT_COLUMN_MQ,
-  }),
-  displaySlot({
-    containerId: "nimbus-right-column-fishstick-bottom",
-    sizeVariant: "fishstick",
-    sizes: FISHSTICK_SIZES,
-    mediaQuery: RIGHT_COLUMN_MQ,
-  }),
-  // In-content video player at the rail's bottom. Re-enabled (TS-3954) after
-  // NitroPay blocked the rubiconproject requests that were causing issues.
-  {
-    containerId: RAIL_VIDEO_ID,
+    mediaQuery,
+  });
+}
+
+// Display slots come in two heights, named in the id: `-square` (336x300) and
+// `-double` (336x600, twice as tall). The id's size token drives the box.
+function railDisplay(id: string, mediaQuery: string): RenderedAdSlot {
+  const square = id.endsWith("-square");
+  return displaySlot({
+    containerId: id,
+    sizeVariant: square ? "rail-square" : "rail-double",
+    sizes: square ? RIGHT_SQUARE_SIZES : RIGHT_DOUBLE_SIZES,
+    mediaQuery,
+  });
+}
+
+// In-content video player; pinned to the rail's bottom in every config. Re-
+// enabled (TS-3954) after NitroPay blocked the rubiconproject requests.
+function railVideo(id: string, mediaQuery: string): RenderedAdSlot {
+  return {
+    containerId: id,
     sizeVariant: "video",
     options: {
       format: "video-nc",
@@ -276,20 +323,54 @@ export const RIGHT_COLUMN_SLOTS: RenderedAdSlot[] = [
       // 30s auto-refresh for the video slot (display slots stay at 90s).
       refreshTime: 30,
       onNavigateMin: ON_NAVIGATE_MIN,
-      video: {
-        // The rail keeps the player on screen; never detach into the floating
-        // (docked) player, which otherwise covers the footer on tall layouts.
-        float: "never",
-      },
-      report: {
-        ...TOP_LEFT_REPORT,
-        icon: true,
-      },
-      mediaQuery: RIGHT_COLUMN_MQ,
+      // The rail keeps the player on screen; never detach into the floating
+      // (docked) player, which otherwise covers the footer on tall layouts.
+      video: { float: "never" },
+      report: { ...TOP_LEFT_REPORT, icon: true },
+      mediaQuery,
     },
-  },
+  };
+}
+
+// One fixed-size slot per ad per configuration (ids <config>-<position>-<type>).
+// CSS container queries (layout.css) show exactly one config's slots per rail
+// height; the narrow slot is the 160px width regime's only placement.
+export const RIGHT_COLUMN_SLOTS: RenderedAdSlot[] = [
+  // 1 — fishstick + fishstick + video
+  railFishstick(`${AD_PREFIX}-1-1-fishstick`, RAIL_MQ_1),
+  railFishstick(`${AD_PREFIX}-1-2-fishstick`, RAIL_MQ_1),
+  railVideo(`${AD_PREFIX}-1-3-video`, RAIL_MQ_1),
+  // 2 — fishstick + square + video
+  railFishstick(`${AD_PREFIX}-2-1-fishstick`, RAIL_MQ_2),
+  railDisplay(`${AD_PREFIX}-2-2-square`, RAIL_MQ_2),
+  railVideo(`${AD_PREFIX}-2-3-video`, RAIL_MQ_2),
+  // 3 — fishstick + square + fishstick + video
+  railFishstick(`${AD_PREFIX}-3-1-fishstick`, RAIL_MQ_3),
+  railDisplay(`${AD_PREFIX}-3-2-square`, RAIL_MQ_3),
+  railFishstick(`${AD_PREFIX}-3-3-fishstick`, RAIL_MQ_3),
+  railVideo(`${AD_PREFIX}-3-4-video`, RAIL_MQ_3),
+  // 4 — fishstick + double + video
+  railFishstick(`${AD_PREFIX}-4-1-fishstick`, RAIL_MQ_4),
+  railDisplay(`${AD_PREFIX}-4-2-double`, RAIL_MQ_4),
+  railVideo(`${AD_PREFIX}-4-3-video`, RAIL_MQ_4),
+  // 5 — fishstick + double + fishstick + video
+  railFishstick(`${AD_PREFIX}-5-1-fishstick`, RAIL_MQ_5),
+  railDisplay(`${AD_PREFIX}-5-2-double`, RAIL_MQ_5),
+  railFishstick(`${AD_PREFIX}-5-3-fishstick`, RAIL_MQ_5),
+  railVideo(`${AD_PREFIX}-5-4-video`, RAIL_MQ_5),
+  // 6 — fishstick + double + square + video
+  railFishstick(`${AD_PREFIX}-6-1-fishstick`, RAIL_MQ_6),
+  railDisplay(`${AD_PREFIX}-6-2-double`, RAIL_MQ_6),
+  railDisplay(`${AD_PREFIX}-6-3-square`, RAIL_MQ_6),
+  railVideo(`${AD_PREFIX}-6-4-video`, RAIL_MQ_6),
+  // 7 — fishstick + double + double + video
+  railFishstick(`${AD_PREFIX}-7-1-fishstick`, RAIL_MQ_7),
+  railDisplay(`${AD_PREFIX}-7-2-double`, RAIL_MQ_7),
+  railDisplay(`${AD_PREFIX}-7-3-double`, RAIL_MQ_7),
+  railVideo(`${AD_PREFIX}-7-4-video`, RAIL_MQ_7),
+  // Narrow (160px) width regime — single fill slot.
   displaySlot({
-    containerId: "nimbus-right-column-narrow",
+    containerId: `${AD_PREFIX}-narrow`,
     sizeVariant: "narrow-dynamic",
     sizes: RIGHT_NARROW_SIZES,
     mediaQuery: RIGHT_COLUMN_NARROW_MQ,
@@ -300,25 +381,25 @@ export const RIGHT_COLUMN_SLOTS: RenderedAdSlot[] = [
 // footer); only the breakpoint-matching banner reveals.
 export const BOTTOM_BANNER_AD_SLOTS: RenderedAdSlot[] = [
   displaySlot({
-    containerId: "nimbus-bottom-ad-very-narrow",
+    containerId: `${AD_PREFIX}-bottom-ad-very-narrow`,
     sizeVariant: "bottom-banner",
     sizes: BOTTOM_VERY_NARROW_SIZES,
     mediaQuery: "(max-width: 767.98px)",
   }),
   displaySlot({
-    containerId: "nimbus-bottom-ad-narrow",
+    containerId: `${AD_PREFIX}-bottom-ad-narrow`,
     sizeVariant: "bottom-banner",
     sizes: BOTTOM_NARROW_SIZES,
     mediaQuery: "(min-width: 768px) and (max-width: 991.98px)",
   }),
   displaySlot({
-    containerId: "nimbus-bottom-ad-wide",
+    containerId: `${AD_PREFIX}-bottom-ad-wide`,
     sizeVariant: "bottom-banner",
     sizes: BOTTOM_WIDE_SIZES,
     mediaQuery: "(min-width: 992px) and (max-width: 1199.98px)",
   }),
   displaySlot({
-    containerId: "nimbus-bottom-ad-very-wide",
+    containerId: `${AD_PREFIX}-bottom-ad-very-wide`,
     sizeVariant: "bottom-banner",
     sizes: BOTTOM_VERY_WIDE_SIZES,
     mediaQuery: "(min-width: 1200px)",
@@ -331,14 +412,14 @@ export const BOTTOM_BANNER_AD_SLOTS: RenderedAdSlot[] = [
 // viewports, the third at 2×982 + 90 + gaps = 2118px.
 export const BOTTOM_RIGHT_AD_SLOTS: RenderedAdSlot[] = [
   displaySlot({
-    containerId: "nimbus-bottom-ad-right",
+    containerId: `${AD_PREFIX}-bottom-ad-right`,
     sizeVariant: "bottom-right",
     sizes: BOTTOM_RIGHT_SIZES,
     mediaQuery: "(min-width: 1120px)",
     report: TOP_LEFT_REPORT,
   }),
   displaySlot({
-    containerId: "nimbus-bottom-ad-third",
+    containerId: `${AD_PREFIX}-bottom-ad-third`,
     sizeVariant: "bottom-right",
     sizes: BOTTOM_RIGHT_SIZES,
     mediaQuery: "(min-width: 2118px)",
@@ -457,16 +538,18 @@ function createNimbusAdsInView(
 }
 
 /**
- * Create every Nimbus ad slot. The above-the-fold right-column rail is created
- * eagerly; the below-the-fold bottom banner row is deferred until it scrolls
- * into view (see createNimbusAdsInView).
+ * Create every Nimbus ad slot. Each slot is created lazily, once its container
+ * is actually on-screen (see createNimbusAdsInView). The rail's slots are
+ * revealed by CSS container queries (layout.css), so a slot hidden for the
+ * current rail height has no box, never intersects, and is never instantiated;
+ * each slot's mediaQuery (width regime + its config's window-height band) is the
+ * belt-and-braces gate inside NitroPay. The rail sits in the initial viewport,
+ * so its visible slots still create on first paint.
  */
 export function createAllNimbusAds(nitroAds: NitroAds): void {
   adsLiveSince = Date.now();
-  for (const slot of RIGHT_COLUMN_SLOTS) {
-    createNimbusAd(nitroAds, slot.containerId, slot.options);
-  }
   createNimbusAdsInView(nitroAds, [
+    ...RIGHT_COLUMN_SLOTS,
     ...BOTTOM_BANNER_AD_SLOTS,
     ...BOTTOM_RIGHT_AD_SLOTS,
   ]);
@@ -488,7 +571,7 @@ export function onNavigateNimbusAds(): void {
   }
   adsLiveSince = now;
   adRegistry.forEach((ad, id) => {
-    if (id === RAIL_VIDEO_ID) {
+    if (id.endsWith(RAIL_VIDEO_ID_SUFFIX)) {
       return;
     }
     try {

--- a/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
@@ -109,7 +109,7 @@ export type RenderedAdSlot = {
 // Minimum creative lifetime (since slot creation or last refresh) before an SPA
 // navigation may refresh ads — 45s favours viewability/CTR over churn. Enforced
 // in onNavigateNimbusAds and mirrored to NitroPay per slot via `onNavigateMin`.
-const MIN_AD_LIFETIME_MS = 45000;
+const MIN_AD_LIFETIME_MS = 40000;
 const ON_NAVIGATE_MIN = MIN_AD_LIFETIME_MS;
 
 // Set to true to render static placeholders instead of making real ad calls,
@@ -212,23 +212,29 @@ const BOTTOM_RIGHT_SIZES = BOTTOM_VERY_WIDE_SIZES;
 const RIGHT_COLUMN_MQ = "(min-width: 1484px)";
 const RIGHT_COLUMN_NARROW_MQ = "(min-width: 1214px) and (max-width: 1483.98px)";
 
-// Chrome reserved above + below the sticky rail stack (mirrors the height calc
-// in layout.css: header + gap-2xs top + gap-2xs bottom). layout.css reveals a
-// config by the rail's own (container) height; NitroPay's mediaQuery is a
-// viewport query, so viewport height = rail (container) height + this.
-const RAIL_CHROME_PX = 64;
+// Chrome reserved above + below the sticky rail stack, mirroring layout.css's
+// stack height calc: --header-height (3.5rem) + --gap-2xs top + --gap-2xs bottom
+// (0.25rem each). layout.css reveals a config by the rail's own (container)
+// height; NitroPay's mediaQuery is a viewport query, so viewport height = rail
+// (container) height + this chrome. Kept in rem (not a hardcoded 64px) so a
+// non-default root font size scales it the same way layout.css does, keeping the
+// two in step.
+const RAIL_CHROME_REM = 3.5 + 0.25 + 0.25;
 
 // A config's NitroPay mediaQuery: the 336px-rail width regime plus that config's
 // rail-height band expressed as VIEWPORT height, so NitroPay only serves the
-// config's slots at the window heights where layout.css shows them. These bands
-// MUST mirror the @container bands in layout.css.
+// config's slots at the window heights where layout.css shows them. The px band
+// and the rem chrome are summed with calc() so the viewport threshold tracks the
+// root font size. These bands MUST mirror the @container bands in layout.css.
 function railHeightMq(minRail: number, maxRail: number | null): string {
   const parts = [
     RIGHT_COLUMN_MQ,
-    `(min-height: ${minRail + RAIL_CHROME_PX}px)`,
+    `(min-height: calc(${minRail}px + ${RAIL_CHROME_REM}rem))`,
   ];
   if (maxRail !== null) {
-    parts.push(`(max-height: ${maxRail + RAIL_CHROME_PX - 0.02}px)`);
+    parts.push(
+      `(max-height: calc(${maxRail}px + ${RAIL_CHROME_REM}rem - 0.02px))`
+    );
   }
   return parts.join(" and ");
 }
@@ -264,8 +270,8 @@ function displaySlot(slot: {
       format: "display",
       demo: AD_DEMO_MODE,
       refreshLimit: 0,
-      // 300s (5 min) auto-refresh: longer dwell for better viewability/CTR.
-      refreshTime: 90,
+      // 60s auto-refresh for display slots (the video slot uses 30s).
+      refreshTime: 60,
       onNavigateMin: ON_NAVIGATE_MIN,
       // Demo placeholders render immediately (not gated on the slot scrolling
       // into view) so the layout is easy to inspect; production stays
@@ -322,7 +328,7 @@ function railVideo(id: string, mediaQuery: string): RenderedAdSlot {
       format: "video-nc",
       demo: AD_DEMO_MODE,
       refreshLimit: 0,
-      // 30s auto-refresh for the video slot (display slots stay at 90s).
+      // 30s auto-refresh for the video slot (display slots use 60s).
       refreshTime: 30,
       onNavigateMin: ON_NAVIGATE_MIN,
       // The rail keeps the player on screen; never detach into the floating

--- a/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/nitroAds.ts
@@ -12,13 +12,12 @@ import type { AdContainerSizeVariant } from "@thunderstore/cyberstorm";
  * `nimbus-v<AD_SLOT_VERSION>-<config>-<position>-<type>`), so a slot is never reused at
  * two sizes. The rail is 336px wide on large viewports and a single 160px fill
  * slot on mid-width ones. NitroPay measures each slot's container and only loads
- * sizes that fit it. Because the reveal is a CSS container query (not a viewport
- * media query), each rail slot is created lazily — only once its container is
- * actually on-screen (see createNimbusAdsInView) — so a slot the current config
- * hides is never instantiated. Each rail slot's `mediaQuery` carries the width
- * regime (full 336px vs 160px narrow rail) AND its config's window-height band,
- * so NitroPay also gates each config by viewport height. All slot ids must be
- * configured in the NitroPay dashboard before they fill.
+ * sizes that fit it. Rail slots are created eagerly; each carries its config's
+ * `mediaQuery` (the width regime — full 336px vs 160px narrow rail — AND its
+ * config's window-height band), so NitroPay serves only the config matching the
+ * current window while CSS hides the rest. The visual reveal is the CSS
+ * container query (layout.css); the mediaQuery keeps NitroPay in step. All slot
+ * ids must be configured in the NitroPay dashboard before they fill.
  *
  * Types are derived from the NitroPay API docs (api-docs.nitropay.com):
  * `createAd` returns a `NitroAd` (or a promise of one/an array), whose
@@ -268,8 +267,11 @@ function displaySlot(slot: {
       // 300s (5 min) auto-refresh: longer dwell for better viewability/CTR.
       refreshTime: 90,
       onNavigateMin: ON_NAVIGATE_MIN,
-      renderVisibleOnly: true,
-      refreshVisibleOnly: true,
+      // Demo placeholders render immediately (not gated on the slot scrolling
+      // into view) so the layout is easy to inspect; production stays
+      // viewport-gated for viewability/CTR.
+      renderVisibleOnly: !AD_DEMO_MODE,
+      refreshVisibleOnly: !AD_DEMO_MODE,
       sizes: slot.sizes,
       report: slot.report ?? DISPLAY_REPORT,
       mediaQuery: slot.mediaQuery,
@@ -538,18 +540,22 @@ function createNimbusAdsInView(
 }
 
 /**
- * Create every Nimbus ad slot. Each slot is created lazily, once its container
- * is actually on-screen (see createNimbusAdsInView). The rail's slots are
- * revealed by CSS container queries (layout.css), so a slot hidden for the
- * current rail height has no box, never intersects, and is never instantiated;
- * each slot's mediaQuery (width regime + its config's window-height band) is the
- * belt-and-braces gate inside NitroPay. The rail sits in the initial viewport,
- * so its visible slots still create on first paint.
+ * Create every Nimbus ad slot. Rail slots are created EAGERLY: each carries its
+ * config's mediaQuery (width regime + window-height band), so NitroPay serves
+ * only the config matching the current window and CSS hides the rest — there's
+ * no need to gate creation on scroll/intersection. With AD_DEMO_MODE on, each
+ * slot is created with `demo: true` so NitroPay paints its own demo placeholders
+ * (NitroPay's demo is unreliable for the larger units / backgrounded tabs). The
+ * below-the-fold bottom banner row stays lazy, created only once it scrolls near
+ * the viewport (see createNimbusAdsInView).
  */
 export function createAllNimbusAds(nitroAds: NitroAds): void {
   adsLiveSince = Date.now();
+
+  for (const slot of RIGHT_COLUMN_SLOTS) {
+    createNimbusAd(nitroAds, slot.containerId, slot.options);
+  }
   createNimbusAdsInView(nitroAds, [
-    ...RIGHT_COLUMN_SLOTS,
     ...BOTTOM_BANNER_AD_SLOTS,
     ...BOTTOM_RIGHT_AD_SLOTS,
   ]);

--- a/apps/cyberstorm-remix/app/styles/layout.css
+++ b/apps/cyberstorm-remix/app/styles/layout.css
@@ -83,9 +83,10 @@
        [1181 - 1481)  6  fishstick + double + square + video
        [1481 -  inf)  7  fishstick + double + double + video
 
-     NitroPay stays in step because each slot is created only once it is actually
-     on-screen (nitroAds.ts createAllNimbusAds), so a hidden config's slots are
-     never instantiated — no viewport height media query required. */
+     NitroPay stays in step because every rail slot is created eagerly with its
+     config's mediaQuery — a viewport-height band mirroring these container bands
+     plus the rail chrome (see railHeightMq in nitroAds.ts) — so NitroPay serves
+     only the matching config while CSS hides the rest. */
 
   /* Hide every rail slot; the matching band (and the narrow width regime below)
      shows exactly one config's slots. */
@@ -158,6 +159,18 @@
      fill slot from 1214-1483.98px; below 1214px the rail is hidden and the
      bottom banner row is the only ad surface. */
   @media (width <= 1213.98px) {
+    .layout__ads {
+      display: none;
+    }
+  }
+
+  /* Below the shortest config's band the rail can show nothing (every slot stays
+     display:none), so hide the column instead of reserving an empty 336px
+     gutter. Threshold = band 1's 331px rail height + the rail chrome
+     (--header-height + 2× --gap-2xs = 4rem); custom properties aren't allowed in
+     media conditions, so the 4rem is inlined. Only the full-width rail regime is
+     height-banded — the narrow fill slot below isn't, so it's left untouched. */
+  @media (width >= 1484px) and (height < calc(331px + 4rem)) {
     .layout__ads {
       display: none;
     }

--- a/apps/cyberstorm-remix/app/styles/layout.css
+++ b/apps/cyberstorm-remix/app/styles/layout.css
@@ -23,61 +23,144 @@
   }
 
   /* Right ad rail beside the content, ending above the full-width bottom ad
-     row. The island spans the content row's height (background column); the
-     stack inside is a sticky, viewport-fitted flex column: fishstick / dynamic
-     display (absorbs the slack, see AdContainer.css) / fishstick / video
-     player, with the bottom pair pinned to the stack's end. */
+     row. The island spans the content row's height; the stack inside is a
+     sticky, viewport-fitted flex column that reveals progressively more ad
+     units as it gets taller (see the container-query bands below), with the
+     video pinned to the stack's end. */
   .layout__ads {
     align-self: stretch;
-    padding: var(--space-16);
   }
 
   .layout__ads-stack {
+    /* Size container-query context: the slots below reveal by THIS stack's own
+       height (see the bands further down), not a viewport media query. */
+    container: nimbus-ad-rail / size;
     position: sticky;
 
     /* Pin at the stack's natural resting offset (header + island-container gap
        + island padding): it never travels relative to the island, so scrolling
        has no catch-up nudge, and it stays clear of the navigation. */
-    top: calc(var(--header-height) + var(--gap-2xs) + var(--space-16));
+    top: calc(var(--header-height) + var(--gap-2xs));
     display: flex;
     flex-direction: column;
-    gap: var(--gap-xl);
+    gap: var(--gap-xs);
     align-items: center;
 
     /* 336px ads + the slots' 1px borders (see AdContainer.css sizing rule). */
     width: calc(336px + 2px);
+
+    /* Use nearly the full viewport height — only a symmetric gap-2xs above (the
+       sticky `top`) and below. A larger bottom reserve left the stack ~3px shy
+       of the 600px-display config at ~1080p, so it fell back to the 300px one
+       with a big empty gap; this gives that configuration the room it needs. */
     height: calc(
-      100dvh - var(--header-height) - var(--gap-2xs) - var(--space-32)
+      100dvh - var(--header-height) - var(--gap-2xs) - var(--gap-2xs)
     );
   }
 
-  /* The bottom fishstick + the video player below it pin to the stack's end:
-     the auto margin here swallows the leftover height (when the dynamic slot
-     hits its 600px cap), so the video always sits directly below the second
-     fishstick at the rail's bottom. */
-  .layout__ads-stack
-    .ad-container[data-cid="nimbus-right-column-fishstick-bottom"] {
+  /* The active config's video pins to the rail's bottom (it is last in every
+     configuration that has one); the auto margin swallows the leftover height so
+     the slack sits above it. Matches by id suffix as each config has its own
+     video slot. */
+  .layout__ads-stack .ad-container[data-cid$="-video"] {
     margin-top: auto;
   }
 
-  /* Reveal breakpoints mirror each slot's NitroPay `mediaQuery` (see
-     app/commonComponents/Ads/nitroAds.ts) so NitroPay never instantiates a
-     slot that CSS hides — keep the two in sync. The `.98px` upper bounds make
-     each band meet the next `>=` reveal with no fractional-width gap
-     (Bootstrap convention).
+  /* --- Rail configurations: shortest to tallest rail height ---
+     Each configuration owns its slots and exactly one config shows per height
+     band. Slots are matched by their VERSION-INDEPENDENT suffix
+     (-<config>-<position>-<type>), not the `nimbus-v<N>-` prefix, so bumping
+     AD_SLOT_VERSION in nitroAds.ts never has to touch this file. A band's lower
+     bound is that configuration's cumulative content height — ad box heights
+     (incl. their 1px borders) plus the 8px inter-slot gap — so it appears when
+     it fits (square = 336x300 display, double = 336x600 display):
 
-     Rail bands: the full 336px rail at >= 1484px (the old Django site's rail
-     breakpoint), a 160px narrow rail from 1214px up to 1483.98px, nothing
-     below either threshold — there the bottom banner row is the only ad
-     surface. */
-  @media (width <= 1213.98px), (height <= 599.98px) {
-    .layout__ads {
-      display: none;
+       [ 331 -  571)  1  fishstick + fishstick + video
+       [ 571 -  641)  2  fishstick + square + video
+       [ 641 -  871)  3  fishstick + square + fishstick + video
+       [ 871 -  941)  4  fishstick + double + video
+       [ 941 - 1181)  5  fishstick + double + fishstick + video
+       [1181 - 1481)  6  fishstick + double + square + video
+       [1481 -  inf)  7  fishstick + double + double + video
+
+     NitroPay stays in step because each slot is created only once it is actually
+     on-screen (nitroAds.ts createAllNimbusAds), so a hidden config's slots are
+     never instantiated — no viewport height media query required. */
+
+  /* Hide every rail slot; the matching band (and the narrow width regime below)
+     shows exactly one config's slots. */
+  .layout__ads .ad-container {
+    display: none;
+  }
+
+  @container nimbus-ad-rail (331px <= height < 571px) {
+    .layout__ads .ad-container[data-cid$="-1-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-1-2-fishstick"],
+    .layout__ads .ad-container[data-cid$="-1-3-video"] {
+      display: flex;
     }
   }
 
-  .layout__ads .ad-container[data-cid="nimbus-right-column-narrow"] {
-    display: none;
+  @container nimbus-ad-rail (571px <= height < 641px) {
+    .layout__ads .ad-container[data-cid$="-2-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-2-2-square"],
+    .layout__ads .ad-container[data-cid$="-2-3-video"] {
+      display: flex;
+    }
+  }
+
+  @container nimbus-ad-rail (641px <= height < 871px) {
+    .layout__ads .ad-container[data-cid$="-3-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-3-2-square"],
+    .layout__ads .ad-container[data-cid$="-3-3-fishstick"],
+    .layout__ads .ad-container[data-cid$="-3-4-video"] {
+      display: flex;
+    }
+  }
+
+  @container nimbus-ad-rail (871px <= height < 941px) {
+    .layout__ads .ad-container[data-cid$="-4-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-4-2-double"],
+    .layout__ads .ad-container[data-cid$="-4-3-video"] {
+      display: flex;
+    }
+  }
+
+  @container nimbus-ad-rail (941px <= height < 1181px) {
+    .layout__ads .ad-container[data-cid$="-5-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-5-2-double"],
+    .layout__ads .ad-container[data-cid$="-5-3-fishstick"],
+    .layout__ads .ad-container[data-cid$="-5-4-video"] {
+      display: flex;
+    }
+  }
+
+  @container nimbus-ad-rail (1181px <= height < 1481px) {
+    .layout__ads .ad-container[data-cid$="-6-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-6-2-double"],
+    .layout__ads .ad-container[data-cid$="-6-3-square"],
+    .layout__ads .ad-container[data-cid$="-6-4-video"] {
+      display: flex;
+    }
+  }
+
+  @container nimbus-ad-rail (height >= 1481px) {
+    .layout__ads .ad-container[data-cid$="-7-1-fishstick"],
+    .layout__ads .ad-container[data-cid$="-7-2-double"],
+    .layout__ads .ad-container[data-cid$="-7-3-double"],
+    .layout__ads .ad-container[data-cid$="-7-4-video"] {
+      display: flex;
+    }
+  }
+
+  /* Width regimes (viewport-driven: horizontal room for the rail). Full 336px
+     rail at >= 1484px (the old Django site's breakpoint); a single 160px narrow
+     fill slot from 1214-1483.98px; below 1214px the rail is hidden and the
+     bottom banner row is the only ad surface. */
+  @media (width <= 1213.98px) {
+    .layout__ads {
+      display: none;
+    }
   }
 
   @media (width >= 1214px) and (width <= 1483.98px) {
@@ -85,14 +168,16 @@
       width: calc(160px + 2px);
     }
 
-    .layout__ads .ad-container[data-cid="nimbus-right-column-fishstick-top"],
-    .layout__ads .ad-container[data-cid="nimbus-right-column-dynamic"],
-    .layout__ads .ad-container[data-cid="nimbus-right-column-fishstick-bottom"],
-    .layout__ads .ad-container[data-cid="nimbus-right-column-video"] {
+    /* Width regime wins over the height bands: hide every config slot (any
+       fishstick/square/double/video), show only the narrow fill slot. */
+    .layout__ads .ad-container[data-cid$="-fishstick"],
+    .layout__ads .ad-container[data-cid$="-square"],
+    .layout__ads .ad-container[data-cid$="-double"],
+    .layout__ads .ad-container[data-cid$="-video"] {
       display: none;
     }
 
-    .layout__ads .ad-container[data-cid="nimbus-right-column-narrow"] {
+    .layout__ads .ad-container[data-cid$="-narrow"] {
       display: flex;
     }
   }
@@ -138,13 +223,13 @@
   }
 
   @media (width >= 1120px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-right"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-right"] {
       display: inline-flex;
     }
   }
 
   @media (width >= 2118px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-third"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-third"] {
       display: inline-flex;
     }
   }
@@ -154,7 +239,7 @@
      adblock notice stays in the accessibility tree (as on the slim rail slots
      in AdContainer.css). The third companion keeps the full text. */
   .layout__bottom-ads
-    .ad-container[data-cid="nimbus-bottom-ad-right"]
+    .ad-container[data-cid$="-bottom-ad-right"]
     .ad-container__fallback-text {
     position: absolute;
     width: 1px;
@@ -175,25 +260,25 @@
   }
 
   @media (width <= 767.98px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-very-narrow"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-very-narrow"] {
       display: flex;
     }
   }
 
   @media (width >= 768px) and (width <= 991.98px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-narrow"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-narrow"] {
       display: flex;
     }
   }
 
   @media (width >= 992px) and (width <= 1199.98px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-wide"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-wide"] {
       display: flex;
     }
   }
 
   @media (width >= 1200px) {
-    .layout__bottom-ads .ad-container[data-cid="nimbus-bottom-ad-very-wide"] {
+    .layout__bottom-ads .ad-container[data-cid$="-bottom-ad-very-wide"] {
       display: flex;
     }
   }

--- a/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.css
+++ b/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.css
@@ -65,6 +65,23 @@
     max-height: calc(600px + 2px);
   }
 
+  /* Right-rail display units — fixed boxes (336 wide). Each is a distinct
+     per-config slot (see Nimbus layout.css / nitroAds.ts): "square" is 336x300,
+     "double" is 336x600 (twice as tall). */
+  .ad-container[data-size="rail-square"] {
+    display: flex;
+    flex: none;
+    width: calc(336px + 2px);
+    height: calc(300px + 2px);
+  }
+
+  .ad-container[data-size="rail-double"] {
+    display: flex;
+    flex: none;
+    width: calc(336px + 2px);
+    height: calc(600px + 2px);
+  }
+
   /* The mid-width rail band's only placement: a 160px-wide column that fills
      the available rail height. */
   .ad-container[data-size="narrow-dynamic"] {

--- a/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.tsx
+++ b/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.tsx
@@ -9,7 +9,7 @@ export type AdContainerSizeVariant =
   | "fishstick"
   | "dynamic"
   // Right-rail display units — fixed boxes: "square" (336x300) and "double"
-  // (336x600, twice as tall); one per per-config slot in the Nimbus ad rail.
+  // (336x600, twice as tall) used in the rail's per-config slots.
   | "rail-square"
   | "rail-double"
   | "narrow-dynamic"

--- a/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.tsx
+++ b/packages/cyberstorm/src/newComponents/AdContainer/AdContainer.tsx
@@ -8,6 +8,10 @@ export type AdContainerSizeVariant =
   | "display-300-250"
   | "fishstick"
   | "dynamic"
+  // Right-rail display units — fixed boxes: "square" (336x300) and "double"
+  // (336x600, twice as tall); one per per-config slot in the Nimbus ad rail.
+  | "rail-square"
+  | "rail-double"
   | "narrow-dynamic"
   | "video"
   | "bottom-banner"


### PR DESCRIPTION
Ad layout changes

Refactor the ad layouts to work better and more fairly based on the
sidebar height. Also remove unnecessary spacing in the sidebar, which
caused the ad sidebar to become wider.

Potentially fix demo mode

Nitros demo mode is weirdlt inconsistent. Sometimes it works and sometimes it doesn't. Now after these changes it works sometimes.