### PR TITLE
WIP: Add moderator note API client layer (thunderstore-api + dapper types)

### DIFF
--- a/packages/dapper-fake/src/fakers/package.ts
+++ b/packages/dapper-fake/src/fakers/package.ts
@@ -171,6 +171,17 @@ export const getFakePackageListingDetails = async (
     install_url: `ror2mm://v1/install/thunderstore.io/${namespace}/${name}/${ver}/`,
     latest_version_number: getVersionNumber(),
     package_created: packageCreated.toISOString(),
+    moderator_note: faker.datatype.boolean(0.3)
+      ? {
+          id: faker.number.int({ min: 1, max: 100000 }),
+          target_type: "listing" as const,
+          content: faker.lorem.sentence(),
+          version_number: null,
+          is_active: true,
+          datetime_created: faker.date.recent({ days: 30 }).toISOString(),
+          datetime_updated: faker.date.recent({ days: 30 }).toISOString(),
+        }
+      : null,
     team: {
       name: faker.word.words(3),
       members: await getFakeTeamMembers(seed),

--- a/packages/dapper/src/types/community.ts
+++ b/packages/dapper/src/types/community.ts
@@ -1,4 +1,8 @@
-import { type PackageCategory, type PaginatedList } from "./shared";
+import {
+  type ModeratorNote,
+  type PackageCategory,
+  type PaginatedList,
+} from "./shared";
 
 export interface Community {
   name: string;
@@ -14,6 +18,9 @@ export interface Community {
   community_icon_url: string | null;
   total_download_count: number;
   total_package_count: number;
+  // Single active note; only present on the community detail endpoint, never
+  // the list.
+  moderator_note?: ModeratorNote | null;
 }
 
 export type Communities = PaginatedList<Community>;

--- a/packages/dapper/src/types/index.ts
+++ b/packages/dapper/src/types/index.ts
@@ -4,4 +4,8 @@ export * from "./package";
 export * from "./team";
 export * from "./user";
 export { type PackageListingType } from "./props";
-export { type PackageCategory } from "./shared";
+export {
+  type ModeratorNote,
+  type ModeratorNoteTargetType,
+  type PackageCategory,
+} from "./shared";

--- a/packages/dapper/src/types/package.ts
+++ b/packages/dapper/src/types/package.ts
@@ -1,4 +1,8 @@
-import { type PackageCategory, type PaginatedList } from "./shared";
+import {
+  type ModeratorNote,
+  type PackageCategory,
+  type PaginatedList,
+} from "./shared";
 import { type TeamMember } from "./team";
 
 export interface PackageListing {
@@ -39,6 +43,7 @@ export interface PackageListingDetails
   install_url: string;
   latest_version_number: string;
   listing_admin_url?: string | null;
+  moderator_note: ModeratorNote | null;
   package_admin_url?: string | null;
   team: PackageTeam;
   website_url: string | null;

--- a/packages/dapper/src/types/shared.ts
+++ b/packages/dapper/src/types/shared.ts
@@ -17,6 +17,19 @@ export interface PackageCategory {
   slug: string;
 }
 
+export type ModeratorNoteTargetType = "community" | "listing" | "version";
+
+export interface ModeratorNote {
+  id: number;
+  target_type: ModeratorNoteTargetType;
+  content: string;
+  // Set only for version notes.
+  version_number: string | null;
+  is_active: boolean;
+  datetime_created: string;
+  datetime_updated: string;
+}
+
 export type PaginatedList<T> = {
   count: number;
   hasMore: boolean;

--- a/packages/thunderstore-api/src/delete/moderatorNote.ts
+++ b/packages/thunderstore-api/src/delete/moderatorNote.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "../apiFetch";
+import type { ApiEndpointProps } from "../index";
+import type { ModeratorNoteDetailRequestParams } from "../schemas/requestSchemas";
+
+export function deleteModeratorNote(
+  props: ApiEndpointProps<ModeratorNoteDetailRequestParams, object, object>
+) {
+  const { config, params } = props;
+  const path = `/api/cyberstorm/moderator-note/${params.note_id}/`;
+
+  return apiFetch({
+    args: {
+      config,
+      path,
+      request: {
+        method: "DELETE",
+        cache: "no-store",
+      },
+      useSession: true,
+    },
+    requestSchema: undefined,
+    queryParamsSchema: undefined,
+    responseSchema: undefined,
+  });
+}

--- a/packages/thunderstore-api/src/index.ts
+++ b/packages/thunderstore-api/src/index.ts
@@ -16,6 +16,7 @@ export interface ApiEndpointProps<Params, QueryParams, Data> {
 
 export const BASE_LISTING_PATH = "api/cyberstorm/listing/";
 
+export * from "./delete/moderatorNote";
 export * from "./delete/packageWiki";
 export * from "./delete/teamDisband";
 export * from "./delete/teamRemoveMember";
@@ -44,9 +45,11 @@ export * from "./get/packageSource";
 export * from "./get/teamDetails";
 export * from "./get/teamMembers";
 export * from "./get/teamServiceAccounts";
+export * from "./patch/moderatorNote";
 export * from "./patch/teamDetailsEdit";
 export * from "./patch/teamEditMember";
 export * from "./post/frontend";
+export * from "./post/moderatorNote";
 export * from "./post/package";
 export * from "./post/packageListing";
 export * from "./post/packageWiki";

--- a/packages/thunderstore-api/src/patch/moderatorNote.ts
+++ b/packages/thunderstore-api/src/patch/moderatorNote.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from "../apiFetch";
+import type { ApiEndpointProps } from "../index";
+import { moderatorNoteSchema } from "../schemas/objectSchemas";
+import type { ModeratorNote } from "../schemas/objectSchemas";
+import { moderatorNoteUpdateRequestDataSchema } from "../schemas/requestSchemas";
+import type {
+  ModeratorNoteDetailRequestParams,
+  ModeratorNoteUpdateRequestData,
+} from "../schemas/requestSchemas";
+
+export function updateModeratorNote(
+  props: ApiEndpointProps<
+    ModeratorNoteDetailRequestParams,
+    object,
+    ModeratorNoteUpdateRequestData
+  >
+): Promise<ModeratorNote> {
+  const { config, params, data } = props;
+  const path = `/api/cyberstorm/moderator-note/${params.note_id}/`;
+
+  return apiFetch({
+    args: {
+      config,
+      path,
+      request: {
+        method: "PATCH",
+        cache: "no-store",
+        body: JSON.stringify(data),
+      },
+      useSession: true,
+    },
+    requestSchema: moderatorNoteUpdateRequestDataSchema,
+    queryParamsSchema: undefined,
+    responseSchema: moderatorNoteSchema,
+  });
+}

--- a/packages/thunderstore-api/src/post/moderatorNote.ts
+++ b/packages/thunderstore-api/src/post/moderatorNote.ts
@@ -1,0 +1,92 @@
+import { apiFetch } from "../apiFetch";
+import type { ApiEndpointProps } from "../index";
+import { moderatorNoteSchema } from "../schemas/objectSchemas";
+import type { ModeratorNote } from "../schemas/objectSchemas";
+import { moderatorNoteWriteRequestDataSchema } from "../schemas/requestSchemas";
+import type {
+  CommunityModeratorNoteCreateRequestParams,
+  ListingModeratorNoteCreateRequestParams,
+  ModeratorNoteWriteRequestData,
+  VersionModeratorNoteCreateRequestParams,
+} from "../schemas/requestSchemas";
+
+export function createCommunityModeratorNote(
+  props: ApiEndpointProps<
+    CommunityModeratorNoteCreateRequestParams,
+    object,
+    ModeratorNoteWriteRequestData
+  >
+): Promise<ModeratorNote> {
+  const { config, params, data } = props;
+  const path = `/api/cyberstorm/community/${params.community}/notes/`;
+
+  return apiFetch({
+    args: {
+      config,
+      path,
+      request: {
+        method: "POST",
+        cache: "no-store",
+        body: JSON.stringify(data),
+      },
+      useSession: true,
+    },
+    requestSchema: moderatorNoteWriteRequestDataSchema,
+    queryParamsSchema: undefined,
+    responseSchema: moderatorNoteSchema,
+  });
+}
+
+export function createListingModeratorNote(
+  props: ApiEndpointProps<
+    ListingModeratorNoteCreateRequestParams,
+    object,
+    ModeratorNoteWriteRequestData
+  >
+): Promise<ModeratorNote> {
+  const { config, params, data } = props;
+  const path = `/api/cyberstorm/listing/${params.community}/${params.namespace}/${params.package}/notes/`;
+
+  return apiFetch({
+    args: {
+      config,
+      path,
+      request: {
+        method: "POST",
+        cache: "no-store",
+        body: JSON.stringify(data),
+      },
+      useSession: true,
+    },
+    requestSchema: moderatorNoteWriteRequestDataSchema,
+    queryParamsSchema: undefined,
+    responseSchema: moderatorNoteSchema,
+  });
+}
+
+export function createVersionModeratorNote(
+  props: ApiEndpointProps<
+    VersionModeratorNoteCreateRequestParams,
+    object,
+    ModeratorNoteWriteRequestData
+  >
+): Promise<ModeratorNote> {
+  const { config, params, data } = props;
+  const path = `/api/cyberstorm/listing/${params.community}/${params.namespace}/${params.package}/v/${params.version_number}/notes/`;
+
+  return apiFetch({
+    args: {
+      config,
+      path,
+      request: {
+        method: "POST",
+        cache: "no-store",
+        body: JSON.stringify(data),
+      },
+      useSession: true,
+    },
+    requestSchema: moderatorNoteWriteRequestDataSchema,
+    queryParamsSchema: undefined,
+    responseSchema: moderatorNoteSchema,
+  });
+}

--- a/packages/thunderstore-api/src/schemas/objectSchemas.ts
+++ b/packages/thunderstore-api/src/schemas/objectSchemas.ts
@@ -43,6 +43,18 @@ export type UsermediaCompletedPart = z.infer<
   typeof usermediaCompletedPartSchema
 >;
 
+export const moderatorNoteSchema = z.object({
+  id: z.number().int(),
+  target_type: z.enum(["community", "listing", "version"]),
+  content: z.string(),
+  version_number: z.string().nullable(),
+  is_active: z.boolean(),
+  datetime_created: z.string().datetime(),
+  datetime_updated: z.string().datetime(),
+});
+
+export type ModeratorNote = z.infer<typeof moderatorNoteSchema>;
+
 export const communitySchema = z.object({
   name: z.string().min(1),
   identifier: z.string().min(1),
@@ -57,6 +69,9 @@ export const communitySchema = z.object({
   community_icon_url: z.string().nullable(),
   total_download_count: z.number().int(),
   total_package_count: z.number().int(),
+  // Single active note; only present on the community detail endpoint, never
+  // the list.
+  moderator_note: moderatorNoteSchema.nullable().optional(),
 });
 
 export type Community = z.infer<typeof communitySchema>;
@@ -179,6 +194,7 @@ export const packageListingDetailsSchema = packageListingSchema
     install_url: z.string(),
     latest_version_number: z.string().min(1),
     listing_admin_url: z.string().nullable().optional(),
+    moderator_note: moderatorNoteSchema.nullable(),
     package_admin_url: z.string().nullable().optional(),
     team: packageTeamSchema,
     website_url: z.string().nullable(),

--- a/packages/thunderstore-api/src/schemas/requestSchemas.ts
+++ b/packages/thunderstore-api/src/schemas/requestSchemas.ts
@@ -684,3 +684,59 @@ export const packageSourceRequestParamsSchema = z.object({
 export type PackageSourceRequestParams = z.infer<
   typeof packageSourceRequestParamsSchema
 >;
+
+// ModeratorNote create (content is shared between all targets)
+export const moderatorNoteWriteRequestDataSchema = z.object({
+  content: z.string().min(1),
+});
+
+export type ModeratorNoteWriteRequestData = z.infer<
+  typeof moderatorNoteWriteRequestDataSchema
+>;
+
+// ModeratorNote update is a partial update: edit the text and/or toggle active.
+export const moderatorNoteUpdateRequestDataSchema = z.object({
+  content: z.string().min(1).optional(),
+  is_active: z.boolean().optional(),
+});
+
+export type ModeratorNoteUpdateRequestData = z.infer<
+  typeof moderatorNoteUpdateRequestDataSchema
+>;
+
+export const communityModeratorNoteCreateRequestParamsSchema = z.object({
+  community: z.string(),
+});
+
+export type CommunityModeratorNoteCreateRequestParams = z.infer<
+  typeof communityModeratorNoteCreateRequestParamsSchema
+>;
+
+export const listingModeratorNoteCreateRequestParamsSchema = z.object({
+  community: z.string(),
+  namespace: z.string(),
+  package: z.string(),
+});
+
+export type ListingModeratorNoteCreateRequestParams = z.infer<
+  typeof listingModeratorNoteCreateRequestParamsSchema
+>;
+
+export const versionModeratorNoteCreateRequestParamsSchema = z.object({
+  community: z.string(),
+  namespace: z.string(),
+  package: z.string(),
+  version_number: z.string(),
+});
+
+export type VersionModeratorNoteCreateRequestParams = z.infer<
+  typeof versionModeratorNoteCreateRequestParamsSchema
+>;
+
+export const moderatorNoteDetailRequestParamsSchema = z.object({
+  note_id: z.number().int(),
+});
+
+export type ModeratorNoteDetailRequestParams = z.infer<
+  typeof moderatorNoteDetailRequestParamsSchema
+>;


### PR DESCRIPTION
- zod moderatorNoteSchema (incl. is_active) plus a single nullable
  moderator_note on the package listing detail schema and the community schema
  (only the detail endpoint returns it, never the list).
- POST/PATCH/DELETE fetchers (create community/listing/version notes; partial
  update of content/is_active; delete) — all cache:"no-store", useSession:true.
- dapper ModeratorNote type + moderator_note on PackageListingDetails and
  Community, exported from the types barrel.
- dapper-fake gains a sample note so fake/storybook mode renders the feature.