### PR TITLE
Fix Code Wrapping

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
@@ -128,6 +128,7 @@
       border: var(--border-width--px) solid var(--color-surface-8);
       border-radius: var(--radius-md);
       background: var(--color-surface-1);
+      overflow-x: scroll;
     }
 
     code {
@@ -147,7 +148,6 @@
     }
 
     pre code {
-      display: block;
       padding: 0;
       border: 0;
       border-radius: 0;

--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -128,6 +128,7 @@
       border: var(--border-width--px) solid var(--color-surface-8);
       border-radius: var(--radius-md);
       background: var(--color-surface-1);
+      overflow-x: scroll;
     }
 
     code {
@@ -147,7 +148,6 @@
     }
 
     pre code {
-      display: block;
       padding: 0;
       border: 0;
       border-radius: 0;


### PR DESCRIPTION
Overflow-X was not set to scroll, and display block broke the wrapping on Code Blocks.

This PR turns this
<img width="669" height="903" alt="image" src="https://github.com/user-attachments/assets/fc9cf9af-fc3e-4783-a9f1-a6bea5beb608" />
into this
<img width="704" height="695" alt="image" src="https://github.com/user-attachments/assets/1197002f-28cc-409d-ac04-d2bb24021d1b" />
