### PR TITLE
Shrink Table Header Min Width

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
@@ -197,7 +197,7 @@
     }
 
     table tr th {
-      min-width: 15em;
+      min-width: 9em;
       border-top: solid var(--border-width--px) var(--color-surface-a8);
       color: var(--color-text-tertiary);
       white-space: nowrap;

--- a/apps/cyberstorm-remix/app/styles/markdown.css
+++ b/apps/cyberstorm-remix/app/styles/markdown.css
@@ -197,7 +197,7 @@
     }
 
     table tr th {
-      min-width: 15em;
+      min-width: 9em;
       border-top: solid var(--border-width--px) var(--color-surface-a8);
       color: var(--color-text-tertiary);
       white-space: nowrap;


### PR DESCRIPTION
This makes tables with images behave better, and tables feel more compacted while still looking visually nice.

<img width="811" height="919" alt="image" src="https://github.com/user-attachments/assets/6b7d4224-25b3-4e25-8d2e-7bf8c3c242da" />

<img width="733" height="978" alt="image" src="https://github.com/user-attachments/assets/b25b4135-ec27-4f0e-a3cb-99dc7f5b4a0f" />

<img width="757" height="972" alt="image" src="https://github.com/user-attachments/assets/fa0f551c-f4f7-48bd-8846-56d5bd8e79dc" />

<img width="754" height="874" alt="image" src="https://github.com/user-attachments/assets/5dcc83ab-ab74-4ca3-b4e3-9551ebb94487" />

If users want longer headers or the column to take more space, they can give it a longer header name to do so.

If pages got a pinch more width it would prolly feel even nicer.