### PR TITLE
Add Overflow-Wrap Anywhere to CardPackage.css Description

### DIFF
--- a/packages/cyberstorm-theme/src/components/CardPackage/CardPackage.css
+++ b/packages/cyberstorm-theme/src/components/CardPackage/CardPackage.css
@@ -40,6 +40,7 @@
     --card-package--description-line-height: var(
       --card-package-shared--description-line-height
     );
+    --card-package--description-overflow-wrap: anywhere;
     --card-package--tags-gap: var(--card-package-shared--tags-gap);
     --card-package--footer-gap: var(--card-package-shared--footer-gap);
   }

--- a/packages/cyberstorm-theme/src/components/CardPackage/CardPackage.css
+++ b/packages/cyberstorm-theme/src/components/CardPackage/CardPackage.css
@@ -40,7 +40,6 @@
     --card-package--description-line-height: var(
       --card-package-shared--description-line-height
     );
-    --card-package--description-overflow-wrap: anywhere;
     --card-package--tags-gap: var(--card-package-shared--tags-gap);
     --card-package--footer-gap: var(--card-package-shared--footer-gap);
   }

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
@@ -136,6 +136,7 @@
     font-family: var(--card-package--description-font-family);
     font-style: var(--card-package--description-font-style);
     line-height: var(--card-package--description-line-height);
+    overflow-wrap: anywhere;
   }
 
   /* Tags */


### PR DESCRIPTION
* Add Overflow Wrap to Card Package Description

This appears to be the correct file for adding the given change based on the sites live css.

Should look like this live if all went well

<img width="457" height="381" alt="image" src="https://github.com/user-attachments/assets/12e516c7-9d6e-455e-a2cd-f703e1b3d5e4" />

and not

<img width="388" height="355" alt="image" src="https://github.com/user-attachments/assets/aa2f7f2e-bbf6-4bb8-b586-b68331f0338a" />