### PR TITLE
Rework footer layout and unify shared layout variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
           - prettier@3.1.0
           - "@trivago/prettier-plugin-sort-imports@6.0.0"
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-    rev: v16.9.0
+    rev: v16.26.1
     hooks:
       - id: stylelint
         args: [--fix]
         additional_dependencies:
           # stylelint itself needs to be here when using additional_dependencies.
-          - stylelint@16.9.0
+          - stylelint@16.26.1
           - stylelint-config-standard@36.0.1
           - stylelint-config-rational-order@0.1.2

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.css
@@ -1,251 +1,127 @@
 @layer nimbus-components {
   .footer {
-    --footer-column-width: 45rem;
+    --footer-width: min(var(--container-width), 90rem);
+    --footer-inner-padding-inline: var(--container-padding);
+    --footer-inner-padding-block: 2.5rem;
+    --footer-inner-width: 100%;
 
-    display: flex;
-    flex-direction: column;
-    container-type: inline-size;
+    display: grid;
+    width: 100%;
+    line-height: 160%;
+    container: footer / inline-size;
+    reading-flow: source-order;
+
+    @media (width >= 60rem) {
+      --footer-inner-padding-block: 3.5rem;
+
+      grid-template:
+        "socials manager" auto
+        "links manager" auto
+        "copyright copyright" auto
+        / 1fr 1fr;
+    }
   }
 
-  .footer__content {
+  .footer__inner {
     display: flex;
-    flex-direction: row;
-    min-height: 34rem;
+    justify-content: center;
+
+    width: min(100%, var(--footer-inner-width));
+    min-width: 0;
+    max-width: var(--footer-width);
+
+    padding: var(--footer-inner-padding-block)
+      var(--footer-inner-padding-inline);
+
+    @media (width >= 60rem) {
+      justify-content: start;
+    }
   }
 
   .footer__section {
-    display: flex;
-    flex: 1 0 var(--footer-column-width);
-    flex-direction: column;
-  }
+    @media (width >= 60rem) {
+      display: grid;
 
-  .footer-item {
-    display: flex;
-    padding-block: 4.5rem;
-  }
+      &:where(.footer__section--socials) {
+        grid-area: socials;
+        justify-items: end;
+        reading-order: 1;
+      }
 
-  .footer__section:first-child > .footer-item:first-child,
-  .footer__section:first-child > .footer-item:last-child {
-    justify-content: flex-end;
-  }
+      &:where(.footer__section--links) {
+        grid-area: links;
+        justify-items: end;
+        reading-order: 2;
+      }
 
-  .footer__section:first-child > .footer-item:last-child {
-    flex-grow: 1;
-  }
+      &:where(.footer__section--manager) {
+        grid-area: manager;
+        justify-items: start;
+        reading-order: 3;
+      }
 
-  .footer-item__content {
-    display: flex;
-    flex-direction: row;
-    gap: var(--gap-3xl);
-    justify-content: space-between;
-    box-sizing: border-box;
-    width: var(--footer-column-width);
-    padding-inline: 3.5rem;
-  }
+      &:where(.footer__section--copyright) {
+        grid-area: copyright;
+        justify-items: center;
+        reading-order: 4;
+      }
 
-  .footer__company {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-
-  .footer__logo > svg {
-    height: var(--space-32);
-    color: #fff;
-  }
-
-  .footer__icon-links {
-    display: flex;
-    flex-shrink: 0;
-    gap: var(--gap-3xl);
-    justify-content: center;
-  }
-
-  .footer__icon-link {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: var(--space-32);
-    border-radius: var(--radius-md);
-
-    --icon-color: var(--link-color);
-
-    &:hover {
-      --icon-color: var(--link-color-hover);
+      /* If the section is socials, links, or manager,
+      set the width to half of the container width
+      footnote always stays at full width */
+      &:where(.footer__section--socials),
+      &:where(.footer__section--links),
+      &:where(.footer__section--manager) {
+        .footer__inner {
+          --footer-inner-width: calc(
+            (var(--footer-width) / 2) - (var(--island-gap) / 2)
+          );
+        }
+      }
     }
   }
 
-  .footer__nav {
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-xl);
-    align-items: flex-start;
-
-    > ul {
-      display: flex;
-      flex-direction: column;
-      gap: var(--gap-xs);
-      align-self: stretch;
-      font-size: var(--font-size-body-md);
-      line-height: var(--line-height-lg);
-      list-style-type: none;
-    }
-  }
-
-  .manager-ad {
+  .footer__section--manager {
     position: relative;
-    overflow: clip;
+    overflow: hidden;
 
     &::before {
       position: absolute;
-      right: 0;
-      bottom: 0;
-      height: 100%;
+      inset: 0;
       background-image: linear-gradient(
         165deg,
         hsl(276deg 39% 38% / 0) 45%,
         hsl(276deg 39% 38%) 121%
       );
-      background-repeat: no-repeat;
-      background-position: 100% 100%;
-      content: "\0020";
-      aspect-ratio: 5/1;
+      content: "";
+    }
+
+    .footer__inner {
+      position: relative;
+      padding-block-end: 0;
     }
   }
 
-  .manager-ad__wrapper {
-    position: relative;
-    z-index: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--gap-md);
-    align-items: flex-start;
-    box-sizing: border-box;
-    width: 100%;
-    padding-block: 5rem 0;
-    padding-inline: 3.5rem;
-  }
-
-  .manager-ad__description {
-    max-width: 475px;
-    padding-bottom: var(--space-16);
-    color: var(--color-text-secondary);
-    font-weight: var(--font-weight-medium);
-    font-size: var(--font-size-body-xl);
-    line-height: 160%;
-  }
-
-  .manager-ad__image-wrapper {
-    width: 100%;
-    max-width: 640px;
-    max-height: 13rem;
-    margin-top: var(--space-48);
-    overflow: visible;
-    filter: drop-shadow(-36px -36px 40px rgb(0 0 0 / 0.35));
-    aspect-ratio: 2.5/1;
-  }
-
-  .manager-ad__image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: left top;
-  }
-
-  .footnote {
-    padding: var(--space-32) 3.5rem;
-  }
-
-  .footnote__inner {
-    display: flex;
-    flex-direction: row;
-    gap: var(--gap-2xl);
-    justify-content: space-between;
-    width: 100%;
-    max-width: min(100%, calc(var(--footer-column-width) * 2));
-    margin-inline: auto;
-  }
-
-  .footnote__links {
-    display: flex;
-    gap: var(--gap-3xl);
-  }
-
-  .footnote__inner a {
-    color: var(--color-text-secondary);
-    font-weight: var(--font-weight-regular);
-    font-size: var(--font-size-body-sm);
-    line-height: var(--line-height-lg);
-
-    &:where(:hover) {
-      color: var(--color-text-primary);
+  .footer__section--copyright {
+    .footer__inner {
+      gap: 1rem;
+      justify-content: center;
+      padding-block: 2rem;
+      color: var(--color-text-tertiary);
+      font-size: var(--font-size-body-sm);
     }
   }
 
-  .footer__copyright {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-    align-items: center;
-    justify-content: center;
+  .footer-link {
     color: var(--color-text-tertiary);
-    font-weight: var(--font-weight-regular);
-    font-size: var(--font-size-body-sm);
-    line-height: var(--line-height-lg);
-  }
 
-  /* Stack when footer is narrower than two column widths (45rem * 2) */
-  @container (width <= 90rem) {
-    .footer__content {
-      --footer-column-width: 100%;
-
-      flex-direction: column;
-      min-height: 0;
+    &:where(.footer-link--secondary) {
+      text-decoration: underline dotted;
     }
 
-    .footer__section {
-      flex: 0 0 auto;
-      width: 100%;
-    }
-
-    .footer-item {
-      padding-block: var(--space-40);
-    }
-
-    .footer-item__content,
-    .manager-ad__wrapper {
-      padding-inline: var(--space-24);
-    }
-
-    .footer__section:first-child .footer-item__content {
-      justify-content: center;
-    }
-
-    .footer__section:first-child
-      > .footer-item:first-child
-      .footer-item__content {
-      flex-direction: column;
-    }
-
-    .footer__company {
-      justify-content: center;
-    }
-
-    .manager-ad {
-      padding-block-start: 3rem;
-    }
-
-    .manager-ad > .footer-item {
-      padding-block: 0;
-    }
-
-    .footnote {
-      padding-inline: var(--space-24);
-    }
-
-    .footnote__inner {
-      flex-direction: column;
-      align-items: center;
+    &:hover,
+    &:focus-visible {
+      color: var(--color-text-primary);
     }
   }
 }

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/Footer.tsx
@@ -1,20 +1,10 @@
-import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
-import { faBoltLightning } from "@fortawesome/free-solid-svg-icons";
-import { faArrowUpRight } from "@fortawesome/pro-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Island, IslandContainer } from "~/commonComponents/Island/Island";
 
-import {
-  Heading,
-  NewButton,
-  NewIcon,
-  NewLink,
-  ThunderstoreLogoHorizontal,
-} from "@thunderstore/cyberstorm";
-
-const AD_IMAGE_SRC = "/cyberstorm-static/images/tsmm_screenshot.webp";
-const DISCORD_URL = "https://discord.thunderstore.io/";
-const GITHUB_URL = "https://github.com/thunderstore-io";
+import "./Footer.css";
+import { FooterCopyright } from "./FooterCopyright";
+import { FooterLinks } from "./FooterLinks";
+import { FooterManagerAd } from "./FooterManagerAd";
+import { FooterSocials } from "./FooterSocials";
 
 /**
  * Cyberstorm Footer Component
@@ -26,198 +16,25 @@ const GITHUB_URL = "https://github.com/thunderstore-io";
 export function Footer(props: { domain: string }) {
   const { domain } = props;
   return (
-    <IslandContainer as="footer" rootClasses="footer" aria-label="Footer">
-      <IslandContainer direction="x" rootClasses="footer__content">
-        <IslandContainer direction="y" rootClasses="footer__section">
-          <Island rootClasses="footer-item">
-            <div className="footer-item__content">
-              <div className="footer__company">
-                <NewIcon csVariant="accent" wrapperClasses="footer__logo">
-                  <ThunderstoreLogoHorizontal />
-                </NewIcon>
-              </div>
-              <div className="footer__icon-links">
-                <NewLink
-                  primitiveType="link"
-                  tooltipText="Join our Discord"
-                  href={DISCORD_URL}
-                  rootClasses="footer__icon-link"
-                  csVariant="primary"
-                  aria-label="Invite link to Thunderstores Discord server"
-                >
-                  <NewIcon noWrapper>
-                    <FontAwesomeIcon icon={faDiscord} />
-                  </NewIcon>
-                </NewLink>
-                <NewLink
-                  primitiveType="link"
-                  tooltipText="Check out our GitHub"
-                  href={GITHUB_URL}
-                  rootClasses="footer__icon-link"
-                  aria-label="Link to Thunderstores Github"
-                  csVariant="primary"
-                >
-                  <NewIcon noWrapper>
-                    <FontAwesomeIcon icon={faGithub} />
-                  </NewIcon>
-                </NewLink>
-              </div>
-            </div>
-          </Island>
-          <Island rootClasses="footer-item">
-            <div className="footer-item__content">
-              <nav className="footer__nav" aria-label="Thunderstore links">
-                <Heading
-                  csVariant="primary"
-                  mode="heading"
-                  csLevel="2"
-                  csSize="4"
-                >
-                  Thunderstore
-                </Heading>
-                <ul>
-                  <li>
-                    <NewLink
-                      primitiveType="cyberstormLink"
-                      linkId="Communities"
-                      csVariant="primary"
-                    >
-                      Communities
-                    </NewLink>
-                  </li>
-                </ul>
-              </nav>
-              <nav className="footer__nav" aria-label="Developer links">
-                <Heading
-                  csVariant="primary"
-                  mode="heading"
-                  csLevel="2"
-                  csSize="4"
-                >
-                  Developers
-                </Heading>
-                <ul>
-                  <li>
-                    <NewLink
-                      primitiveType="link"
-                      href={`${domain}/api/docs/`}
-                      csVariant="primary"
-                    >
-                      API Documentation
-                    </NewLink>
-                  </li>
-                  <li>
-                    <NewLink
-                      primitiveType="link"
-                      href="https://wiki.thunderstore.io/mods/creating-a-package"
-                      csVariant="primary"
-                    >
-                      Package Format Docs
-                    </NewLink>
-                  </li>
-                  <li>
-                    <NewLink
-                      primitiveType="cyberstormLink"
-                      linkId="ManifestValidator"
-                      csVariant="primary"
-                    >
-                      Manifest Validator
-                    </NewLink>
-                  </li>
-                  <li>
-                    <NewLink
-                      primitiveType="cyberstormLink"
-                      linkId="MarkdownPreview"
-                      csVariant="primary"
-                    >
-                      Markdown Preview
-                    </NewLink>
-                  </li>
-                  <li>
-                    <NewLink
-                      primitiveType="link"
-                      href="https://github.com/thunderstore-io"
-                      csVariant="primary"
-                    >
-                      GitHub
-                    </NewLink>
-                  </li>
-                </ul>
-              </nav>
-            </div>
-          </Island>
-        </IslandContainer>
-
-        <Island rootClasses="footer__section manager-ad">
-          <div className="footer-item manager-ad__wrapper">
-            <Heading mode="display" csLevel="2" csSize="3">
-              Thunderstore Mod Manager
-            </Heading>
-            <p className="manager-ad__description">
-              Download Thunderstore Mod Manager for Windows to easily install,
-              update, and manage your mods.{" "}
-              <NewIcon csMode="inline" noWrapper>
-                <FontAwesomeIcon icon={faBoltLightning} />
-              </NewIcon>
-            </p>
-            <NewButton
-              primitiveType="link"
-              href="https://get.thunderstore.io/"
-              csSize="big"
-              csVariant="accent"
-              rootClasses="manager-ad__get-manager-button"
-            >
-              Get Manager
-              <NewIcon csMode="inline" noWrapper>
-                <FontAwesomeIcon icon={faArrowUpRight} />
-              </NewIcon>
-            </NewButton>
-            <div className="manager-ad__image-wrapper">
-              <img
-                alt="Screenshot of the Thunderstore Mod Manager"
-                width="640"
-                height="321"
-                src={AD_IMAGE_SRC}
-                className="manager-ad__image"
-              />
-            </div>
-          </div>
-        </Island>
-      </IslandContainer>
-
-      <Island rootClasses="footnote">
-        <div className="footnote__inner">
-          <div className="footnote__links">
-            <NewLink
-              primitiveType="link"
-              href="https://pages.thunderstore.io/p/contact-us"
-            >
-              Contact Us
-            </NewLink>
-            <NewLink
-              primitiveType="link"
-              href="https://pages.thunderstore.io/p/privacy-policy"
-            >
-              Privacy Policy
-            </NewLink>
-            <NewLink primitiveType="link" href="https://blog.thunderstore.io/">
-              News
-            </NewLink>
-          </div>
-          <p className="footer__copyright">
-            © 2026 Thunderstore and contributors.{" "}
-            <span>
-              This page is{" "}
-              <NewLink
-                primitiveType="link"
-                href="https://github.com/thunderstore-io/thunderstore-ui/"
-                aria-label="This page is open source, link to Thunderstore UIs Github page"
-                csVariant="primary"
-              >
-                open-source ❤
-              </NewLink>
-            </span>
-          </p>
+    <IslandContainer as="footer" rootClasses="footer">
+      <Island rootClasses="footer__section footer__section--manager">
+        <div className="footer__inner">
+          <FooterManagerAd />
+        </div>
+      </Island>
+      <Island rootClasses="footer__section footer__section--links">
+        <div className="footer__inner">
+          <FooterLinks domain={domain} />
+        </div>
+      </Island>
+      <Island rootClasses="footer__section footer__section--socials">
+        <div className="footer__inner">
+          <FooterSocials />
+        </div>
+      </Island>
+      <Island rootClasses="footer__section footer__section--copyright">
+        <div className="footer__inner">
+          <FooterCopyright />
         </div>
       </Island>
     </IslandContainer>

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterCopyright.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterCopyright.css
@@ -1,0 +1,22 @@
+@layer nimbus-components {
+  .footer-copyright {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    align-items: center;
+    width: 100%;
+    font-size: 0.75rem;
+    text-align: center;
+
+    @container footer (width >= 60rem) {
+      flex-direction: row;
+      justify-content: space-between;
+      text-align: start;
+    }
+  }
+
+  .footer-copyright__links {
+    display: flex;
+    gap: 2rem;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterCopyright.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterCopyright.tsx
@@ -1,0 +1,49 @@
+import { NewLink } from "@thunderstore/cyberstorm";
+
+import "./FooterCopyright.css";
+
+export function FooterCopyright() {
+  return (
+    <div className="footer-copyright">
+      <nav className="footer-copyright__links">
+        <NewLink
+          primitiveType="link"
+          rootClasses="footer-link"
+          href="https://pages.thunderstore.io/p/contact-us"
+        >
+          Contact Us
+        </NewLink>
+        <NewLink
+          primitiveType="link"
+          rootClasses="footer-link"
+          href="https://pages.thunderstore.io/p/privacy-policy"
+        >
+          Privacy Policy
+        </NewLink>
+        <NewLink
+          primitiveType="link"
+          rootClasses="footer-link"
+          href="https://blog.thunderstore.io/"
+        >
+          News
+        </NewLink>
+      </nav>
+      <div className="footer-copyright__footnote">
+        © 2026 Thunderstore and contributors.{" "}
+        <span>
+          This page is{" "}
+          <NewLink
+            primitiveType="link"
+            href="https://github.com/thunderstore-io/thunderstore-ui/"
+            aria-label="This page is open source, link to Thunderstore UIs Github page"
+            rootClasses="footer-link footer-link--secondary"
+          >
+            open-source ❤
+          </NewLink>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+FooterCopyright.displayName = "FooterCopyright";

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterLinks.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterLinks.css
@@ -1,0 +1,33 @@
+@layer nimbus-components {
+  .footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+
+    @container footer (width >= 60rem) {
+      flex: 1;
+    }
+  }
+
+  .footer-links__section {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    gap: 1.5rem;
+
+    min-width: 20ch;
+
+    @container footer (width >= 60rem) {
+      flex: 1;
+    }
+  }
+
+  .footer-links__list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterLinks.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterLinks.tsx
@@ -1,0 +1,80 @@
+import { Heading, NewLink } from "@thunderstore/cyberstorm";
+
+import "./FooterLinks.css";
+
+export function FooterLinks({ domain }: { domain: string }) {
+  return (
+    <nav className="footer-links">
+      <div className="footer-links__section">
+        <Heading csVariant="primary" mode="heading" csLevel="2" csSize="4">
+          Thunderstore
+        </Heading>
+        <ul className="footer-links__list">
+          <li>
+            <NewLink
+              primitiveType="cyberstormLink"
+              linkId="Communities"
+              rootClasses="footer-link"
+            >
+              Communities
+            </NewLink>
+          </li>
+        </ul>
+      </div>
+      <div className="footer-links__section" aria-label="Developer links">
+        <Heading csVariant="primary" mode="heading" csLevel="2" csSize="4">
+          Developers
+        </Heading>
+        <ul className="footer-links__list">
+          <li>
+            <NewLink
+              primitiveType="link"
+              href={`${domain}/api/docs/`}
+              rootClasses="footer-link"
+            >
+              API Documentation
+            </NewLink>
+          </li>
+          <li>
+            <NewLink
+              primitiveType="link"
+              href="https://wiki.thunderstore.io/mods/creating-a-package"
+              rootClasses="footer-link"
+            >
+              Package Format Docs
+            </NewLink>
+          </li>
+          <li>
+            <NewLink
+              primitiveType="cyberstormLink"
+              linkId="ManifestValidator"
+              rootClasses="footer-link"
+            >
+              Manifest Validator
+            </NewLink>
+          </li>
+          <li>
+            <NewLink
+              primitiveType="cyberstormLink"
+              linkId="MarkdownPreview"
+              rootClasses="footer-link"
+            >
+              Markdown Preview
+            </NewLink>
+          </li>
+          <li>
+            <NewLink
+              primitiveType="link"
+              href="https://github.com/thunderstore-io"
+              rootClasses="footer-link"
+            >
+              GitHub
+            </NewLink>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+}
+
+FooterLinks.displayName = "FooterLinks";

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterManagerAd.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterManagerAd.css
@@ -1,0 +1,29 @@
+@layer nimbus-components {
+  .footer-manager {
+    display: flex;
+    flex-direction: column;
+    gap: 4rem;
+    justify-content: end;
+    width: 100%;
+  }
+
+  .footer-manager__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-md);
+    align-items: start;
+  }
+
+  .footer-manager__desc {
+    margin-block-end: 1rem;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-body-xl);
+  }
+
+  .footer-manager__media {
+    width: 40rem;
+    max-height: 16rem;
+    aspect-ratio: 2 / 1;
+    filter: drop-shadow(-36px -36px 40px rgb(0 0 0 / 0.35));
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterManagerAd.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterManagerAd.tsx
@@ -1,0 +1,49 @@
+import { faBoltLightning } from "@fortawesome/free-solid-svg-icons";
+import { faArrowUpRight } from "@fortawesome/pro-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { Heading, NewButton, NewIcon } from "@thunderstore/cyberstorm";
+
+import "./FooterManagerAd.css";
+
+const AD_IMAGE_SRC = "/cyberstorm-static/images/tsmm_screenshot.webp";
+
+export function FooterManagerAd() {
+  return (
+    <div className="footer-manager">
+      <div className="footer-manager__body">
+        <Heading mode="display" csLevel="2" csSize="3">
+          Thunderstore Mod Manager
+        </Heading>
+        <p className="footer-manager__desc">
+          Download Thunderstore Mod Manager for Windows to easily install,
+          update, and manage your mods.{" "}
+          <NewIcon csMode="inline" noWrapper>
+            <FontAwesomeIcon icon={faBoltLightning} />
+          </NewIcon>
+        </p>
+        <NewButton
+          primitiveType="link"
+          href="https://get.thunderstore.io/"
+          csSize="big"
+          csVariant="accent"
+        >
+          Get Manager
+          <NewIcon csMode="inline" noWrapper>
+            <FontAwesomeIcon icon={faArrowUpRight} />
+          </NewIcon>
+        </NewButton>
+      </div>
+      <div className="footer-manager__media">
+        <img
+          alt="Screenshot of the Thunderstore Mod Manager"
+          width="640"
+          height="321"
+          src={AD_IMAGE_SRC}
+        />
+      </div>
+    </div>
+  );
+}
+
+FooterManagerAd.displayName = "FooterManagerAd";

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterSocials.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterSocials.css
@@ -1,0 +1,21 @@
+@layer nimbus-components {
+  .footer-socials {
+    --logo-height: 2rem;
+
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    align-items: center;
+    width: 100%;
+
+    @container footer (width >= 60rem) {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+  }
+
+  .footer-socials__links {
+    display: flex;
+    gap: 2rem;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/Footer/FooterSocials.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Footer/FooterSocials.tsx
@@ -1,0 +1,52 @@
+import { faDiscord, faGithub } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import {
+  NewIcon,
+  NewLink,
+  ThunderstoreLogoHorizontal,
+} from "@thunderstore/cyberstorm";
+
+import "./FooterSocials.css";
+
+const DISCORD_URL = "https://discord.thunderstore.io/";
+const GITHUB_URL = "https://github.com/thunderstore-io";
+
+export function FooterSocials() {
+  return (
+    <div className="footer-socials">
+      <NewIcon noWrapper csHeight="2rem" csWidth="auto">
+        <ThunderstoreLogoHorizontal />
+      </NewIcon>
+
+      <div className="footer-socials__links">
+        <NewLink
+          primitiveType="link"
+          tooltipText="Join our Discord"
+          href={DISCORD_URL}
+          rootClasses="footer-link"
+          csVariant="primary"
+          aria-label="Invite link to Thunderstores Discord server"
+        >
+          <NewIcon noWrapper csWidth="2rem" csHeight="2rem">
+            <FontAwesomeIcon icon={faDiscord} />
+          </NewIcon>
+        </NewLink>
+        <NewLink
+          primitiveType="link"
+          tooltipText="Check out our GitHub"
+          href={GITHUB_URL}
+          rootClasses="footer-link"
+          aria-label="Link to Thunderstores Github"
+          csVariant="primary"
+        >
+          <NewIcon noWrapper csWidth="2rem" csHeight="2rem">
+            <FontAwesomeIcon icon={faGithub} />
+          </NewIcon>
+        </NewLink>
+      </div>
+    </div>
+  );
+}
+
+FooterSocials.displayName = "FooterSocials";

--- a/apps/cyberstorm-remix/app/commonComponents/Island/Island.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Island/Island.css
@@ -1,6 +1,6 @@
 @layer nimbus-layout {
   .island-container {
-    gap: var(--gap-2xs);
+    gap: var(--island-gap);
     container-type: inline-size;
   }
 

--- a/apps/cyberstorm-remix/app/commonComponents/index.css
+++ b/apps/cyberstorm-remix/app/commonComponents/index.css
@@ -5,7 +5,6 @@
 @import "./CollapsibleText/CollapsibleText.css";
 @import "./Connection/Connection.css";
 @import "./ErrorBoundary/RouteErrorBoundary.css";
-@import "./Footer/Footer.css";
 @import "./FormSection/FormSection.css";
 @import "./ListingDependency/ListingDependency.css";
 @import "./Loading/Loading.css";

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -333,7 +333,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     tabIndex={-1}
                     rootClasses="layout__main flex--grow-1"
                   >
-                    <Container size="narrow">
+                    <Container size="default">
                       <Breadcrumbs />
                       {children}
                     </Container>

--- a/packages/cyberstorm-theme/src/styles/globals.css
+++ b/packages/cyberstorm-theme/src/styles/globals.css
@@ -63,5 +63,10 @@
     --animation-duration-sm: 120ms;
     --animation-duration-md: 150ms;
     --animation-duration-lg: 300ms;
+
+    /* Shared variables for layout */
+    --container-padding: clamp(1rem, 3.75vw, 4rem);
+    --container-width: 90rem;
+    --island-gap: 0.25rem;
   }
 }

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
@@ -74,7 +74,6 @@
   .card-package__info {
     display: flex;
     flex-direction: column;
-
     gap: var(--card-package--info-gap);
     align-items: flex-start;
     align-self: var(--card-package--info-align-self);
@@ -86,7 +85,6 @@
   /* Title */
   .card-package__title {
     width: 100%;
-
     overflow: hidden;
     color: var(--card-package--title-color);
     font-weight: var(--font-weight-bold);
@@ -143,7 +141,6 @@
     display: flex;
     flex: 0 1 auto;
     flex-wrap: wrap;
-
     gap: var(--card-package--tags-gap);
     place-content: var(--card-package--tags-align-content)
       var(--card-package--tags-justify-content);

--- a/packages/cyberstorm/src/newComponents/Container/Container.css
+++ b/packages/cyberstorm/src/newComponents/Container/Container.css
@@ -2,16 +2,17 @@
   .container {
     container-type: inline-size;
     flex: 0 1 auto;
-    width: min(100%, var(--container-max-width));
+    width: min(100%, var(--container-width));
     margin-inline: auto;
-    padding: var(--space-16) var(--space-16) 4rem;
+    padding-inline: var(--container-padding);
+    padding-bottom: 4rem;
   }
 
   .container:where([data-size="wide"]) {
-    --container-max-width: 120rem;
+    --container-width: 120rem;
   }
 
-  .container:where([data-size="narrow"]) {
-    --container-max-width: 90rem;
+  .container:where([data-size="default"]) {
+    --container-width: 90rem;
   }
 }

--- a/packages/cyberstorm/src/newComponents/Container/Container.tsx
+++ b/packages/cyberstorm/src/newComponents/Container/Container.tsx
@@ -5,12 +5,17 @@ import { classnames } from "../../utils/utils";
 import "./Container.css";
 
 export interface ContainerProps extends PrimitiveComponentDefaultProps {
-  size?: "narrow" | "wide";
+  size?: "default" | "wide";
 }
 
 export const Container = React.forwardRef<HTMLDivElement, ContainerProps>(
   (props: ContainerProps, forwardedRef) => {
-    const { children, rootClasses, size = "narrow", ...forwardedProps } = props;
+    const {
+      children,
+      rootClasses,
+      size = "default",
+      ...forwardedProps
+    } = props;
 
     return (
       <div


### PR DESCRIPTION
* Rebuild the footer as a CSS grid and split the monolithic Footer.tsx into focused section components (FooterManagerAd, FooterSocials, FooterLinks, FooterCopyright), leaving Footer.tsx as a thin container.
* Introduce shared layout custom properties (--container-width, --container-padding, --island-gap) in the theme globals and adopt them across Container and Island so widths, gutters, and island gaps come from a single source of truth.
* Container: rename size "narrow" -> "default" and the --container-max-width var -> --container-width; update root.tsx usage
* Island: use --island-gap instead of --gap-2xs
* Bump pre-commit stylelint hook to 16.26.1 so its known-css-properties recognizes reading-order/reading-flow