### PR TITLE
Fix legacy-switch link hydration mismatch from trailing slash

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
@@ -110,7 +110,14 @@ function toLegacyPath(pathname: string): string {
     return "/settings/linked-accounts/";
   }
 
-  return pathname;
+  // Django canonicalises to a trailing slash (APPEND_SLASH). React Router
+  // reports pathname WITHOUT a trailing slash on the server but WITH one on the
+  // client (e.g. the `/c/:communityId/` landing), so passing it through verbatim
+  // makes the SSR and hydrated hrefs disagree — a hydration mismatch on every
+  // such page. Normalising to a trailing slash here (as every branch above
+  // already does) makes both sides deterministic and matches Django's canonical
+  // form.
+  return pathname.endsWith("/") ? pathname : `${pathname}/`;
 }
 
 // Absolute URL of the legacy Django site for the given in-app path. Built from


### PR DESCRIPTION
React Router reports the location pathname without a trailing slash on
the server but with one on the client (e.g. the /c/:communityId/
landing), so toLegacyPath's default branch emitted a different href on
each side — a hydration mismatch fired on every such page.

Normalize the path to a trailing slash, matching Django's APPEND_SLASH
canonical form as the function's other branches already do, so the SSR
and hydrated hrefs are deterministic.