### PR TITLE
Move the package rejection notice into the banner beside the notes

### DIFF
--- a/apps/cyberstorm-remix/app/p/components/PackageListing/PackageListingManagement.tsx
+++ b/apps/cyberstorm-remix/app/p/components/PackageListing/PackageListingManagement.tsx
@@ -10,7 +10,6 @@ import {
 
 import { type getPrivateListing } from "../../listingUtils";
 import { ManagementTools } from "./ManagementTools";
-import { RejectionReason } from "./ReviewInformation";
 
 type Listing = NonNullable<Awaited<ReturnType<typeof getPrivateListing>>>;
 type Permissions = Awaited<ReturnType<typeof fetchPackagePermissions>>;
@@ -35,12 +34,6 @@ export function PackageListingManagement({
 }: PackageListingManagementProps) {
   return (
     <Suspense>
-      <Await resolve={listingStatus}>
-        {(resolvedListingStatus) => (
-          <RejectionReason status={resolvedListingStatus} />
-        )}
-      </Await>
-
       <Await resolve={permissions}>
         {(resolvedPermissions) =>
           !resolvedPermissions ? null : (

--- a/apps/cyberstorm-remix/app/p/components/PackageListing/ReviewInformation.tsx
+++ b/apps/cyberstorm-remix/app/p/components/PackageListing/ReviewInformation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { classnames } from "@thunderstore/cyberstorm";
 import { type PackageListingStatus } from "@thunderstore/dapper/types";
@@ -7,22 +7,26 @@ export interface ReviewInformationProps {
   status?: PackageListingStatus;
 }
 
-// Internal notes are shown as an overlay on the community banner (see
-// packageListing.tsx + packageListing.css), so they don't take sidebar space or
-// shift the layout. Collapsed, the card is clamped to the banner's height; when
-// the note is longer it can be expanded over the content below (capped at
-// min(80vh, 40rem), scrolling past that). The "Show more"/"Show less" toggle
-// only appears when the note actually overflows the collapsed area.
-export const InternalNotes = ({ status }: ReviewInformationProps) => {
+/**
+ * A collapsible note card overlaid on the community banner (positioned by
+ * packageListing.css), used for the rejection reason and mod internal notes so
+ * neither costs sidebar space nor shifts the page. The Show more/less toggle
+ * appears only when the text overflows the collapsed height.
+ */
+function BannerNote(props: {
+  label: string;
+  text: string;
+  danger?: boolean;
+  footer?: ReactNode;
+}) {
+  const { label, text, danger, footer } = props;
   const cardRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
 
-  const notes = status?.internal_notes || "";
-
   useEffect(() => {
     const el = cardRef.current;
-    if (!el || !notes) return;
+    if (!el) return;
     const measure = () => setOverflowing(el.scrollHeight > el.clientHeight + 1);
     measure();
     // ResizeObserver may be missing in older/edge environments; skip the live
@@ -31,26 +35,23 @@ export const InternalNotes = ({ status }: ReviewInformationProps) => {
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [notes, expanded]);
-
-  if (!notes) {
-    return null;
-  }
+  }, [text, expanded]);
 
   return (
     <div
       ref={cardRef}
       className={classnames(
-        "package-listing__internal-notes",
-        expanded ? "package-listing__internal-notes--expanded" : undefined
+        "package-listing__banner-note",
+        danger ? "package-listing__banner-note--danger" : undefined,
+        expanded ? "package-listing__banner-note--expanded" : undefined
       )}
     >
-      <div className="package-listing__internal-notes-header">
-        <span className="review-package__label">Internal notes</span>
+      <div className="package-listing__banner-note-header">
+        <span className="review-package__label">{label}</span>
         {overflowing || expanded ? (
           <button
             type="button"
-            className="package-listing__internal-notes-toggle"
+            className="package-listing__banner-note-toggle"
             aria-expanded={expanded}
             onClick={() => setExpanded((value) => !value)}
           >
@@ -58,31 +59,41 @@ export const InternalNotes = ({ status }: ReviewInformationProps) => {
           </button>
         ) : null}
       </div>
-      <pre className="package-listing__internal-notes-text">{notes}</pre>
+      <pre className="package-listing__banner-note-text">{text}</pre>
+      {footer}
     </div>
   );
-};
+}
 
-export const RejectionReason = ({ status }: ReviewInformationProps) => {
-  if (!status) {
+export const InternalNotes = ({ status }: ReviewInformationProps) => {
+  const notes = status?.internal_notes || "";
+
+  if (!notes) {
     return null;
   }
 
-  const isRejected = status.review_status === "rejected";
-  const reason = status.rejection_reason || "";
+  return <BannerNote label="Internal notes" text={notes} />;
+};
+
+export const RejectionReason = ({ status }: ReviewInformationProps) => {
+  const isRejected = status?.review_status === "rejected";
+  const reason = status?.rejection_reason || "";
 
   if (!reason || !isRejected) {
     return null;
   }
 
   return (
-    <div className="review-information-card review-information-card--danger">
-      <h4 className="review-package__label">Package rejected</h4>
-      <pre className="review-information-card__text">{reason}</pre>
-      <p className="review-information-card__text">
-        If you think this is a mistake, please reach out to the moderators in{" "}
-        <a href="https://discord.thunderstore.io/">our Discord server</a>.
-      </p>
-    </div>
+    <BannerNote
+      label="Package rejected"
+      text={reason}
+      danger
+      footer={
+        <p className="package-listing__banner-note-text">
+          If you think this is a mistake, please reach out to the moderators in{" "}
+          <a href="https://discord.thunderstore.io/">our Discord server</a>.
+        </p>
+      }
+    />
   );
 };

--- a/apps/cyberstorm-remix/app/p/packageListing.css
+++ b/apps/cyberstorm-remix/app/p/packageListing.css
@@ -90,8 +90,7 @@
     display: none;
   }
 
-  .package-listing-sidebar__categories,
-  .review-information-card {
+  .package-listing-sidebar__categories {
     display: flex;
     flex-direction: column;
     gap: var(--gap-md);
@@ -100,61 +99,80 @@
     background-color: var(--color-surface-default);
   }
 
-  .review-information-card--danger {
-    background-color: var(--color-accent-red-5);
-  }
-
-  .review-information-card__text {
-    font: inherit;
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-  }
-
-  /* Banner cell is the positioning context for the internal-notes overlay. */
+  /* Banner cell is the positioning context for the banner-note overlay. */
   .package-listing__banner {
     position: relative;
   }
 
-  .package-listing__internal-notes {
+  /* The rejection reason and the mods-only internal notes render as collapsible
+     cards overlaid on the community banner (rejection first), so neither takes
+     sidebar space nor shifts the layout. */
+  .package-listing__banner-notes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-8);
+    align-items: flex-start;
+  }
+
+  .package-listing__banner-notes:empty {
+    display: none;
+  }
+
+  .package-listing__banner-note {
     display: flex;
     flex-direction: column;
     gap: var(--gap-sm);
     box-sizing: border-box;
+    width: fit-content;
+    max-width: min(28rem, 100%);
     padding: var(--space-12);
     border-radius: var(--radius-md);
     background-color: var(--color-surface-1);
   }
 
-  /* When the community has a banner, overlay the notes on it and clamp them to
-     the banner's height; when expanded they grow beyond it (over the content
-     below) without reflowing the page since the overlay is out of flow. Without
-     a banner there's nothing to overlay, so the notes stay in normal flow. */
+  .package-listing__banner-note--danger {
+    background-color: var(--color-accent-red-5);
+  }
+
+  /* The cards sit side by side, overlaid on the banner and each clamped to its
+     height; expanding one grows it over the content below without reflowing the
+     page since the overlay is out of flow. Without a banner there's nothing to
+     overlay, so the cards stay in normal flow. They never wrap here (a wrapped
+     second card would stack below the short banner and cover the package
+     header) — instead they shrink side by side until the mobile breakpoint
+     below drops them into a column. */
   .package-listing__banner:has(.community__header--compact)
-    .package-listing__internal-notes {
+    .package-listing__banner-notes {
     position: absolute;
     inset: var(--space-8) auto auto var(--space-8);
     z-index: 1;
-    width: fit-content;
-    max-width: min(32rem, calc(100% - 2 * var(--space-8)));
-    max-height: calc(100% - 2 * var(--space-8));
+    flex-wrap: nowrap;
+    max-width: calc(100% - 2 * var(--space-8));
+  }
+
+  .package-listing__banner:has(.community__header--compact)
+    .package-listing__banner-note {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-height: 5rem;
     overflow: hidden;
   }
 
   .package-listing__banner:has(.community__header--compact)
-    .package-listing__internal-notes--expanded {
+    .package-listing__banner-note--expanded {
     max-height: min(80vh, 40rem);
     overflow-y: auto;
     box-shadow: var(--shadow-lg);
   }
 
-  .package-listing__internal-notes-header {
+  .package-listing__banner-note-header {
     display: flex;
     gap: var(--gap-sm);
     align-items: center;
     justify-content: space-between;
   }
 
-  .package-listing__internal-notes-toggle {
+  .package-listing__banner-note-toggle {
     flex: none;
     padding: 0;
     border: none;
@@ -170,7 +188,7 @@
     }
   }
 
-  .package-listing__internal-notes-text {
+  .package-listing__banner-note-text {
     margin: 0;
     font: inherit;
     white-space: pre-wrap;
@@ -178,22 +196,27 @@
   }
 
   /* On single-column (mobile/tablet) layouts the banner is too short to overlay
-     the notes on — the clamped card ends up unusably small (Show more becomes
+     on — the clamped cards end up unusably small (Show more becomes
      unclickable). Drop them into normal flow below the banner instead, with a
      comfortable collapsed height. */
   @media (width <= 70rem) {
     .package-listing__banner:has(.community__header--compact)
-      .package-listing__internal-notes {
+      .package-listing__banner-notes {
       position: static;
       inset: auto;
-      width: auto;
+      flex-direction: column;
       max-width: none;
-      max-height: 6rem;
-      margin-top: var(--gap-sm);
     }
 
     .package-listing__banner:has(.community__header--compact)
-      .package-listing__internal-notes--expanded {
+      .package-listing__banner-note {
+      width: 100%;
+      max-width: none;
+      max-height: 6rem;
+    }
+
+    .package-listing__banner:has(.community__header--compact)
+      .package-listing__banner-note--expanded {
       max-height: min(80vh, 40rem);
     }
   }

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -62,7 +62,10 @@ import { DapperTs, type DapperTsInterface } from "@thunderstore/dapper-ts";
 import type { Route } from "./+types/packageListing";
 import { PackageActions } from "./components/PackageListing/PackageActions";
 import { PackageListingManagement } from "./components/PackageListing/PackageListingManagement";
-import { InternalNotes } from "./components/PackageListing/ReviewInformation";
+import {
+  InternalNotes,
+  RejectionReason,
+} from "./components/PackageListing/ReviewInformation";
 import {
   getPackageListingStatusWhenNeeded,
   getPrivateListing,
@@ -354,8 +357,9 @@ export default function PackageListing() {
       {/* Community hero banner — its own grid row (col 2), so the sidebar's
           Install lines up with the page header below it (see
           .layout__main--package-detail). Null when the community has no hero.
-          The internal notes (mods only) overlay the banner rather than taking a
-          sidebar slot, so they never shift the layout — see packageListing.css. */}
+          The rejection reason and mod-only internal notes overlay the banner
+          rather than taking a sidebar slot, so they never shift the layout —
+          see packageListing.css. */}
       <div className="package-listing__banner">
         <Suspense fallback={null}>
           <Await resolve={community}>
@@ -369,7 +373,10 @@ export default function PackageListing() {
         <Suspense fallback={null}>
           <Await resolve={listingStatus}>
             {(resolvedListingStatus) => (
-              <InternalNotes status={resolvedListingStatus} />
+              <div className="package-listing__banner-notes">
+                <RejectionReason status={resolvedListingStatus} />
+                <InternalNotes status={resolvedListingStatus} />
+              </div>
             )}
           </Await>
         </Suspense>

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.css
@@ -98,6 +98,10 @@
   }
 
   .card-package__title {
+    /* The title link is an <a> (inline by default); block makes its width:100% +
+       overflow/text-overflow ellipsis actually clip long unbreakable names in
+       grid mode. List mode's flex heading already blockifies it. */
+    display: block;
     grid-area: title;
     width: 100%;
     overflow: hidden;
@@ -153,6 +157,7 @@
     font-family: var(--font-family--inter);
     font-style: normal;
     line-height: var(--line-height-md);
+    overflow-wrap: anywhere;
   }
 
   .card-package__tags {


### PR DESCRIPTION
The rejection reason rendered in the sidebar management block, floating above the moderation tools row — an awkward spot. Show it like the mod internal notes instead: a collapsible card overlaid on the community banner, laid out side by side with the notes (rejection first). A shared BannerNote card backs both.

Side by side, each card keeps its preview and clamps to the banner height, so neither an owner's single rejection card nor a mod's rejection + notes overhang the content below. Expanding a card grows it over the content, like the notes already did. On single-column widths the cards drop into normal flow, stacked.