### PR TITLE
Bound the search and category listing query params

### DIFF
--- a/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/c/tabs/PackageSearch/PackageSearch.tsx
@@ -7,6 +7,7 @@ import { createSeo } from "cyberstorm/utils/meta";
 import {
   parseIntListParam,
   parsePageParam,
+  parseSearchParam,
 } from "cyberstorm/utils/searchParamsUtils";
 import { getSectionDefault } from "cyberstorm/utils/section";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
@@ -34,7 +35,7 @@ export const loader = ssrLoader(
       const ordering =
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
-      const search = searchParams.get("search");
+      const search = parseSearchParam(searchParams.get("search"));
       const includedCategories = parseIntListParam(
         searchParams,
         "includedCategories"
@@ -64,7 +65,7 @@ export const loader = ssrLoader(
           },
           ordering ?? "",
           parsePageParam(page),
-          search ?? "",
+          search,
           includedCategories,
           excludedCategories,
           finalSection,
@@ -108,7 +109,7 @@ export async function clientLoader({
     const ordering =
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
-    const search = searchParams.get("search");
+    const search = parseSearchParam(searchParams.get("search"));
     const includedCategories = parseIntListParam(
       searchParams,
       "includedCategories"
@@ -136,7 +137,7 @@ export async function clientLoader({
         },
         ordering ?? "",
         parsePageParam(page),
-        search ?? "",
+        search,
         includedCategories,
         excludedCategories,
         finalSection,

--- a/apps/cyberstorm-remix/app/communities/communities.tsx
+++ b/apps/cyberstorm-remix/app/communities/communities.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getSessionTools } from "cyberstorm/security/publicEnvVariables";
 import { getApiHostForSsr, getCanonicalUrl } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
+import { parseSearchParam } from "cyberstorm/utils/searchParamsUtils";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense, memo, useEffect, useRef, useState } from "react";
 import {
@@ -68,7 +69,7 @@ export const loader = ssrLoader(
     const url = new URL(request.url);
     const searchParams = url.searchParams;
     const order = searchParams.get("order") ?? SortOptions.Popular;
-    const search = searchParams.get("search");
+    const search = parseSearchParam(searchParams.get("search"));
     const page = undefined;
     const dapper = new DapperTs(() => {
       return {
@@ -81,7 +82,7 @@ export const loader = ssrLoader(
       communities: await dapper.getCommunities(
         page,
         order === null ? undefined : order,
-        search === null ? undefined : search
+        search
       ),
       seo: createSeo({
         descriptors: [
@@ -151,13 +152,13 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   });
   const searchParams = new URL(request.url).searchParams;
   const order = searchParams.get("order");
-  const search = searchParams.get("search");
+  const search = parseSearchParam(searchParams.get("search"));
   const page = undefined;
   return {
     communities: dapper.getCommunities(
       page,
       order ?? SortOptions.Popular,
-      search ?? ""
+      search
     ),
   };
 }

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -7,6 +7,7 @@ import { createSeo } from "cyberstorm/utils/meta";
 import {
   parseIntListParam,
   parsePageParam,
+  parseSearchParam,
 } from "cyberstorm/utils/searchParamsUtils";
 import { getSectionDefault } from "cyberstorm/utils/section";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
@@ -45,7 +46,7 @@ export const loader = ssrLoader(
       const ordering =
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
-      const search = searchParams.get("search");
+      const search = parseSearchParam(searchParams.get("search"));
       const includedCategories = parseIntListParam(
         searchParams,
         "includedCategories"
@@ -98,7 +99,7 @@ export const loader = ssrLoader(
           },
           ordering ?? "",
           parsePageParam(page),
-          search ?? "",
+          search,
           includedCategories,
           excludedCategories,
           finalSection,
@@ -164,7 +165,7 @@ export async function clientLoader({
     const ordering =
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
-    const search = searchParams.get("search");
+    const search = parseSearchParam(searchParams.get("search"));
     const includedCategories = parseIntListParam(
       searchParams,
       "includedCategories"
@@ -202,7 +203,7 @@ export async function clientLoader({
         },
         ordering ?? "",
         parsePageParam(page),
-        search ?? "",
+        search,
         includedCategories,
         excludedCategories,
         finalSection,

--- a/apps/cyberstorm-remix/app/p/team/Team.tsx
+++ b/apps/cyberstorm-remix/app/p/team/Team.tsx
@@ -7,6 +7,7 @@ import { createSeo } from "cyberstorm/utils/meta";
 import {
   parseIntListParam,
   parsePageParam,
+  parseSearchParam,
 } from "cyberstorm/utils/searchParamsUtils";
 import { getSectionDefault } from "cyberstorm/utils/section";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
@@ -38,7 +39,7 @@ export const loader = ssrLoader(
       const ordering =
         searchParams.get("ordering") ?? PackageOrderOptions.Updated;
       const page = searchParams.get("page");
-      const search = searchParams.get("search");
+      const search = parseSearchParam(searchParams.get("search"));
       const includedCategories = parseIntListParam(
         searchParams,
         "includedCategories"
@@ -72,7 +73,7 @@ export const loader = ssrLoader(
           },
           ordering ?? "",
           parsePageParam(page),
-          search ?? "",
+          search,
           includedCategories,
           excludedCategories,
           finalSection,
@@ -128,7 +129,7 @@ export async function clientLoader({
     const ordering =
       searchParams.get("ordering") ?? PackageOrderOptions.Updated;
     const page = searchParams.get("page");
-    const search = searchParams.get("search");
+    const search = parseSearchParam(searchParams.get("search"));
     const includedCategories = parseIntListParam(
       searchParams,
       "includedCategories"
@@ -158,7 +159,7 @@ export async function clientLoader({
         },
         ordering ?? "",
         parsePageParam(page),
-        search ?? "",
+        search,
         includedCategories,
         excludedCategories,
         finalSection,

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/searchParamsUtils.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/searchParamsUtils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parseIntListParam, parsePageParam } from "../searchParamsUtils";
+import {
+  parseIntListParam,
+  parsePageParam,
+  parseSearchParam,
+} from "../searchParamsUtils";
 
 describe("utils.searchParamsUtils.parsePageParam", () => {
   it("returns a valid 1-based page number", () => {
@@ -66,5 +70,53 @@ describe("utils.searchParamsUtils.parseIntListParam", () => {
     expect(
       parseIntListParam(params("x=99999999999999999999"), "x")
     ).toBeUndefined();
+  });
+
+  it("caps how many ids one URL can push into the API query", () => {
+    // A header-limit-sized query string otherwise packs thousands of ids into
+    // the listing API's `IN` clause, and each unique URL misses the CDN.
+    const many = Array.from({ length: 500 }, (_, i) => i + 1).join(",");
+    const capped = parseIntListParam(params(`x=${many}`), "x");
+    expect(capped).toHaveLength(100);
+    expect(capped?.[0]).toBe("1");
+
+    // The cap counts unique ids, so repeats don't burn through it.
+    const repeated = `${"7,".repeat(500)}8`;
+    expect(parseIntListParam(params(`x=${repeated}`), "x")).toEqual(["7", "8"]);
+  });
+});
+
+describe("utils.searchParamsUtils.parseSearchParam", () => {
+  // Built from char codes so the control bytes stay visible in the source.
+  const NUL = String.fromCharCode(0);
+  const LF = String.fromCharCode(10);
+  const DEL = String.fromCharCode(127);
+  const C1 = String.fromCharCode(0x9b);
+
+  it("passes ordinary search terms through", () => {
+    expect(parseSearchParam("bepinex")).toBe("bepinex");
+    expect(parseSearchParam("two words")).toBe("two words");
+    expect(parseSearchParam("dash-and_underscore")).toBe("dash-and_underscore");
+  });
+
+  it("strips control characters", () => {
+    // `?search=%00` was forwarded to the API raw and came back 400 — the bug
+    // this guards. C0, DEL and C1 are all Unicode Cc.
+    expect(parseSearchParam(`be${NUL}pinex`)).toBe("bepinex");
+    expect(parseSearchParam(`line${LF}break`)).toBe("linebreak");
+    expect(parseSearchParam(`a${DEL}b${C1}cd`)).toBe("abcd");
+  });
+
+  it("returns an empty string when absent or all control characters", () => {
+    // "" and undefined are filtered out identically when the query string is
+    // built, so an all-control-character search behaves as if never provided.
+    expect(parseSearchParam(null)).toBe("");
+    expect(parseSearchParam("")).toBe("");
+    expect(parseSearchParam("   ")).toBe("");
+    expect(parseSearchParam(NUL)).toBe("");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseSearchParam("  bepinex  ")).toBe("bepinex");
   });
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/searchParamsUtils.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/searchParamsUtils.ts
@@ -21,15 +21,22 @@ export function parsePageParam(raw: string | null): number | undefined {
   return Number.isSafeInteger(page) && page >= 1 ? page : undefined;
 }
 
+// Comfortably above the largest real community (lethal-company has 31
+// categories) while bounding what an arbitrary URL can push into the listing
+// API's `IN` clause: a header-limit-sized query string otherwise packs a few
+// thousand ids, and since each unique URL misses the CDN, every one of those
+// reaches origin.
+const MAX_LIST_PARAM_IDS = 100;
+
 /**
  * The valid positive-integer ids for a repeatable list query param (e.g.
- * includedCategories). Gathers values across EVERY occurrence of the key and
- * across comma-separated values, validates each as a positive integer, drops
- * the invalid ones, and dedupes — returning undefined when none are valid. So
- * junk like `?includedCategories=abc` is ignored instead of 500ing the listing
- * API (which filters on the integer category id), a mix like `?x=1,abc,2` keeps
- * ["1","2"], and `?x=1&x=2` combines to ["1","2"] rather than dropping the
- * second occurrence.
+ * includedCategories), capped at MAX_LIST_PARAM_IDS. Gathers values across
+ * EVERY occurrence of the key and across comma-separated values, validates each
+ * as a positive integer, drops the invalid ones, and dedupes — returning
+ * undefined when none are valid. So junk like `?includedCategories=abc` is
+ * ignored instead of 500ing the listing API (which filters on the integer
+ * category id), a mix like `?x=1,abc,2` keeps ["1","2"], and `?x=1&x=2`
+ * combines to ["1","2"] rather than dropping the second occurrence.
  */
 export function parseIntListParam(
   searchParams: URLSearchParams,
@@ -46,8 +53,25 @@ export function parseIntListParam(
       const value = Number(token);
       if (Number.isSafeInteger(value) && value >= 1) {
         ids.add(String(value));
+        // Stop as soon as the cap is filled rather than parsing the rest of
+        // the query string; anything beyond it is silently dropped, as no
+        // legitimate filter selection reaches this many.
+        if (ids.size >= MAX_LIST_PARAM_IDS) return [...ids];
       }
     }
   }
   return ids.size > 0 ? [...ids] : undefined;
+}
+
+/**
+ * A raw `search` query-param value with control characters stripped, or "" when
+ * absent. A NUL (`?search=%00`) is forwarded to the API raw and comes straight
+ * back as a 400 — bots probing for injection trigger this constantly — and no
+ * control character is meaningful in a package search, so drop the whole
+ * Unicode Cc category instead of special-casing NUL. Returns "" rather than
+ * undefined because the loaders pass this straight to the API's `search`
+ * argument, which expects a string.
+ */
+export function parseSearchParam(raw: string | null): string {
+  return (raw ?? "").replace(/\p{Cc}/gu, "").trim();
 }


### PR DESCRIPTION
Two listing query params reached the API unchecked.

A search containing a null byte (?search=%00) was forwarded as-is and came back a 400, which bots probing for injection trigger often. Control characters are never meaningful in a package search, so strip them. A search left empty by that is dropped like an absent param.

Category id lists had no upper bound, so one URL could push thousands of ids into the API query, and 800 ids returns a 520 today. Cap at 100, comfortably above the largest real community (31 categories).