### PR TITLE
Load the syntax highlighter lazily in CodeBox

### DIFF
--- a/packages/cyberstorm/src/components/CodeBox/CodeBox.tsx
+++ b/packages/cyberstorm/src/components/CodeBox/CodeBox.tsx
@@ -1,8 +1,13 @@
-import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
-import nightOwl from "react-syntax-highlighter/dist/esm/styles/hljs/night-owl";
+import {
+  type CSSProperties,
+  type ComponentType,
+  useEffect,
+  useState,
+} from "react";
 
 import { CopyButton } from "../CopyButton/CopyButton";
 import "./CodeBox.css";
+import type { CodeBoxHighlighterProps } from "./CodeBoxHighlighter";
 
 export interface CodeBoxProps {
   value?: string;
@@ -13,6 +18,16 @@ export interface CodeBoxProps {
 
 /**
  * Cyberstorm CodeBox component
+ *
+ * Renders the code immediately as plain <pre>, then swaps in the highlighted
+ * version once react-syntax-highlighter has loaded. CodeBox is re-exported from
+ * the package barrel but only actually used on the package Source tab, so a
+ * static import dragged the highlighter (~37 KiB) into the shared chunk that
+ * every route downloads. Loading it after mount keeps it out of that chunk.
+ *
+ * The fallback reuses the same inline style as the highlighter, so the box
+ * geometry is identical before and after the swap — only the token colours
+ * change, and no layout shifts.
  */
 export function CodeBox(props: CodeBoxProps) {
   const {
@@ -22,41 +37,61 @@ export function CodeBox(props: CodeBoxProps) {
     allowCopy = true,
   } = props;
 
+  const [Highlighter, setHighlighter] =
+    useState<ComponentType<CodeBoxHighlighterProps> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    import("./CodeBoxHighlighter")
+      .then((module) => {
+        // Store via updater form: React would otherwise call the component as
+        // a lazy initialiser.
+        if (!cancelled) setHighlighter(() => module.CodeBoxHighlighter);
+      })
+      .catch(() => {
+        // Chunk failed to load (offline, deploy mid-session). The plain <pre>
+        // below stays, which is still fully readable code.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const customStyle: CSSProperties = {
+    alignSelf: "stretch",
+    width: inline ? "auto" : "100%",
+    display: inline ? "inline-flex" : "block",
+    maxWidth: "100%",
+    overflowX: "auto",
+    overflowY: inline ? "auto" : "inherit",
+    padding: inline ? "var(--space-4)" : "var(--space-16)",
+    paddingRight: allowCopy && !inline ? "var(--space-48)" : undefined,
+    borderRadius: "var(--radius-md)",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: "var(--color-surface-8)",
+    whiteSpace: "pre",
+    lineHeight: inline ? "var(--line-height-xs)" : "var(--line-height-md)",
+    fontSize: inline ? "var(--font-size-body-lg)" : "var(--font-size-body-md)",
+    fontStyle: "normal",
+    fontFamily: "var(--font-family-monospace)",
+    fontWeight: "var(--font-weight-regular)",
+    backgroundColor: "var(--color-surface-1)",
+  };
+
   return (
     <div
       className={`codebox-wrapper ${inline ? "codebox-wrapper--inline" : ""}`}
     >
-      <SyntaxHighlighter
-        language={language}
-        style={nightOwl}
-        customStyle={{
-          alignSelf: "stretch",
-          width: inline ? "auto" : "100%",
-          display: inline ? "inline-flex" : "block",
-          maxWidth: "100%",
-          overflowX: "auto",
-          overflowY: inline ? "auto" : "inherit",
-          padding: inline ? "var(--space-4)" : "var(--space-16)",
-          paddingRight: allowCopy && !inline ? "var(--space-48)" : undefined,
-          borderRadius: "var(--radius-md)",
-          borderWidth: "1px",
-          borderStyle: "solid",
-          borderColor: "var(--color-surface-8)",
-          whiteSpace: "pre",
-          lineHeight: inline
-            ? "var(--line-height-xs)"
-            : "var(--line-height-md)",
-          fontSize: inline
-            ? "var(--font-size-body-lg)"
-            : "var(--font-size-body-md)",
-          fontStyle: "normal",
-          fontFamily: "var(--font-family-monospace)",
-          fontWeight: "var(--font-weight-regular)",
-          backgroundColor: "var(--color-surface-1)",
-        }}
-      >
-        {value}
-      </SyntaxHighlighter>
+      {Highlighter ? (
+        <Highlighter
+          value={value}
+          language={language}
+          customStyle={customStyle}
+        />
+      ) : (
+        <pre style={customStyle}>{value}</pre>
+      )}
       {allowCopy && !inline && value && (
         <div className="codebox-copy-button">
           <CopyButton text={value} />

--- a/packages/cyberstorm/src/components/CodeBox/CodeBoxHighlighter.tsx
+++ b/packages/cyberstorm/src/components/CodeBox/CodeBoxHighlighter.tsx
@@ -1,0 +1,31 @@
+import type { CSSProperties } from "react";
+import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
+import nightOwl from "react-syntax-highlighter/dist/esm/styles/hljs/night-owl";
+
+export interface CodeBoxHighlighterProps {
+  value: string;
+  language: string;
+  customStyle: CSSProperties;
+}
+
+/**
+ * The syntax-highlighting half of CodeBox, kept in its own module so
+ * react-syntax-highlighter (~37 KiB) is a lazy chunk instead of riding along in
+ * the shared cyberstorm bundle that every route loads. CodeBox imports this
+ * dynamically after mount; see CodeBox.tsx.
+ */
+export function CodeBoxHighlighter(props: CodeBoxHighlighterProps) {
+  const { value, language, customStyle } = props;
+
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={nightOwl}
+      customStyle={customStyle}
+    >
+      {value}
+    </SyntaxHighlighter>
+  );
+}
+
+CodeBoxHighlighter.displayName = "CodeBoxHighlighter";


### PR DESCRIPTION
CodeBox is re-exported from the package barrel, so its static import of
react-syntax-highlighter landed in the shared cyberstorm chunk that every
route downloads. The component is only used on the package Source tab.

Splitting the highlighter into its own module and importing it after
mount drops the shared chunk from 342 KiB to 296 KiB raw (~103 KiB to
93 KiB gzipped); the highlighter becomes a 15 KiB gzipped chunk that only
the Source tab pays for.

Until it loads, the code renders as plain <pre> using the same inline
style, so the box geometry is identical and only the token colours
change. That also means SSR emits real code text rather than nothing.