### PR TITLE
Inject the ad script during idle instead of on load

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Ads/__tests__/scheduleWhenIdle.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/__tests__/scheduleWhenIdle.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { IDLE_FALLBACK_DELAY_MS, scheduleWhenIdle } from "../scheduleWhenIdle";
+
+// These run in a real browser, so requestIdleCallback exists; the Safari path is
+// covered by deleting it for the duration of a test. The DOM lib declares both
+// as required, and `delete` rejects a non-optional property — so Omit them off
+// Window before re-adding them as optional.
+type IdleWindow = Omit<Window, "requestIdleCallback" | "cancelIdleCallback"> & {
+  requestIdleCallback?: typeof window.requestIdleCallback;
+  cancelIdleCallback?: typeof window.cancelIdleCallback;
+};
+
+const idleWindow = window as unknown as IdleWindow;
+const realRequestIdleCallback = idleWindow.requestIdleCallback;
+const realCancelIdleCallback = idleWindow.cancelIdleCallback;
+
+const removeRequestIdleCallback = () => {
+  delete idleWindow.requestIdleCallback;
+};
+
+afterEach(() => {
+  idleWindow.requestIdleCallback = realRequestIdleCallback;
+  idleWindow.cancelIdleCallback = realCancelIdleCallback;
+  vi.useRealTimers();
+});
+
+describe("scheduleWhenIdle", () => {
+  test("does not run the callback synchronously", () => {
+    // The whole point: ad work must never land inside the caller's task.
+    const callback = vi.fn();
+    const cancel = scheduleWhenIdle(callback, 2000);
+
+    expect(callback).not.toHaveBeenCalled();
+    cancel();
+  });
+
+  test("runs the callback on idle", async () => {
+    const callback = vi.fn();
+    scheduleWhenIdle(callback, 2000);
+
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+  });
+
+  test("passes the timeout through to requestIdleCallback", () => {
+    const requestIdleCallback = vi.fn(() => 1);
+    idleWindow.requestIdleCallback =
+      requestIdleCallback as unknown as typeof window.requestIdleCallback;
+    idleWindow.cancelIdleCallback = vi.fn();
+
+    scheduleWhenIdle(() => undefined, 2000);
+
+    // A busy page must still load ads within a bounded window, so the timeout
+    // has to reach the browser rather than being dropped.
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 2000,
+    });
+  });
+
+  test("cancelling before idle prevents the callback", async () => {
+    // AdsInit cancels on unmount and on React StrictMode's double-invoke; if
+    // this leaked, the ad script would be injected twice.
+    const callback = vi.fn();
+    const cancel = scheduleWhenIdle(callback, 2000);
+    cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  describe("without requestIdleCallback (Safari)", () => {
+    test("falls back to a short timer", () => {
+      vi.useFakeTimers();
+      removeRequestIdleCallback();
+      const callback = vi.fn();
+
+      scheduleWhenIdle(callback, 2000);
+      expect(callback).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(IDLE_FALLBACK_DELAY_MS);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test("cancelling clears the fallback timer", () => {
+      vi.useFakeTimers();
+      removeRequestIdleCallback();
+      const callback = vi.fn();
+
+      scheduleWhenIdle(callback, 2000)();
+
+      vi.advanceTimersByTime(IDLE_FALLBACK_DELAY_MS * 10);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    test("the fallback is short, not a deferral", () => {
+      // Yielding the current task is the goal; a multi-second hold would push
+      // the first impression out of short visits and shift every slot refresh.
+      expect(IDLE_FALLBACK_DELAY_MS).toBeLessThanOrEqual(500);
+    });
+
+    test("never runs later than the requested timeout", () => {
+      // The contract promises the callback by `timeout`; a caller asking for a
+      // bound tighter than the fallback delay must not get a later callback
+      // here than it would where requestIdleCallback exists.
+      vi.useFakeTimers();
+      removeRequestIdleCallback();
+      const callback = vi.fn();
+
+      scheduleWhenIdle(callback, 50);
+
+      vi.advanceTimersByTime(50);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test("treats a zero or negative timeout as immediate", () => {
+      vi.useFakeTimers();
+      removeRequestIdleCallback();
+      const callback = vi.fn();
+
+      scheduleWhenIdle(callback, -1);
+
+      expect(callback).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(0);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/cyberstorm-remix/app/commonComponents/Ads/scheduleWhenIdle.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Ads/scheduleWhenIdle.ts
@@ -1,0 +1,36 @@
+/**
+ * Runs `callback` on the next main-thread idle period, or at `timeout` at the
+ * latest, and returns a cancel function.
+ *
+ * Ad work (injecting ads-785.js, creating the slots) pulls in the whole auction
+ * stack — GPT, prebid, Confiant, Amazon, btloader — which measured ~1.7s of
+ * script execution. Starting it the instant `load` fires lands all of that on
+ * top of hydration. Idle-gating lets it slot into a gap instead, and the
+ * timeout bounds how long a permanently busy page may hold up the first
+ * impressions.
+ *
+ * Safari has no requestIdleCallback; there we fall back to a short timer, which
+ * is not idle-aware but still yields to the current task. That timer is capped
+ * by `timeout` so the "at `timeout` at the latest" half of the contract holds
+ * on both paths — otherwise a caller asking for a bound tighter than the
+ * fallback delay would quietly get a later callback in Safari than elsewhere.
+ */
+export const IDLE_FALLBACK_DELAY_MS = 200;
+
+export function scheduleWhenIdle(
+  callback: () => void,
+  timeout: number
+): () => void {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  if (typeof window.requestIdleCallback === "function") {
+    const handle = window.requestIdleCallback(callback, { timeout });
+    return () => window.cancelIdleCallback(handle);
+  }
+
+  const delay = Math.max(0, Math.min(IDLE_FALLBACK_DELAY_MS, timeout));
+  const handle = setTimeout(callback, delay);
+  return () => clearTimeout(handle);
+}

--- a/apps/cyberstorm-remix/app/root.tsx
+++ b/apps/cyberstorm-remix/app/root.tsx
@@ -62,6 +62,7 @@ import {
   onNavigateNimbusAds,
   teardownNimbusAds,
 } from "./commonComponents/Ads/nitroAds";
+import { scheduleWhenIdle } from "./commonComponents/Ads/scheduleWhenIdle";
 import { Footer } from "./commonComponents/Footer/Footer";
 import { Island, IslandContainer } from "./commonComponents/Island/Island";
 import { NavigationWrapper } from "./commonComponents/Navigation/NavigationWrapper";
@@ -580,6 +581,19 @@ function App() {
 export default App;
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
+// Upper bound on how long idle-waiting may delay ad work, used for both the
+// script injection and the slot creation below, so a page that never goes idle
+// still loads ads within a bounded, predictable window.
+//
+// Deliberately small, and deliberately not a fixed delay. Holding the script
+// back on a timer to push the auction past the TTI quiet window moves the lab
+// metric without reducing any work — the main thread blocks for exactly as long,
+// just later — and it costs real impressions: a short visit ends before the
+// first render, and every 30-60s slot refresh shifts by the same amount. Ad
+// revenue is the constrained resource here, so idle-gating is as far as this
+// goes: off hydration's back, still inside the visit.
+const AD_IDLE_TIMEOUT_MS = 2000;
+
 // Temporary solution for implementing ads
 // REMIX TODO: Move to dynamic html
 // Loads the NitroPay script (which shows the consent banner) whenever mounted.
@@ -638,15 +652,27 @@ function AdsInit({ createAds }: { createAds: boolean }) {
       }
     };
 
+    // Inject during main-thread idle rather than the instant `load` fires, so
+    // the auction never starts midway through hydration work. See
+    // scheduleWhenIdle for why, and AD_IDLE_TIMEOUT_MS for what this
+    // deliberately does *not* do (hold the script back on a flat timer).
+    let cancelIdle: (() => void) | undefined;
+
+    const startAdLoad = () => {
+      if (cancelled) return;
+      cancelIdle = scheduleWhenIdle(loadAds, AD_IDLE_TIMEOUT_MS);
+    };
+
     if (document.readyState === "complete") {
-      loadAds();
+      startAdLoad();
     } else {
-      window.addEventListener("load", loadAds);
+      window.addEventListener("load", startAdLoad);
     }
 
     return () => {
       cancelled = true;
-      window.removeEventListener("load", loadAds);
+      window.removeEventListener("load", startAdLoad);
+      cancelIdle?.();
       if ($script) {
         $script.onload = null;
         $script.onerror = null;
@@ -682,8 +708,7 @@ function AdsInit({ createAds }: { createAds: boolean }) {
       return;
     }
 
-    let idleHandle: number | undefined;
-    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let cancelIdle: (() => void) | undefined;
 
     // Read window.nitroAds inside the effect rather than depending on it:
     // re-running on its identity change would tear the registry down (cleanup)
@@ -704,14 +729,8 @@ function AdsInit({ createAds }: { createAds: boolean }) {
       };
 
       // Defer slot creation to main-thread idle time so the ad auctions never
-      // contend with hydration/interaction work; the timeout bounds how long
-      // a busy page may delay the first impressions. Safari has no
-      // requestIdleCallback — fall back to a short timeout there.
-      if (typeof window.requestIdleCallback === "function") {
-        idleHandle = window.requestIdleCallback(create, { timeout: 2000 });
-      } else {
-        timeoutHandle = setTimeout(create, 200);
-      }
+      // contend with hydration/interaction work.
+      cancelIdle = scheduleWhenIdle(create, AD_IDLE_TIMEOUT_MS);
     }
 
     // Cancel a still-pending creation and forget the slot refs when this
@@ -719,12 +738,7 @@ function AdsInit({ createAds }: { createAds: boolean }) {
     // consent-only route), so returning re-creates them on fresh containers.
     // Resetting the latch lets the toggled-back-on case re-create.
     return () => {
-      if (idleHandle !== undefined) {
-        window.cancelIdleCallback(idleHandle);
-      }
-      if (timeoutHandle !== undefined) {
-        clearTimeout(timeoutHandle);
-      }
+      cancelIdle?.();
       hasCreatedAds.current = false;
       teardownNimbusAds();
     };


### PR DESCRIPTION
ads-785.js pulls in the whole auction stack (GPT, prebid, Confiant,
Amazon, btloader) and measured ~1.7s of script execution. Injecting it
the instant `load` fired put all of that on top of hydration.

`load` is not late enough on its own: total blocking time is measured
until the main thread goes quiet, so the auction still ran inside that
window. Blocking the ad domains in Lighthouse took the community page
from 43 to 73 and TBT from 2625ms to 148ms, which is what this targets.

Slot creation already waited for idle; this applies the same pattern one
step earlier, to the script itself, and lifts the duplicated
requestIdleCallback/setTimeout/cleanup dance out of both call sites into
scheduleWhenIdle so the two cannot drift. The timeout bounds how long a
busy page can delay the first impressions.

Idle-gating only, deliberately: a fixed delay on top would move the lab
metric without reducing the work, while pushing the first impression out
of short visits and shifting every slot refresh by the same amount.

Ads will appear somewhat later than before, so this wants checking
against impression and viewability numbers on QA before it ships.