### PR TITLE
Load the first package card's icon eagerly at high priority

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -525,10 +525,17 @@ export function PackageSearch(props: Props) {
                 <>
                   {resolvedValue.results.length > 0 ? (
                     <div className="package-search__grid">
-                      {resolvedValue.results.map((p) => (
+                      {resolvedValue.results.map((p, index) => (
                         <CardPackage
                           key={`${p.namespace}-${p.name}`}
                           packageData={p}
+                          // The first card's icon is the LCP element on listing
+                          // pages, and every Image defaults to loading="lazy",
+                          // so the browser only discovered it after layout.
+                          // Only the first: fetchPriority is a ranking hint, so
+                          // flagging a whole row would dilute it and put
+                          // several large icons in contention on mobile.
+                          priority={index === 0}
                           isLiked={ratedPackages.includes(
                             `${p.namespace}-${p.name}`
                           )}

--- a/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
+++ b/packages/cyberstorm/src/newComponents/Card/CardPackage/CardPackage.tsx
@@ -41,6 +41,13 @@ interface Props {
   csSize?: CardPackageSizes;
   csModifiers?: CardPackageModifiers;
   rootClasses?: string;
+  /**
+   * Loads this card's icon eagerly at high priority. Set it on the cards that
+   * start above the fold: on a listing page the first one is the LCP element,
+   * and the default lazy loading means the browser only discovers it after
+   * layout. Leave false everywhere else so the rest of the grid stays lazy.
+   */
+  priority?: boolean;
 }
 
 export function CardPackage(props: Props) {
@@ -51,6 +58,7 @@ export function CardPackage(props: Props) {
     csSize = "medium",
     csModifiers,
     rootClasses,
+    priority = false,
   } = props;
 
   const [tooltipText, setTooltipText] = useState(
@@ -131,6 +139,8 @@ export function CardPackage(props: Props) {
           square
           intrinsicWidth={256}
           intrinsicHeight={256}
+          loading={priority ? "eager" : "lazy"}
+          fetchPriority={priority ? "high" : undefined}
         />
       </NewLink>
 

--- a/packages/cyberstorm/src/newComponents/Image/Image.tsx
+++ b/packages/cyberstorm/src/newComponents/Image/Image.tsx
@@ -21,6 +21,13 @@ export interface ImageProps extends Omit<FrameWindowProps, "primitiveType"> {
   /** Force 1:1 aspect ratio */
   square?: boolean;
   loading?: "eager" | "lazy";
+  /**
+   * Set "high" on the image most likely to be the LCP element (e.g. the first
+   * row of a card grid) and pair it with loading="eager". Lazy-loading defers
+   * discovery until layout, which is why a lazily-loaded LCP image is slow —
+   * Lighthouse flags it as both not-eagerly-loaded and not-priority-hinted.
+   */
+  fetchPriority?: "high" | "low" | "auto";
   csVariant?: ImageVariants;
   intrinsicWidth?: number;
   intrinsicHeight?: number;
@@ -40,6 +47,7 @@ export const Image = memo(function Image(props: ImageProps) {
     intrinsicWidth,
     intrinsicHeight,
     loading = "lazy",
+    fetchPriority,
     ...forwardedProps
   } = props;
   const fProps = forwardedProps as ImageProps;
@@ -73,6 +81,7 @@ export const Image = memo(function Image(props: ImageProps) {
           <img
             src={src}
             loading={loading}
+            fetchPriority={fetchPriority}
             alt={alt}
             className="image__src"
             width={intrinsicWidth}


### PR DESCRIPTION
The LCP element on listing pages is the first card's icon, and Image
defaults every image to loading="lazy" with no way to opt out, so the
browser only discovered it after layout. Lighthouse failed both of its
LCP checks on it: not eagerly loaded, and no priority hint.

Image gains a fetchPriority prop, CardPackage a `priority` flag, and the
listing grid sets it on index 0. Only the first card: fetchPriority is a
ranking hint, so marking a whole row would dilute it and put several
large icons in contention on mobile.

Confirmed against a local production build -- the first card renders
loading="eager" fetchPriority="high", the other 11 stay lazy. The LCP
element was verified with a PerformanceObserver rather than assumed:
community pages resolve to the card icon, package pages to a text span,
which is why the hero banners are deliberately left alone.