### PR TITLE
Cut the excess package-page padding on mobile

### DIFF
--- a/apps/cyberstorm-remix/app/styles/layout.css
+++ b/apps/cyberstorm-remix/app/styles/layout.css
@@ -247,6 +247,13 @@
         minmax(var(--container-padding), 1fr)
         minmax(0, var(--content-max))
         minmax(var(--container-padding), 1fr);
+
+      /* The base --ads grid sets a 32px column-gap to separate content from the
+         ad rail. Here the rail is gone and columns 1/3 are just empty gutters,
+         so that gap stacked on top of the gutter's own --container-padding —
+         giving the content 48px of dead space each side on mobile. Drop it: the
+         gutter is the padding. */
+      column-gap: 0;
     }
 
     .layout__main--package-detail > .breadcrumbs,


### PR DESCRIPTION
The --ads grid sets a 32px column-gap to separate content from the ad
rail. On the package layout below 70rem the rail is gone and columns 1
and 3 collapse to bare gutters, but the gap stayed — stacking on top of
each gutter's own --container-padding for 48px of dead space each side.
At 390px that left the content 294px wide. Drop the gap at that
breakpoint so the gutter alone is the padding: content is now 358px with
a 16px gutter, matching the other pages.