### PR TITLE
Keep the package tab title after hydration

### DIFF
--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -81,6 +81,44 @@ type PackageListingOutletContext = OutletContextShape & {
   packageDownloadUrl?: string;
 };
 
+type ResolvedListing = NonNullable<
+  Awaited<ReturnType<typeof getPublicListing>>
+>;
+
+// Browser-tab title + share metadata, shared by the SSR loader and the
+// clientLoader. clientLoader.hydrate reruns the client loader on load and
+// replaces the match data the <Seo> head reads; when that data omitted `seo`
+// the title collapsed to the root's bare "Thunderstore" after hydration. Every
+// field here comes off the already-awaited `listing`, so producing it on the
+// client costs no extra request — the two loaders emit identical tags and the
+// title never flips.
+function packageListingSeo(listing: ResolvedListing, request: Request) {
+  const displayName = formatToDisplayName(listing.name);
+  return createSeo({
+    descriptors: [
+      {
+        title: `${displayName} by ${listing.namespace} | ${listing.community_name} | Thunderstore`,
+      },
+      { name: "description", content: listing.description },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: getCanonicalUrl(request) },
+      {
+        property: "og:title",
+        content: `${displayName} by ${listing.namespace}`,
+      },
+      { property: "og:description", content: listing.description },
+      ...(listing.icon_url
+        ? [
+            { property: "og:image", content: listing.icon_url },
+            { property: "og:image:width", content: "256" },
+            { property: "og:image:height", content: "256" },
+          ]
+        : []),
+      { property: "og:site_name", content: "Thunderstore" },
+    ],
+  });
+}
+
 export const loader = ssrLoader(
   async ({ params, request }: Route.LoaderArgs) => {
     const { communityId, namespaceId, packageId } = params;
@@ -139,33 +177,7 @@ export const loader = ssrLoader(
       community_identifier: communityId,
       namespace_id: namespaceId,
       package_id: packageId,
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${formatToDisplayName(listing.name)} | Thunderstore - The ${
-              community.name
-            } Mod Database`,
-          },
-          { name: "description", content: listing.description },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: getCanonicalUrl(request) },
-          {
-            property: "og:title",
-            content: `${formatToDisplayName(listing.name)} by ${
-              listing.namespace
-            }`,
-          },
-          { property: "og:description", content: listing.description },
-          ...(listing.icon_url
-            ? [
-                { property: "og:image", content: listing.icon_url },
-                { property: "og:image:width", content: "256" },
-                { property: "og:image:height", content: "256" },
-              ]
-            : []),
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
+      seo: packageListingSeo(listing, request),
     };
   },
   { cache: true }
@@ -217,6 +229,10 @@ export async function clientLoader({
     community_identifier: communityId,
     namespace_id: namespaceId,
     package_id: packageId,
+    // Same title/metadata the SSR loader emits, so hydration doesn't drop it
+    // back to the root "Thunderstore" fallback. `listing` is already awaited
+    // above, so this adds no request.
+    seo: packageListingSeo(listing, request),
   };
 }
 

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -49,6 +49,41 @@ import "./packageListing.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
 
+// Browser-tab title + share metadata, shared by the SSR loader and the
+// clientLoader so the title doesn't collapse to the root "Thunderstore"
+// fallback after hydration (clientLoader.hydrate replaces the match data the
+// <Seo> head reads). Everything comes off the already-awaited `listing`.
+function packageVersionSeo(
+  listing: PackageListingDetails,
+  packageVersion: string,
+  request: Request
+) {
+  const displayName = formatToDisplayName(listing.name);
+  return createSeo({
+    descriptors: [
+      {
+        title: `${displayName} v${packageVersion} by ${listing.namespace} | ${listing.community_name} | Thunderstore`,
+      },
+      { name: "description", content: listing.description },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: getCanonicalUrl(request) },
+      {
+        property: "og:title",
+        content: `${displayName} v${packageVersion} by ${listing.namespace}`,
+      },
+      { property: "og:description", content: listing.description },
+      ...(listing.icon_url
+        ? [
+            { property: "og:image", content: listing.icon_url },
+            { property: "og:image:width", content: "256" },
+            { property: "og:image:height", content: "256" },
+          ]
+        : []),
+      { property: "og:site_name", content: "Thunderstore" },
+    ],
+  });
+}
+
 export const loader = ssrLoader(
   async ({ params, request }: Route.LoaderArgs) => {
     const { communityId, namespaceId, packageId, packageVersion } = params;
@@ -100,33 +135,7 @@ export const loader = ssrLoader(
       listing,
       packageVersion,
       team,
-      seo: createSeo({
-        descriptors: [
-          {
-            title: `${formatToDisplayName(listing.name)} v${packageVersion} | ${
-              community.name
-            } Mod Database`,
-          },
-          { name: "description", content: listing.description },
-          { property: "og:type", content: "website" },
-          { property: "og:url", content: getCanonicalUrl(request) },
-          {
-            property: "og:title",
-            content: `${formatToDisplayName(
-              listing.name
-            )} v${packageVersion} by ${listing.namespace}`,
-          },
-          { property: "og:description", content: listing.description },
-          ...(listing.icon_url
-            ? [
-                { property: "og:image", content: listing.icon_url },
-                { property: "og:image:width", content: "256" },
-                { property: "og:image:height", content: "256" },
-              ]
-            : []),
-          { property: "og:site_name", content: "Thunderstore" },
-        ],
-      }),
+      seo: packageVersionSeo(listing, packageVersion, request),
     };
   },
   { cache: true }
@@ -158,6 +167,8 @@ export async function clientLoader({
     listing,
     packageVersion,
     team: dapper.getTeamDetails(namespaceId),
+    // Match the SSR title so hydration doesn't drop it (see packageVersionSeo).
+    seo: packageVersionSeo(listing, packageVersion, request),
   };
 }
 


### PR DESCRIPTION
clientLoader.hydrate reruns the client loader on load and replaces the
match data the <Seo> head reads. The package clientLoaders returned no
`seo`, so once hydration swapped their data in, the title collapsed from
the SSR value to the root "Thunderstore" fallback.

Both loaders now build the title from the already-awaited `listing`
(name, namespace, community_name), so the client path emits the same
tags as SSR and the title no longer flips — at no extra request, since
`listing` is resolved either way. The format is also updated to the
requested "<package> by <author> | <community> | Thunderstore" (and the
versioned page's "<package> v<version> by <author> | ..."), shared
between the two loaders so they can't drift.

Community and package-search pages have the same underlying gap, but
their clientLoaders don't hold the community display name without
awaiting a deferred fetch, so they're left for a follow-up rather than
reintroducing that await.