### PR TITLE
Render <details> collapsibles in wiki markdown

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.css
@@ -5,6 +5,17 @@
     scrollbar-width: none;
   }
 
+  /* Shown when a document fails to convert (see MarkdownErrorBoundary). The
+     source is still readable, so wrap it rather than letting long lines force
+     the page wide. */
+  .markdown__fallback {
+    margin: 0;
+    color: var(--color-text-primary);
+    font-family: var(--font-family-monospace);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
   .markdown {
     display: block;
     color: var(--color-text-primary);

--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/Markdown.tsx
@@ -1,6 +1,8 @@
 import { MarkdownHooks } from "react-markdown";
+import raw from "rehype-raw";
 import gfm from "remark-gfm";
 
+import { MarkdownErrorBoundary } from "./MarkdownErrorBoundary";
 import { nimbusSanitize } from "./Sanitize";
 
 interface MarkdownProps {
@@ -11,16 +13,14 @@ interface MarkdownProps {
 
 export function Markdown(props: MarkdownProps) {
   const { input, dangerous, placeholder } = props;
+  const source = input && input !== "" ? input : placeholder ? placeholder : "";
 
   if (dangerous) {
     return (
       <div className="markdown-wrapper">
         <div
           className="markdown"
-          dangerouslySetInnerHTML={{
-            __html:
-              input && input !== "" ? input : placeholder ? placeholder : "",
-          }}
+          dangerouslySetInnerHTML={{ __html: source }}
         />
       </div>
     );
@@ -28,13 +28,25 @@ export function Markdown(props: MarkdownProps) {
   return (
     <div className="markdown-wrapper">
       <div className="markdown">
-        <MarkdownHooks
-          remarkPlugins={[gfm]}
-          rehypePlugins={[nimbusSanitize]}
-          fallback={"Loading markdown..."}
-        >
-          {input && input !== "" ? input : placeholder ? placeholder : ""}
-        </MarkdownHooks>
+        {/* The conversion recurses over the document, so deeply nested input
+            can overflow the stack — and this input is author-controlled. The
+            boundary degrades that to plain text instead of losing the page;
+            see MarkdownErrorBoundary. */}
+        <MarkdownErrorBoundary input={source}>
+          <MarkdownHooks
+            remarkPlugins={[gfm]}
+            // `raw` parses embedded HTML (e.g. <details>/<summary> collapsibles)
+            // into real nodes; without it react-markdown drops raw HTML and the
+            // collapsibles the old site rendered vanished. It MUST run before
+            // nimbusSanitize, which is a strict allowlist (details/summary/open
+            // are permitted, <script> etc. stripped) — so raw HTML is parsed then
+            // sanitized, never trusted.
+            rehypePlugins={[raw, nimbusSanitize]}
+            fallback={"Loading markdown..."}
+          >
+            {source}
+          </MarkdownHooks>
+        </MarkdownErrorBoundary>
       </div>
     </div>
   );

--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/MarkdownErrorBoundary.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/MarkdownErrorBoundary.tsx
@@ -1,0 +1,81 @@
+import * as Sentry from "@sentry/react-router";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface MarkdownErrorBoundaryProps {
+  /**
+   * The source being rendered. Doubles as the reset key: a new document must
+   * get a fresh attempt, or one bad wiki page would leave every page visited
+   * afterwards showing the fallback for the rest of the session.
+   */
+  input: string;
+  children: ReactNode;
+}
+
+interface MarkdownErrorBoundaryState {
+  hasError: boolean;
+  seenInput: string;
+}
+
+/**
+ * Renders markdown that fails to convert as plain text instead of taking the
+ * page down with it.
+ *
+ * Markdown here is author-controlled, and the conversion walks the document
+ * recursively, so an unusually structured one can exhaust the call stack partway
+ * through. Catching the failure is more robust than enumerating the shapes that
+ * cause it — what matters is that a document which cannot be converted costs its
+ * own formatting rather than the reader's page. The text is still shown, because
+ * a page that renders as plain text is far more useful than an error.
+ *
+ * Scope: React render errors, which is where the conversion runs (MarkdownHooks
+ * processes in an effect and rethrows on the following render).
+ */
+export class MarkdownErrorBoundary extends Component<
+  MarkdownErrorBoundaryProps,
+  MarkdownErrorBoundaryState
+> {
+  static displayName = "MarkdownErrorBoundary";
+
+  state: MarkdownErrorBoundaryState = {
+    hasError: false,
+    seenInput: this.props.input,
+  };
+
+  static getDerivedStateFromError(): Partial<MarkdownErrorBoundaryState> {
+    return { hasError: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: MarkdownErrorBoundaryProps,
+    state: MarkdownErrorBoundaryState
+  ): Partial<MarkdownErrorBoundaryState> | null {
+    if (props.input === state.seenInput) return null;
+    // New document: clear the latch so it gets its own attempt.
+    return { hasError: false, seenInput: props.input };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Match the other boundaries: log in dev, report in prod.
+    if (!import.meta.env.PROD) {
+      console.error("Markdown render error", error);
+      return;
+    }
+
+    Sentry.captureException(error, {
+      // One issue for all of these rather than one per document, so a single
+      // crafted page can't flood the project.
+      fingerprint: ["markdown-render"],
+      contexts: {
+        markdownErrorBoundary: {
+          inputLength: this.props.input.length,
+          componentStack: info.componentStack,
+        },
+      },
+    });
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+    return <pre className="markdown__fallback">{this.props.input}</pre>;
+  }
+}

--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/__tests__/Markdown.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/__tests__/Markdown.test.ts
@@ -1,0 +1,151 @@
+import { waitFor } from "@testing-library/dom";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { Markdown } from "../Markdown";
+
+// Opts into React's act() support; without it every render logs "The current
+// testing environment is not configured to support act(...)".
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// Renders the real component (MarkdownHooks resolves its pipeline in an effect,
+// so we wait for the "Loading markdown..." fallback to be replaced) and returns
+// the HTML it produced. This exercises the exact plugin chain Markdown.tsx
+// wires up — rehype-raw parsing embedded HTML, then nimbusSanitize allowlisting
+// it — rather than a reconstruction of it, so the tests cannot drift from the
+// component.
+let container: HTMLDivElement | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = undefined;
+  root = undefined;
+});
+
+async function renderMarkdown(input: string): Promise<string> {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(Markdown, { input }));
+  });
+
+  const markdown = container.querySelector(".markdown");
+  await waitFor(() => {
+    expect(markdown?.textContent).not.toBe("Loading markdown...");
+  });
+  return markdown?.innerHTML ?? "";
+}
+
+describe("Markdown renders embedded HTML the old site supported", () => {
+  test("keeps <details>/<summary> collapsibles", async () => {
+    const html = await renderMarkdown(
+      "<details>\n<summary>Click me</summary>\n\nHidden body.\n\n</details>"
+    );
+
+    expect(html).toContain("<details>");
+    expect(html).toContain("<summary>Click me</summary>");
+    expect(html).toContain("Hidden body.");
+  });
+
+  test("keeps the `open` attribute on <details>", async () => {
+    const html = await renderMarkdown(
+      "<details open>\n<summary>Open</summary>\n\nBody\n\n</details>"
+    );
+
+    expect(html).toMatch(/<details open(="")?>/);
+  });
+
+  test("still parses markdown around and inside the raw HTML", async () => {
+    const html = await renderMarkdown(
+      "# Heading\n\n<details><summary>s</summary>\n\n- one\n- two\n\n</details>"
+    );
+
+    expect(html).toContain("<h1>Heading</h1>");
+    expect(html).toContain("<li>one</li>");
+  });
+});
+
+describe("Markdown sanitizes embedded HTML", () => {
+  // rehype-raw parses whatever the author wrote, so nimbusSanitize is the only
+  // thing standing between package/wiki authors and script execution. Each of
+  // these is a way that has historically bypassed a markdown sanitizer.
+  const attacks: [name: string, input: string][] = [
+    ["script tag", "<script>window.__xss = 1</script>"],
+    ["uppercase script tag", "<SCRIPT>window.__xss = 1</SCRIPT>"],
+    ["img onerror", '<img src=x onerror="window.__xss = 1">'],
+    ["svg onload", '<svg onload="window.__xss = 1"></svg>'],
+    [
+      "anchor onmouseover",
+      '<a href="https://ok.example" onmouseover="window.__xss = 1">x</a>',
+    ],
+    [
+      "details onclick",
+      '<details onclick="window.__xss = 1"><summary>s</summary>b</details>',
+    ],
+    ["javascript: href", '<a href="javascript:window.__xss = 1">click</a>'],
+    ["javascript: img src", '<img src="javascript:window.__xss = 1">'],
+    ["iframe", '<iframe src="https://evil.example"></iframe>'],
+    [
+      "iframe srcdoc",
+      '<iframe srcdoc="&lt;script&gt;window.__xss = 1&lt;/script&gt;"></iframe>',
+    ],
+    ["object and embed", '<object data="x.swf"></object><embed src="y.swf">'],
+    ["base tag", '<base href="https://evil.example/">'],
+    [
+      "meta refresh",
+      '<meta http-equiv="refresh" content="0;url=https://evil.example">',
+    ],
+    [
+      "remote stylesheet",
+      '<link rel="stylesheet" href="https://evil.example/x.css">',
+    ],
+    [
+      "template wrapping a script",
+      "<template><script>window.__xss = 1</script></template>",
+    ],
+    ["unclosed tags", "<details><summary>a</summary><script>window.__xss = 1"],
+    ["comment breakout", "<!--><script>window.__xss = 1</script>-->"],
+  ];
+
+  test.each(attacks)("strips %s", async (_name, input) => {
+    const html = await renderMarkdown(input);
+
+    expect(html).not.toMatch(/<script/i);
+    expect(html).not.toMatch(/<iframe/i);
+    expect(html).not.toMatch(/<object/i);
+    expect(html).not.toMatch(/<embed/i);
+    expect(html).not.toMatch(/<base/i);
+    expect(html).not.toMatch(/<meta/i);
+    expect(html).not.toMatch(/<link/i);
+    expect(html).not.toMatch(/<template/i);
+    expect(html).not.toMatch(/\son[a-z]+=/i);
+    expect(html).not.toMatch(/javascript:/i);
+    expect(html).not.toMatch(/srcdoc/i);
+    // Nothing above should have executed while rendering.
+    expect(
+      (window as unknown as Record<string, unknown>).__xss
+    ).toBeUndefined();
+  });
+
+  test("drops disallowed attributes but keeps the allowed ones", async () => {
+    const html = await renderMarkdown(
+      '<details data-foo="bar" class="evil" style="color:red"><summary>s</summary>b</details>'
+    );
+
+    expect(html).toContain("<details>");
+    expect(html).not.toContain("data-foo");
+    expect(html).not.toContain("evil");
+    expect(html).not.toContain("color:red");
+  });
+
+  test("keeps http(s) links intact", async () => {
+    const html = await renderMarkdown('<a href="https://ok.example">ok</a>');
+
+    expect(html).toContain('href="https://ok.example"');
+  });
+});

--- a/apps/cyberstorm-remix/app/commonComponents/Markdown/__tests__/MarkdownErrorBoundary.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Markdown/__tests__/MarkdownErrorBoundary.test.ts
@@ -1,0 +1,114 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { Markdown } from "../Markdown";
+
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = undefined;
+  root = undefined;
+});
+
+async function render(input: string, budgetMs = 20_000) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(Markdown, { input }));
+  });
+  const deadline = performance.now() + budgetMs;
+  while (
+    container.textContent === "Loading markdown..." &&
+    performance.now() < deadline
+  ) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 25));
+    });
+  }
+  return container;
+}
+
+// Two shapes the converter walks recursively. Kept as generators so the depth
+// is a knob rather than a fixture — the point is that the boundary holds for
+// documents the conversion cannot finish, not these particular numbers.
+const nestedElements = (depth: number) =>
+  "<div>".repeat(depth) + "nested element text" + "</div>".repeat(depth);
+
+const nestedBlocks = (depth: number) =>
+  ">".repeat(depth) + " nested block text";
+
+describe("Markdown survives documents the converter cannot finish", () => {
+  test.each([
+    [
+      "moderately nested elements",
+      nestedElements(2_000),
+      "nested element text",
+    ],
+    ["deeply nested elements", nestedElements(20_000), "nested element text"],
+    ["deeply nested blocks", nestedBlocks(20_000), "nested block text"],
+  ])("renders %s as text instead of failing", async (_name, input, needle) => {
+    const el = await render(input);
+
+    // The tab is alive, the page still has a markdown region, and the author's
+    // content is still legible.
+    expect(el.querySelector(".markdown")).not.toBeNull();
+    expect(el.textContent).toContain(needle);
+    expect(el.textContent).not.toBe("Loading markdown...");
+  });
+
+  test("ordinary documents are unaffected by the boundary", async () => {
+    const el = await render(
+      "# Title\n\n<details><summary>s</summary>\n\nbody\n\n</details>"
+    );
+
+    expect(el.querySelector("h1")?.textContent).toBe("Title");
+    expect(el.querySelector("details")).not.toBeNull();
+    expect(el.querySelector(".markdown__fallback")).toBeNull();
+  });
+
+  test("one unconvertible document does not affect the next", async () => {
+    // The boundary latches on error; without a reset keyed to the input, every
+    // page visited afterwards would render as plain text too.
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(createElement(Markdown, { input: nestedElements(20_000) }));
+    });
+    let deadline = performance.now() + 20_000;
+    while (
+      container.textContent === "Loading markdown..." &&
+      performance.now() < deadline
+    ) {
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 25));
+      });
+    }
+    expect(container.querySelector(".markdown__fallback")).not.toBeNull();
+
+    await act(async () => {
+      root?.render(createElement(Markdown, { input: "# Recovered" }));
+    });
+    deadline = performance.now() + 20_000;
+    while (
+      container.querySelector("h1") === null &&
+      performance.now() < deadline
+    ) {
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 25));
+      });
+    }
+
+    expect(container.querySelector("h1")?.textContent).toBe("Recovered");
+    expect(container.querySelector(".markdown__fallback")).toBeNull();
+  });
+});

--- a/apps/cyberstorm-remix/package.json
+++ b/apps/cyberstorm-remix/package.json
@@ -51,6 +51,7 @@
     "react-markdown": "10.1.0",
     "react-router": "7.17.0",
     "react-syntax-highlighter": "16.1.0",
+    "rehype-raw": "7.0.0",
     "rehype-sanitize": "6.0.0",
     "remark-gfm": "4.0.1",
     "remix-utils": "7.7.0",

--- a/apps/cyberstorm-remix/vitest.config.ts
+++ b/apps/cyberstorm-remix/vitest.config.ts
@@ -30,6 +30,12 @@ export default defineProject({
       "react-dom",
       "react-dom/client",
       "react-dom/server",
+      // react-markdown must be pre-bundled in the same pass as react, or it
+      // gets its own optimized copy, hooks resolve against a second React
+      // instance and every render throws "Cannot read properties of null".
+      "react-markdown",
+      "rehype-raw",
+      "remark-gfm",
     ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       react-syntax-highlighter:
         specifier: 16.1.0
         version: 16.1.0(react@19.2.3)
+      rehype-raw:
+        specifier: 7.0.0
+        version: 7.0.0
       rehype-sanitize:
         specifier: 6.0.0
         version: 6.0.0
@@ -4440,6 +4443,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.0:
     resolution: {integrity: sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==}
     engines: {node: '>=0.12'}
@@ -4953,14 +4960,23 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -4994,6 +5010,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -6000,6 +6019,9 @@ packages:
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -6393,6 +6415,9 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
@@ -6968,6 +6993,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -7185,6 +7211,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -7290,6 +7319,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -11235,6 +11267,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@6.0.1: {}
+
   entities@7.0.0: {}
 
   env-paths@2.2.1: {}
@@ -11934,9 +11968,36 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
 
   hast-util-sanitize@5.0.2:
     dependencies:
@@ -11963,6 +12024,16 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -11993,6 +12064,8 @@ snapshots:
   html-tags@3.3.1: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -13242,6 +13315,10 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -13633,6 +13710,12 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
 
   rehype-sanitize@6.0.0:
     dependencies:
@@ -14557,6 +14640,11 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -14687,6 +14775,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
The wiki renders raw markdown through react-markdown, which drops
embedded HTML unless rehype-raw is in the chain — so the <details>/
<summary> collapsibles the old site showed vanished. Add rehype-raw
before nimbusSanitize: raw parses the HTML into real nodes, then the
existing strict allowlist (which already permits details/summary/open
and strips <script>) cleans them, so raw HTML is parsed then sanitized,
never trusted.

rehype-raw parses whatever a wiki author wrote, which makes the sanitiser
the only thing between them and script execution — so cover it. The new
tests render the real component (not a reconstruction of its plugin
chain, which could drift from it) against 17 vectors: script tags, event
handlers, javascript: URLs, iframe srcdoc, svg onload, object/embed,
base/meta/link, template>script, unclosed tags and comment breakout. All
are neutralised; inverting the plugin order fails four of them.

Conversion also walks the document recursively, so an unusually
structured one can exhaust the call stack partway through and cost the
reader the page rather than just its formatting. MarkdownErrorBoundary
catches that and renders the source as plain text instead — more robust
than enumerating the shapes that cause it, since what matters is the
failure rather than its cause. It resets per document, so one that
cannot be converted doesn't affect the next.

react-markdown has to join optimizeDeps.include or Vite pre-bundles it
with a second copy of React and every render throws on a null dispatcher.