### PR TITLE
Sort, cap, and filter the nav teams dropdown

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.css
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.css
@@ -141,6 +141,69 @@
     min-width: 14rem;
   }
 
+  /* Teams submenu: cap the height so a user in many teams gets a scrollable
+     list instead of one that runs off the bottom of the screen. The filter box
+     and "All Teams" link stay pinned; only the team list scrolls. */
+  .navigation-header__teams-dropdown {
+    min-width: 14rem;
+    max-height: min(
+      24rem,
+      var(--radix-dropdown-menu-content-available-height, 24rem)
+    );
+  }
+
+  /* The cap above turns every child into a shrinkable flex item, so once the
+     teams overflowed it, flexbox squeezed the filter box and "All Teams" too —
+     and .dropdown's overflow:hidden clipped rather than revealed the result,
+     leaving a half-height search field tucked under "All Teams". The list is
+     the only child that should absorb the cap; pin the rest. */
+  .navigation-header__teams-dropdown > *:not(.navigation-header__teams-list) {
+    flex-shrink: 0;
+  }
+
+  /* The item styling `.dropdown > *` would have applied, re-aimed one level
+     down: this scroller is what that selector matches now, so the item padding
+     and background would otherwise land on the whole list rather than the links
+     inside it. The custom properties still inherit from the scroller, so only
+     the declarations consuming them need repeating — except the highlight
+     switch, which the dropdown also scopes to its direct children and so has to
+     be redeclared for the nested items. */
+  .navigation-header__teams-dropdown > .navigation-header__teams-list > * {
+    padding: var(--dropdown-item-padding);
+    overflow: hidden;
+    background-color: var(--dropdown-item-background-color);
+    outline: none;
+
+    --icon-color: var(--dropdown-item-icon-color);
+  }
+
+  .navigation-header__teams-dropdown
+    > .navigation-header__teams-list
+    > *[data-highlighted] {
+    --dropdown-item-background-color: var(--dropdown-item-bg-color--hover);
+    --dropdown-item-color: var(--dropdown-item-text-color--hover);
+    --dropdown-item-icon-color: var(--dropdown-item-icon-color--hover);
+  }
+
+  .navigation-header__teams-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--dropdown-gap);
+
+    /* min-height:0 lets this flex child shrink below its content height, so the
+       overflow (and its scrollbar) actually engages inside the capped parent.
+       padding/background are declined here because they belong to the items,
+       per the rule above. */
+    min-height: 0;
+    padding: 0;
+    overflow-y: auto;
+    background-color: transparent;
+  }
+
+  .navigation-header__teams-filter {
+    padding-bottom: var(--space-4);
+  }
+
   .navigation-header__externalLink {
     display: flex;
     align-items: center;

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
@@ -6,6 +6,7 @@ import {
   faCog,
   faGamepad,
   faLongArrowLeft,
+  faMagnifyingGlass,
   faUpload,
   faUserShield,
   faUsers,
@@ -25,7 +26,7 @@ import {
   buildAuthLoginUrl,
   buildLogoutUrl,
 } from "cyberstorm/utils/ThunderstoreAuth";
-import { type CSSProperties, useEffect } from "react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
 import { Island } from "~/commonComponents/Island/Island";
 
@@ -43,11 +44,14 @@ import {
   NewDropDownSubTrigger,
   NewIcon,
   NewLink,
+  NewTextInput,
   OverwolfLogo,
   ThunderstoreLogo,
   classnames,
 } from "@thunderstore/cyberstorm";
 import { type CurrentUser } from "@thunderstore/dapper/types";
+
+import { TEAMS_FILTER_THRESHOLD, filterTeams, sortTeams } from "./teams";
 
 const NAVIGATION_POPOVER_ID = "mobileNavMenu";
 const DEVELOPERS_POPOVER_ID = "mobileNavMenuDevelopers";
@@ -516,6 +520,86 @@ export function DesktopLoginPopover() {
   );
 }
 
+// The Teams submenu of the desktop user dropdown: alphabetised, height-capped
+// with its own scrollbar, and — past TEAMS_FILTER_THRESHOLD — a lightweight
+// client-side filter. Its own component so the filter state lives here.
+function TeamsSubmenu(props: { teams: string[]; communityId: string }) {
+  const { teams, communityId } = props;
+  const [query, setQuery] = useState("");
+
+  const sortedTeams = useMemo(() => sortTeams(teams), [teams]);
+  const showFilter = sortedTeams.length > TEAMS_FILTER_THRESHOLD;
+  const filteredTeams = useMemo(
+    () => filterTeams(sortedTeams, query),
+    [sortedTeams, query]
+  );
+
+  return (
+    <NewDropDownSub>
+      <NewDropDownSubTrigger rootClasses="dropdown__item navigation-header__dropdown-item">
+        <NewIcon csMode="inline" noWrapper csVariant="tertiary">
+          <FontAwesomeIcon icon={faUsers} />
+        </NewIcon>
+        Teams
+      </NewDropDownSubTrigger>
+      <NewDropDownSubContent rootClasses="navigation-header__teams-dropdown">
+        {showFilter ? (
+          // stopPropagation keeps Radix's menu typeahead + arrow navigation
+          // from stealing keystrokes while the user types in the filter. The
+          // wrapper is a passive event boundary, not a control — role
+          // "presentation" says so, and keeps the static-interaction rule (and
+          // the code scanner behind it) from reading it as a custom widget.
+          <div
+            role="presentation"
+            className="navigation-header__teams-filter"
+            onKeyDown={(event) => event.stopPropagation()}
+          >
+            <NewTextInput
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              clearValue={query ? () => setQuery("") : undefined}
+              placeholder="Filter teams..."
+              aria-label="Filter teams"
+              type="search"
+              csSize="small"
+              leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
+            />
+          </div>
+        ) : null}
+        <NewDropDownItem asChild>
+          <NewLink
+            primitiveType="cyberstormLink"
+            linkId="Teams"
+            rootClasses="dropdown__item navigation-header__dropdown-item"
+          >
+            <NewIcon csMode="inline" noWrapper csVariant="tertiary">
+              <FontAwesomeIcon icon={faUsers} />
+            </NewIcon>
+            All Teams
+          </NewLink>
+        </NewDropDownItem>
+        {filteredTeams.length > 0 ? <NewDropDownDivider /> : null}
+        <div className="navigation-header__teams-list">
+          {filteredTeams.map((teamName) => (
+            <NewDropDownItem key={teamName} asChild>
+              <NewLink
+                primitiveType="link"
+                href={`/c/${communityId}/p/${teamName}/`}
+                rootClasses="dropdown__item navigation-header__dropdown-item"
+              >
+                <NewIcon csMode="inline" noWrapper csVariant="tertiary">
+                  <FontAwesomeIcon icon={faUsers} />
+                </NewIcon>
+                {teamName}
+              </NewLink>
+            </NewDropDownItem>
+          ))}
+        </div>
+      </NewDropDownSubContent>
+    </NewDropDownSub>
+  );
+}
+
 export function DesktopUserDropdown(props: {
   user: CurrentUser;
   domain: string;
@@ -561,43 +645,7 @@ export function DesktopUserDropdown(props: {
         </NewLink>
       </NewDropDownItem>
       {communityId ? (
-        <NewDropDownSub>
-          <NewDropDownSubTrigger rootClasses="dropdown__item navigation-header__dropdown-item">
-            <NewIcon csMode="inline" noWrapper csVariant="tertiary">
-              <FontAwesomeIcon icon={faUsers} />
-            </NewIcon>
-            Teams
-          </NewDropDownSubTrigger>
-          <NewDropDownSubContent>
-            <NewDropDownItem asChild>
-              <NewLink
-                primitiveType="cyberstormLink"
-                linkId="Teams"
-                rootClasses="dropdown__item navigation-header__dropdown-item"
-              >
-                <NewIcon csMode="inline" noWrapper csVariant="tertiary">
-                  <FontAwesomeIcon icon={faUsers} />
-                </NewIcon>
-                All Teams
-              </NewLink>
-            </NewDropDownItem>
-            {user.teams.length > 0 ? <NewDropDownDivider /> : null}
-            {user.teams.map((teamName) => (
-              <NewDropDownItem key={teamName} asChild>
-                <NewLink
-                  primitiveType="link"
-                  href={`/c/${communityId}/p/${teamName}/`}
-                  rootClasses="dropdown__item navigation-header__dropdown-item"
-                >
-                  <NewIcon csMode="inline" noWrapper csVariant="tertiary">
-                    <FontAwesomeIcon icon={faUsers} />
-                  </NewIcon>
-                  {teamName}
-                </NewLink>
-              </NewDropDownItem>
-            ))}
-          </NewDropDownSubContent>
-        </NewDropDownSub>
+        <TeamsSubmenu teams={user.teams} communityId={communityId} />
       ) : (
         <NewDropDownItem asChild>
           <NewLink
@@ -714,7 +762,7 @@ export function MobileUserMenu(props: {
             {communityId ? "All Teams" : "Teams"}
           </NewLink>
           {communityId &&
-            user.teams.map((teamName) => (
+            sortTeams(user.teams).map((teamName) => (
               <NewLink
                 key={teamName}
                 primitiveType="link"

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/__tests__/teams.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/__tests__/teams.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import { TEAMS_FILTER_THRESHOLD, filterTeams, sortTeams } from "../teams";
+
+describe("sortTeams", () => {
+  test("sorts case-insensitively", () => {
+    // The pre-sort bug this replaced: a plain sort() puts every capitalised
+    // name ahead of every lowercase one, so "zebra" sorted before "apple".
+    expect(sortTeams(["zebra", "Apple", "mango", "Banana"])).toEqual([
+      "Apple",
+      "Banana",
+      "mango",
+      "zebra",
+    ]);
+  });
+
+  test("does not mutate the input", () => {
+    // `teams` comes straight off the loader data, which is shared.
+    const input = ["c", "a", "b"];
+    sortTeams(input);
+    expect(input).toEqual(["c", "a", "b"]);
+  });
+
+  test("handles duplicates and empty input", () => {
+    expect(sortTeams([])).toEqual([]);
+    expect(sortTeams(["a", "A", "a"])).toHaveLength(3);
+  });
+});
+
+describe("filterTeams", () => {
+  const teams = ["Alpha_Crew", "beta_squad", "Gamma_Guild", "delta"];
+
+  test("matches case-insensitively on a substring", () => {
+    expect(filterTeams(teams, "squad")).toEqual(["beta_squad"]);
+    expect(filterTeams(teams, "ALPHA")).toEqual(["Alpha_Crew"]);
+    expect(filterTeams(teams, "_")).toEqual([
+      "Alpha_Crew",
+      "beta_squad",
+      "Gamma_Guild",
+    ]);
+  });
+
+  test("returns everything for an empty or whitespace query", () => {
+    // Clearing the box has to restore the full list, not empty it.
+    expect(filterTeams(teams, "")).toEqual(teams);
+    expect(filterTeams(teams, "   ")).toEqual(teams);
+  });
+
+  test("ignores surrounding whitespace in the query", () => {
+    expect(filterTeams(teams, "  delta  ")).toEqual(["delta"]);
+  });
+
+  test("returns an empty list when nothing matches", () => {
+    expect(filterTeams(teams, "nope")).toEqual([]);
+  });
+
+  test("preserves the order it was given", () => {
+    // The submenu sorts first and filters second, so filtering must not
+    // reorder or the list would jump around as the user types.
+    expect(filterTeams(sortTeams(teams), "a")).toEqual([
+      "Alpha_Crew",
+      "beta_squad",
+      "delta",
+      "Gamma_Guild",
+    ]);
+  });
+});
+
+describe("TEAMS_FILTER_THRESHOLD", () => {
+  test("is small enough that the filter appears before the list needs scrolling", () => {
+    // The dropdown caps at 24rem (~384px) and items are ~22px, so roughly 14
+    // fit. The filter must show up before the user has to scroll blind.
+    expect(TEAMS_FILTER_THRESHOLD).toBeGreaterThan(0);
+    expect(TEAMS_FILTER_THRESHOLD).toBeLessThan(14);
+  });
+});

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/teams.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/teams.ts
@@ -1,0 +1,27 @@
+// Team-list helpers for the nav's Teams menus. Kept out of Navigation.tsx so
+// they can be unit tested without pulling in the whole navigation tree.
+
+/**
+ * Case-insensitive alphabetical sort of the current user's team names. The API
+ * returns them in an arbitrary order. Non-mutating: the caller's array (which
+ * comes straight off the loader data) is left alone.
+ */
+export function sortTeams(teams: string[]): string[] {
+  return [...teams].sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" })
+  );
+}
+
+/**
+ * Case-insensitive substring filter. An empty or whitespace-only query matches
+ * everything, so clearing the box restores the full list.
+ */
+export function filterTeams(teams: string[], query: string): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return teams;
+  return teams.filter((team) => team.toLowerCase().includes(needle));
+}
+
+// Above this many teams the desktop dropdown shows a filter box; below it the
+// list is short enough to scan.
+export const TEAMS_FILTER_THRESHOLD = 8;


### PR DESCRIPTION
The user's teams arrived in the API's arbitrary order and the desktop
submenu had no height limit, so many teams ran off the screen with no
way to scan them.

- Sort alphabetically (case-insensitive), desktop and mobile.
- Cap the desktop submenu height and give the team list its own
  scrollbar, keeping the filter box and "All Teams" pinned.
- Past 8 teams, show a lightweight client-side filter. Its wrapper stops
  keydown propagation so Radix's menu typeahead doesn't hijack the input.

Pinning is load-bearing rather than cosmetic: the height cap makes every
child a shrinkable flex item, so without it flexbox squeezed the filter
box and "All Teams" alongside the list, and .dropdown's overflow:hidden
clipped the result instead of revealing it — the search field rendered at
24px against 42px of content and sat underneath "All Teams". Only the
list should absorb the cap.

The sort and filter live in teams.ts so they can be tested without
mounting the whole navigation tree.