### PR TITLE
Render the package source without re-highlighting it client-side

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.css
+++ b/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.css
@@ -1,6 +1,63 @@
-.code-box-html {
-  position: relative;
-  align-self: stretch;
-  width: 100%;
-  overflow: auto;
+@layer nimbus-components {
+  .code-view {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gap-sm);
+    align-self: stretch;
+    width: 100%;
+    min-width: 0;
+  }
+
+  /* The scroll port. Both axes live here: rows are absolutely positioned on the
+     surface inside, which is sized to the full line count and the widest line. */
+  .code-view__scroll {
+    position: relative;
+    width: 100%;
+    padding: var(--space-8) 0;
+    border: 1px solid var(--color-surface-8);
+    border-radius: var(--radius-md);
+    overflow: auto;
+    font-size: var(--font-size-body-md);
+    font-family: var(--font-family-monospace);
+    background-color: var(--color-surface-1);
+
+    /* Rows are positioned against this box, so it must not be the containing
+       block's scroll parent for `top` to mean "offset within the file". */
+    contain: paint;
+  }
+
+  .code-view__surface {
+    position: relative;
+  }
+
+  .code-view__row {
+    position: absolute;
+    left: 0;
+    display: flex;
+    gap: var(--space-16);
+    align-items: flex-start;
+    width: 100%;
+    height: var(--code-view-line-height);
+    line-height: var(--code-view-line-height);
+  }
+
+  .code-view__gutter {
+    position: sticky;
+    left: 0;
+    flex-shrink: 0;
+
+    /* Wide enough for a six-digit line number; decompiled assemblies get long. */
+    width: 6ch;
+    padding-right: var(--space-8);
+    color: var(--color-text-tertiary);
+    text-align: right;
+    background-color: var(--color-surface-1);
+    user-select: none;
+  }
+
+  .code-view__code {
+    flex: 1;
+    font: inherit;
+    white-space: pre;
+  }
 }

--- a/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/CodeBoxHTML.tsx
@@ -1,48 +1,354 @@
-import { stripHtmlTags } from "cyberstorm/utils/HTMLParsing";
-import { memo, useMemo } from "react";
+import { decodeHtmlEntities } from "cyberstorm/utils/HTMLParsing";
+import {
+  type CSSProperties,
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
-import { CodeBox, NewAlert } from "@thunderstore/cyberstorm";
+import { NewAlert } from "@thunderstore/cyberstorm";
 
 export interface CodeBoxHTMLProps {
+  /** Pygments-highlighted HTML as returned by the source API. */
   value?: string;
   maxHeight?: number;
-  language?: string;
+  /** Names the scroll region for assistive technology, e.g. the file name. */
+  label?: string;
+}
+
+// Row height in px. Also set as a CSS custom property on the surface, so the
+// windowing maths and the laid-out height stay in step.
+const LINE_HEIGHT = 20;
+
+// Rows rendered above and below the visible range.
+const OVERSCAN = 20;
+
+// Assumed viewport height until the container is measured, and during SSR.
+const INITIAL_VISIBLE_ROWS = 60;
+
+// Lines rendered per file; beyond this the file is truncated with a notice.
+const MAX_LINES = 200_000;
+
+// The token classes Highlight.css styles. Any other class is dropped.
+const PYGMENTS_TOKEN_CLASSES = new Set([
+  "bp",
+  "c",
+  "c1",
+  "ch",
+  "cm",
+  "cp",
+  "cpf",
+  "cs",
+  "dl",
+  "err",
+  "esc",
+  "fm",
+  "g",
+  "gd",
+  "ge",
+  "ges",
+  "gh",
+  "gi",
+  "go",
+  "gp",
+  "gr",
+  "gs",
+  "gt",
+  "gu",
+  "il",
+  "k",
+  "kc",
+  "kd",
+  "kn",
+  "kp",
+  "kr",
+  "kt",
+  "l",
+  "ld",
+  "m",
+  "mb",
+  "mf",
+  "mh",
+  "mi",
+  "mo",
+  "n",
+  "na",
+  "nb",
+  "nc",
+  "nd",
+  "ne",
+  "nf",
+  "ni",
+  "nl",
+  "nn",
+  "no",
+  "nt",
+  "nv",
+  "nx",
+  "o",
+  "ow",
+  "p",
+  "pm",
+  "py",
+  "s",
+  "s1",
+  "s2",
+  "sa",
+  "sb",
+  "sc",
+  "sd",
+  "se",
+  "sh",
+  "si",
+  "sr",
+  "ss",
+  "sx",
+  "vc",
+  "vg",
+  "vi",
+  "vm",
+  "w",
+  "x",
+]);
+
+// Sticky, so both the parser and the width measurement can test a position in
+// place without slicing, and neither can drift from the other's idea of a tag.
+const SPAN_OPEN = /<span class="([a-zA-Z0-9]+)">/y;
+const SPAN_CLOSE = "</span>";
+
+/** Length of the span tag at `index`, or 0 if there isn't one. */
+function spanTagLength(line: string, index: number): number {
+  if (line.charCodeAt(index) !== 60 /* < */) return 0;
+  SPAN_OPEN.lastIndex = index;
+  const open = SPAN_OPEN.exec(line);
+  if (open) return open[0].length;
+  return line.startsWith(SPAN_CLOSE, index) ? SPAN_CLOSE.length : 0;
+}
+
+// Styled runs per line; past this the rest of the line renders as one unstyled
+// run, so the text is still complete.
+const MAX_TOKENS_PER_LINE = 2_000;
+
+export interface CodeToken {
+  text: string;
+  /** A Pygments token class, when the span carried one this component styles. */
+  className?: string;
 }
 
 /**
- * CodeBox component which renders HTML content by stripping HTML tags
- * and passing the plain text to the CodeBox component for syntax highlighting
+ * Splits one line of the API's highlighted HTML into text runs and their token
+ * classes, for the caller to render as React children.
+ *
+ * Only `<span class="token">` and `</span>` are recognised, with the class taken
+ * from the styled set above. Anything else — a stray `<`, a malformed tag, an
+ * unknown class — is kept as literal text.
+ */
+export function parseHighlightedLine(line: string): CodeToken[] {
+  const tokens: CodeToken[] = [];
+  let pending = "";
+  let className: string | undefined;
+  let index = 0;
+
+  const flush = () => {
+    if (!pending) return;
+    tokens.push(
+      className
+        ? { text: decodeHtmlEntities(pending), className }
+        : { text: decodeHtmlEntities(pending) }
+    );
+    pending = "";
+  };
+
+  let capped = false;
+
+  while (index < line.length) {
+    if (!capped && tokens.length >= MAX_TOKENS_PER_LINE) {
+      // Close the last styled run; everything remaining becomes one plain one.
+      capped = true;
+      flush();
+      className = undefined;
+    }
+    const tagLength = spanTagLength(line, index);
+    if (tagLength) {
+      if (!capped) {
+        flush();
+        // An unrecognised class, and a closing tag, both render unstyled.
+        SPAN_OPEN.lastIndex = index;
+        const open = SPAN_OPEN.exec(line);
+        className =
+          open && PYGMENTS_TOKEN_CLASSES.has(open[1]) ? open[1] : undefined;
+      }
+      index += tagLength;
+      continue;
+    }
+    pending += line[index];
+    index += 1;
+  }
+
+  flush();
+  return tokens;
+}
+
+/**
+ * Number of characters a line occupies on screen. Skips exactly the span tags
+ * the parser skips, so anything it renders as text is counted as text. Entities
+ * count as their source length, which overestimates the width slightly rather
+ * than clipping code.
+ */
+function visibleLength(line: string): number {
+  let length = 0;
+  let index = 0;
+  while (index < line.length) {
+    const tagLength = spanTagLength(line, index);
+    if (tagLength) {
+      index += tagLength;
+      continue;
+    }
+    length++;
+    index++;
+  }
+  return length;
+}
+
+/**
+ * One rendered row: its line number and the parsed line.
+ *
+ * Memoised on (row, line) so a scroll only renders the rows entering or leaving
+ * the window, rather than re-parsing every row that stayed.
+ */
+const CodeRow = memo(function CodeRow({
+  row,
+  line,
+}: {
+  row: number;
+  line: string;
+}) {
+  return (
+    <div className="code-view__row" style={{ top: row * LINE_HEIGHT }}>
+      <span className="code-view__gutter" aria-hidden="true">
+        {row + 1}
+      </span>
+      <code className="code-view__code">
+        {parseHighlightedLine(line).map((token, tokenIndex) =>
+          token.className ? (
+            <span key={tokenIndex} className={token.className}>
+              {token.text}
+            </span>
+          ) : (
+            token.text
+          )
+        )}
+      </code>
+    </div>
+  );
+});
+
+/**
+ * Viewer for the server-highlighted source on a package's Source tab.
+ *
+ * Renders the highlighting the API already did — no client-side re-highlighting
+ * — and mounts DOM only for the rows in view, so file size does not change how
+ * much is on the page.
  */
 export const CodeBoxHTML = memo(function CodeBoxHTML({
   value = "",
   maxHeight = 600,
-  language = "text",
+  label,
 }: CodeBoxHTMLProps) {
-  const result = useMemo(() => {
-    try {
-      const text = stripHtmlTags(value);
-      return { text, error: null };
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Failed to process HTML content";
-      return { text: "", error: errorMessage };
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(
+    INITIAL_VISIBLE_ROWS * LINE_HEIGHT
+  );
+
+  const { lines, widestLine, droppedLines } = useMemo(() => {
+    if (!value) {
+      return { lines: [] as string[], widestLine: 0, droppedLines: 0 };
     }
+    // Each row is parsed on its own, so a span left open by the newline split
+    // just stops applying at the end of its row.
+    const all = value.split("\n");
+    const split = all.length > MAX_LINES ? all.slice(0, MAX_LINES) : all;
+    let widest = 0;
+    for (const line of split) {
+      const length = visibleLength(line);
+      if (length > widest) widest = length;
+    }
+    return {
+      lines: split,
+      widestLine: widest,
+      droppedLines: all.length - split.length,
+    };
   }, [value]);
 
-  if (result.error) {
-    return <NewAlert csVariant="danger">{result.error}</NewAlert>;
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    setViewportHeight(element.clientHeight);
+    // ResizeObserver may be missing in older/edge environments; the measurement
+    // above still runs there, only the live updates are skipped.
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      setViewportHeight(element.clientHeight);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const firstRow = Math.max(0, Math.floor(scrollTop / LINE_HEIGHT) - OVERSCAN);
+  const lastRow = Math.min(
+    lines.length,
+    Math.ceil((scrollTop + viewportHeight) / LINE_HEIGHT) + OVERSCAN
+  );
+
+  if (!value) {
+    return <NewAlert csVariant="info">No source available.</NewAlert>;
   }
 
+  const surfaceStyle = {
+    height: lines.length * LINE_HEIGHT,
+    // `ch` is exact for a monospace face, so the horizontal scroll range stays
+    // put instead of resizing as rows scroll in and out of the window.
+    minWidth: `${widestLine}ch`,
+    "--code-view-line-height": `${LINE_HEIGHT}px`,
+  } as CSSProperties;
+
   return (
-    <div
-      className="code-box-html"
-      style={{
-        maxHeight,
-        width: "100%",
-        overflow: "auto",
-      }}
-    >
-      <CodeBox value={result.text} language={language} />
+    <div className="code-view">
+      {droppedLines > 0 && (
+        <NewAlert csVariant="warning">
+          Showing the first {MAX_LINES.toLocaleString()} lines;{" "}
+          {droppedLines.toLocaleString()} more are not displayed. Download the
+          file to read it in full.
+        </NewAlert>
+      )}
+      <div
+        ref={scrollRef}
+        className="code-view__scroll highlight"
+        style={{ maxHeight }}
+        onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+        // Nothing inside this region is focusable, so it has to take focus
+        // itself to be scrollable by keyboard in browsers that don't focus
+        // scrollers on their own. The lint rule allows tabindex only on
+        // interactive elements, which is the opposite of what a scrollable
+        // region needs.
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        role="region"
+        aria-label={label ? `Source of ${label}` : "Source code"}
+      >
+        <div className="code-view__surface" style={surfaceStyle}>
+          {lines.slice(firstRow, lastRow).map((line, index) => (
+            <CodeRow
+              key={firstRow + index}
+              row={firstRow + index}
+              line={line}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 });

--- a/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/__tests__/CodeBoxHTML.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/CodeBoxHTML/__tests__/CodeBoxHTML.test.ts
@@ -1,0 +1,328 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { CodeBoxHTML, parseHighlightedLine } from "../CodeBoxHTML";
+// The windowing is driven by the scroll port's real geometry, so the component's
+// own stylesheet has to be applied for the scrolling test to mean anything.
+import "../CodeBoxHTML.css";
+
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement | undefined;
+let root: ReturnType<typeof createRoot> | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  container = undefined;
+  root = undefined;
+  delete (window as unknown as Record<string, unknown>).__xss;
+});
+
+async function render(value: string, maxHeight = 600, label?: string) {
+  container = document.createElement("div");
+  container.style.cssText = "width:900px";
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(createElement(CodeBoxHTML, { value, maxHeight, label }));
+  });
+  return container;
+}
+
+/** A line of Pygments output, the shape the source API returns. */
+const line = (n: number) =>
+  `<span class="k">var</span><span class="w"> </span><span class="n">x${n}</span><span class="p">;</span>`;
+
+const pygmentsFile = (lineCount: number) =>
+  Array.from({ length: lineCount }, (_, i) => line(i)).join("\n");
+
+describe("CodeBoxHTML rendering", () => {
+  test("keeps the server's highlighting instead of re-deriving it", async () => {
+    const el = await render(pygmentsFile(3));
+
+    expect(el.querySelectorAll(".code-view__row")).toHaveLength(3);
+    expect(el.querySelector(".code-view__code")?.innerHTML).toBe(line(0));
+    // The `.highlight` scope is what the Pygments stylesheet keys off.
+    expect(el.querySelector(".code-view__scroll")?.classList).toContain(
+      "highlight"
+    );
+  });
+
+  test("numbers the lines from one", async () => {
+    const el = await render(pygmentsFile(5));
+    const gutters = [...el.querySelectorAll(".code-view__gutter")].map(
+      (g) => g.textContent
+    );
+
+    expect(gutters).toEqual(["1", "2", "3", "4", "5"]);
+  });
+
+  test("only mounts a window of rows for a large file", async () => {
+    // The regression this guards: a decompiled assembly mounted every line at
+    // once, and the resulting DOM kept the tab at 100% CPU.
+    const el = await render(pygmentsFile(20_000));
+
+    const rows = el.querySelectorAll(".code-view__row").length;
+    expect(rows).toBeGreaterThan(0);
+    expect(rows).toBeLessThan(200);
+    expect(el.querySelectorAll("*").length).toBeLessThan(2_000);
+  });
+
+  test("sizes the scroll surface for every line, not just the mounted ones", async () => {
+    const el = await render(pygmentsFile(1_000));
+    const surface = el.querySelector(".code-view__surface") as HTMLElement;
+
+    // 1000 lines at the 20px row height.
+    expect(surface.style.height).toBe("20000px");
+  });
+
+  test("sizes the width from the text, ignoring only the tags it strips", async () => {
+    const el = await render('<span class="k">abcd</span>');
+    const surface = el.querySelector(".code-view__surface") as HTMLElement;
+
+    expect(surface.style.minWidth).toBe("4ch");
+  });
+
+  test("counts a tag it does not recognise, because that renders as text", async () => {
+    const markup = '<div class="x">abc</div>';
+    const el = await render(markup);
+    const surface = el.querySelector(".code-view__surface") as HTMLElement;
+
+    expect(surface.style.minWidth).toBe(`${markup.length}ch`);
+  });
+
+  test("renders later lines after scrolling", async () => {
+    const el = await render(pygmentsFile(5_000));
+    const scroller = el.querySelector(".code-view__scroll") as HTMLElement;
+
+    await act(async () => {
+      scroller.scrollTop = 10_000;
+      scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    const gutters = [...el.querySelectorAll(".code-view__gutter")].map((g) =>
+      Number(g.textContent)
+    );
+    // 10000px / 20px = line 500, minus the overscan.
+    expect(Math.min(...gutters)).toBeGreaterThan(400);
+    expect(Math.min(...gutters)).toBeLessThanOrEqual(500);
+    expect(Math.max(...gutters)).toBeGreaterThan(500);
+  });
+
+  test("shows an empty state for a missing file", async () => {
+    const el = await render("");
+
+    expect(el.querySelector(".code-view__row")).toBeNull();
+    expect(el.textContent).toContain("No source available");
+  });
+
+  test("caps absurd line counts instead of building an unreachable surface", async () => {
+    // Past ~1.7M rows the surface exceeds the browser's maximum element height
+    // and the tail silently stops being scrollable. Truncate visibly instead.
+    const el = await render("\n".repeat(250_000));
+    const surface = el.querySelector(".code-view__surface") as HTMLElement;
+
+    // Compared numerically: the browser serialises large px values in
+    // exponential form ("4e+06px").
+    expect(parseFloat(surface.style.height)).toBe(200_000 * 20);
+    expect(el.textContent).toContain("Showing the first");
+    expect(el.textContent).toContain("Download the file");
+  });
+
+  test("says nothing about truncation for an ordinary file", async () => {
+    const el = await render(pygmentsFile(100));
+
+    expect(el.textContent).not.toContain("Showing the first");
+  });
+
+  test("still renders where ResizeObserver is unavailable", async () => {
+    // Only the live resize updates depend on it; losing the observer must not
+    // take the whole tab down with it.
+    const saved = globalThis.ResizeObserver;
+    // @ts-expect-error emulating an environment without the global
+    delete globalThis.ResizeObserver;
+    try {
+      const el = await render(pygmentsFile(3));
+      expect(el.querySelectorAll(".code-view__row")).toHaveLength(3);
+    } finally {
+      globalThis.ResizeObserver = saved;
+    }
+  });
+
+  test("lets the keyboard reach the scroll region", async () => {
+    const el = await render(pygmentsFile(500), 600, "Assembly.cs");
+    const scroller = el.querySelector(".code-view__scroll") as HTMLElement;
+
+    // Nothing inside the region is focusable, so it has to be focusable itself
+    // for arrow keys and PageDown to scroll it.
+    expect(scroller.getAttribute("tabindex")).toBe("0");
+    expect(scroller.getAttribute("aria-label")).toBe("Source of Assembly.cs");
+    scroller.focus();
+    expect(document.activeElement).toBe(scroller);
+  });
+
+  test("keeps the horizontal scroll range fixed while scrolling down", async () => {
+    // The surface is sized from the widest line up front. If the measurement
+    // disagreed with what a row actually renders, the horizontal scrollbar
+    // would resize as that row scrolled into the window.
+    const wide = `<div class="${"a".repeat(400)}">`;
+    const lines = Array.from({ length: 400 }, (_, i) =>
+      i === 380 ? wide : '<span class="n">x</span>'
+    );
+    const el = await render(lines.join("\n"));
+    const scroller = el.querySelector(".code-view__scroll") as HTMLElement;
+
+    const before = scroller.scrollWidth;
+    await act(async () => {
+      scroller.scrollTop = 380 * 20;
+      scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    expect(scroller.scrollWidth).toBe(before);
+  });
+});
+
+describe("parseHighlightedLine", () => {
+  test("splits the backend's spans into text and token classes", () => {
+    expect(parseHighlightedLine(line(0))).toEqual([
+      { text: "var", className: "k" },
+      { text: " ", className: "w" },
+      { text: "x0", className: "n" },
+      { text: ";", className: "p" },
+    ]);
+  });
+
+  test("decodes the entities Pygments escapes", () => {
+    // These arrive escaped and must come back as characters, because they are
+    // rendered as text rather than parsed as HTML.
+    expect(
+      parseHighlightedLine('<span class="o">&lt;&gt;&amp;&quot;&#39;</span>')
+    ).toEqual([{ text: "<>&\"'", className: "o" }]);
+  });
+
+  test("keeps text with no markup at all", () => {
+    expect(parseHighlightedLine("plain source line")).toEqual([
+      { text: "plain source line" },
+    ]);
+  });
+
+  test("drops classes outside the styled token set", () => {
+    // Package contents must not be able to borrow the site's own class names.
+    // A token-shaped but unknown class keeps its text and loses the class.
+    expect(parseHighlightedLine('<span class="kk">x</span>')).toEqual([
+      { text: "x" },
+    ]);
+    // A class that isn't even token-shaped (the site's names are hyphenated)
+    // fails to match the span grammar at all, so the tag stays literal text.
+    expect(
+      parseHighlightedLine('<span class="navigation-header">x</span>')
+    ).toEqual([{ text: '<span class="navigation-header">x' }]);
+  });
+
+  test("treats anything that is not the expected span shape as text", () => {
+    // Not a decision about safety — these simply are not the grammar, so they
+    // stay text and React escapes them on the way out.
+    const notSpans = [
+      "<script>alert(1)</script>",
+      '<img src=x onerror="alert(1)">',
+      '<span class="k" onclick="alert(1)">x</span>',
+      "<SPAN CLASS=k>x</SPAN>",
+      "<span class='k'>x</span>",
+      "a < b && c > d",
+      "<",
+    ];
+    for (const input of notSpans) {
+      const text = parseHighlightedLine(input)
+        .map((token) => token.text)
+        .join("");
+      // Every character survives as text, and no token carries a class.
+      expect(
+        parseHighlightedLine(input).every((t) => !t.className),
+        input
+      ).toBe(true);
+      expect(text.length, input).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("CodeBoxHTML cannot turn source into markup", () => {
+  // The viewer no longer decides whether input is safe to inject — every run of
+  // text goes through React as a child. These assert that property end to end.
+  const attacks = [
+    "<script>window.__xss = 1</script>",
+    '<img src=x onerror="window.__xss = 1">',
+    '<iframe src="https://evil.example"></iframe>',
+    '<span class="k" onmouseover="window.__xss = 1">hover</span>',
+    '<span class="k">ok</span>\n<script>window.__xss = 1</script>',
+    // No `>` anywhere, which an HTML parser would have discarded silently.
+    '<img src=x onerror="window.__xss = 1"',
+    // Entity-encoded so a naive decode-then-inject would resurrect the tag.
+    "&lt;script&gt;window.__xss = 1&lt;/script&gt;",
+  ];
+
+  test.each(attacks)("renders %s as visible text", async (markup) => {
+    const el = await render(markup);
+
+    expect(el.querySelector("script")).toBeNull();
+    expect(el.querySelector("img")).toBeNull();
+    expect(el.querySelector("iframe")).toBeNull();
+    expect(
+      (window as unknown as Record<string, unknown>).__xss
+    ).toBeUndefined();
+
+    // Asserted over real attributes rather than innerHTML: the payload is
+    // *shown* as text, so `onerror="..."` legitimately appears in the markup as
+    // content. What matters is that no element carries such an attribute.
+    for (const node of el.querySelectorAll("*")) {
+      for (const attribute of node.attributes) {
+        expect(
+          attribute.name.toLowerCase(),
+          node.outerHTML.slice(0, 80)
+        ).not.toMatch(/^on/);
+      }
+    }
+
+    // Only spans carrying a styled token class are ever created inside a row.
+    for (const span of el.querySelectorAll(".code-view__code span")) {
+      expect(span.attributes).toHaveLength(1);
+      expect(span.getAttribute("class")).toMatch(/^[a-z0-9]+$/);
+    }
+  });
+
+  test("still shows the source when it is not valid highlighting", async () => {
+    const el = await render('<span class="k">keep</span><script>bad</script>');
+
+    expect(el.textContent).toContain("keep");
+    expect(el.textContent).toContain("<script>bad</script>");
+  });
+});
+
+describe("one very long line cannot escape the windowing", () => {
+  // Windowing bounds mounted rows, not tokens within a row, so a single line
+  // packed with spans could otherwise put tens of thousands of nodes in the DOM
+  // on its own.
+  const packed = '<span class="k">a</span>'.repeat(50_000);
+
+  test("caps the tokens a single line can produce", () => {
+    // 50k spans in, a couple of thousand tokens out — the exact figure is the
+    // cap plus the runs that close it out, so assert the bound, not a count.
+    expect(parseHighlightedLine(packed).length).toBeLessThan(2_100);
+  });
+
+  test("keeps the whole line readable past the cap", () => {
+    const text = parseHighlightedLine(packed)
+      .map((token) => token.text)
+      .join("");
+    // Every "a" survives — the tail is folded into one unstyled run, not cut.
+    expect(text).toBe("a".repeat(50_000));
+  });
+
+  test("bounds the DOM it mounts", async () => {
+    const el = await render(packed);
+    expect(el.querySelectorAll("*").length).toBeLessThan(3_000);
+    expect(el.textContent).toContain("aaaa");
+  });
+});

--- a/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
+++ b/apps/cyberstorm-remix/app/p/tabs/Source/Source.tsx
@@ -158,9 +158,12 @@ export default function Source() {
                   className="package-source__decompilations-file"
                   key={decompilation.source_file_name}
                 >
+                  {/* The API returns Pygments-highlighted HTML, which
+                      CodeBoxHTML renders directly — no client-side
+                      re-highlighting, and only the visible rows are mounted. */}
                   <CodeBoxHTML
                     value={decompilation.result}
-                    language={"csharp"}
+                    label={decompilation.source_file_name}
                   />
                 </div>
               </div>

--- a/apps/cyberstorm-remix/cyberstorm/utils/HTMLParsing.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/HTMLParsing.ts
@@ -36,7 +36,7 @@ export function stripHtmlTags(html: string = ""): string {
  * All entities including &amp; are handled in one pass to correctly decode
  * double-encoded entities like &amp;lt;.
  */
-function decodeHtmlEntities(text: string): string {
+export function decodeHtmlEntities(text: string): string {
   return text.replace(
     /&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-z0-9]+));/gi,
     (match, dec, hex, named) => {


### PR DESCRIPTION
Opening the Source tab on a package with large decompilations pinned the
CPU at 100% and left the page unusable. BepInExPack_Inscryption is the
reported case: 12 decompilations, 5.97MB of HTML carrying 0.89MB of
actual code, 229,651 spans.

Two things were wrong.

The API already returns Pygments-highlighted HTML — and CodeBoxHTML
stripped every span back out with a regex, then re-highlighted the plain
text client-side with highlight.js. That measured ~700ms of blocking work
per file, so ~9s for that package. The .highlight stylesheet for the
server's classes was already in the bundle and already imported; it was
just unused, because the markup it styles was being thrown away.

Everything was mounted at once, so even rendering the server's HTML
directly cost 229k DOM nodes, 2.3s to parse and 5.6s of layout — and kept
costing, since every later layout and paint had to walk it. That is the
part that made the CPU stay busy rather than merely spike.

So: render the server's highlighting, and only build DOM for the rows in
view. Measured on the same payload, all 12 files now render in 145ms with
4.1k nodes on the whole page, and a scroll step costs ~0.1ms. No size
gate and no click-to-reveal — files of any size open and scroll, with
line numbers and a sticky gutter.

The decompiled code derives from uploaded packages, so the markup is not
simply trusted: it is checked against the exact grammar Pygments emits
and falls back to plain text with a visible notice if anything else
appears. A full sanitiser over several MB would cost more than the
rendering does. The permitted class is pinned to the token set
Highlight.css actually styles rather than any word — a class this
component does not style has no reason to reach the DOM, and allowing
arbitrary ones would let package contents borrow the site's own class
names to restyle text inside the viewer. All 229,651 spans in the sampled
payload use classes from that set.

Line count is capped with a visible notice: past ~1.7M rows the surface
would exceed the browser's maximum element height and the tail would
silently stop being reachable. The API truncates long results well before
that, so it is a backstop against failing quietly.