### PR TITLE
"All" section for all communities(TS-3255)

### DIFF
--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearch.tsx
@@ -2,6 +2,7 @@ import { faGhost, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { faFilterList } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { setParamsBlobValue } from "cyberstorm/utils/searchParamsUtils";
+import { ALL_SECTIONS, getSectionSelection } from "cyberstorm/utils/section";
 import { isPromise } from "cyberstorm/utils/typeChecks";
 import {
   type ReactNode,
@@ -33,6 +34,7 @@ import { DapperTs } from "@thunderstore/dapper-ts";
 import {
   type CurrentUser,
   type PackageListings,
+  type Section,
 } from "@thunderstore/dapper/types";
 import {
   type CommunityFilters,
@@ -60,6 +62,13 @@ import { PackageOrder } from "./components/PackageOrder";
 import { PackageOrderOptions } from "./components/packageOrderOptions";
 
 const PER_PAGE = 20;
+
+const ALL_SECTIONS_OPTION: Section = {
+  uuid: ALL_SECTIONS,
+  name: "All",
+  slug: ALL_SECTIONS,
+  priority: 0,
+};
 
 interface Props {
   listings: Promise<PackageListings> | PackageListings;
@@ -147,11 +156,13 @@ export function PackageSearch(props: Props) {
         (a, b) => b.priority - a.priority
       );
       setSortedSections(sections);
-      if (sections.length !== 0) {
-        setSearchParamsBlob((prev) =>
-          prev.section === "" ? { ...prev, section: sections[0].uuid } : prev
+      setSearchParamsBlob((prev) => {
+        const section = getSectionSelection(
+          prev.section === "" ? null : prev.section,
+          sections
         );
-      }
+        return section === prev.section ? prev : { ...prev, section };
+      });
       setCategories(
         [...resolved.package_categories]
           .sort((a, b) => a.slug.localeCompare(b.slug))
@@ -329,22 +340,9 @@ export function PackageSearch(props: Props) {
       {sortedSections ? (
         <CollapsibleMenu headerTitle="Sections" defaultOpen>
           <RadioGroup
-            sections={[
-              ...sortedSections,
-              {
-                uuid: "all",
-                name: "All",
-                slug: "all",
-                priority: -999999999,
-              },
-            ]}
-            selected={
-              searchParamsBlob.section === "" || sortedSections.length === 0
-                ? sortedSections.length > 0
-                  ? sortedSections[0].uuid
-                  : "all"
-                : searchParamsBlob.section
-            }
+            sections={[ALL_SECTIONS_OPTION, ...sortedSections]}
+            dividerAfterUuid={ALL_SECTIONS}
+            selected={searchParamsBlob.section}
             setSelected={setParamsBlobValue(
               setSearchParamsBlob,
               searchParamsBlob,

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearchLogic.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/PackageSearchLogic.ts
@@ -1,4 +1,4 @@
-import { getSectionDefault } from "cyberstorm/utils/section";
+import { getSectionSelection } from "cyberstorm/utils/section";
 
 import { type Section } from "@thunderstore/dapper/types";
 import { type CommunityFilters } from "@thunderstore/thunderstore-api";
@@ -40,7 +40,7 @@ export const searchParamsToBlob = (
       initialOrder && isPackageOrderOptions(initialOrder)
         ? (initialOrder as PackageOrderOptionsType)
         : undefined,
-    section: getSectionDefault(initialSection, sections),
+    section: getSectionSelection(initialSection, sections),
     deprecated:
       initialDeprecated === null
         ? false
@@ -136,7 +136,7 @@ export const resetParams = (
   setter({
     search: "",
     order: order,
-    section: getSectionDefault(null, sortedSections as Section[]),
+    section: getSectionSelection(null, sortedSections as Section[]),
     deprecated: false,
     nsfw: false,
     page: 1,

--- a/apps/cyberstorm-remix/app/commonComponents/PackageSearch/__tests__/PackageSearch.test.ts
+++ b/apps/cyberstorm-remix/app/commonComponents/PackageSearch/__tests__/PackageSearch.test.ts
@@ -87,11 +87,18 @@ describe("searchParamsToBlob", () => {
     expect(result.section).toBe("section-1");
   });
 
-  test("handles empty sections array correctly", () => {
+  test('selects "all" when the community has no sections', () => {
     const params = new URLSearchParams();
     const result = searchParamsToBlob(params, []);
 
-    expect(result.section).toBe("");
+    expect(result.section).toBe("all");
+  });
+
+  test('keeps an explicitly requested "all" selected', () => {
+    const params = new URLSearchParams();
+    params.set("section", "all");
+
+    expect(searchParamsToBlob(params, sections).section).toBe("all");
   });
 
   test("handles invalid integer for page", () => {
@@ -359,6 +366,24 @@ describe("synchronizeSearchParams", () => {
     expect(params.has("section")).toBe(false);
   });
 
+  test('writes out an explicitly picked "all"', () => {
+    const params = new URLSearchParams();
+    const blob = { ...defaultBlob, section: "all" };
+
+    synchronizeSearchParams(params, blob, defaultBlob, sections);
+
+    expect(params.get("section")).toBe("all");
+  });
+
+  test('omits "all" when the community has no sections to pick from', () => {
+    const params = new URLSearchParams();
+    const blob = { ...defaultBlob, section: "all" };
+
+    synchronizeSearchParams(params, blob, defaultBlob, []);
+
+    expect(params.has("section")).toBe(false);
+  });
+
   test("resets page if section has changed in ref", () => {
     const params = new URLSearchParams();
     params.set("section", "other-section");
@@ -521,7 +546,7 @@ describe("resetParams", () => {
 
     expect(setter2).toHaveBeenCalledWith(
       expect.objectContaining({
-        section: "",
+        section: "all",
       })
     );
   });

--- a/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.css
+++ b/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.css
@@ -48,6 +48,12 @@
     }
   }
 
+  .radio-group__divider {
+    height: var(--divider-height);
+    margin: var(--space-8) 0;
+    background-color: var(--divider-bg-color);
+  }
+
   .radio-group__radio {
     position: relative;
     display: flex;

--- a/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,7 @@
 import { faCircle, faCircleDot } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as RadixRadioGroup from "@radix-ui/react-radio-group";
-import { memo } from "react";
+import { Fragment, memo } from "react";
 
 import { NewIcon, classnames } from "@thunderstore/cyberstorm";
 import { type Section } from "@thunderstore/dapper/types";
@@ -10,10 +10,11 @@ interface Props {
   sections: Section[];
   selected: string;
   setSelected: (v: string) => void;
+  dividerAfterUuid?: string;
 }
 
 export const RadioGroup = memo(function RadioGroup(props: Props) {
-  const { sections, selected, setSelected } = props;
+  const { sections, selected, setSelected, dividerAfterUuid } = props;
 
   return (
     <RadixRadioGroup.Root
@@ -21,30 +22,34 @@ export const RadioGroup = memo(function RadioGroup(props: Props) {
       onValueChange={setSelected}
       className="radio-group"
     >
-      {sections.map((s) => (
-        <label
-          key={s.slug}
-          className={classnames(
-            "radio-group__label",
-            s.uuid === selected
-              ? "radio-group__label--selected"
-              : "radio-group__label--unselected"
-          )}
-        >
-          <RadixRadioGroup.Item value={s.uuid} className="radio-group__radio">
-            {s.uuid !== selected ? (
-              <NewIcon csMode="inline" noWrapper>
-                <FontAwesomeIcon icon={faCircle} />
-              </NewIcon>
-            ) : undefined}
-            <RadixRadioGroup.Indicator asChild>
-              <NewIcon csMode="inline" noWrapper>
-                <FontAwesomeIcon icon={faCircleDot} />
-              </NewIcon>
-            </RadixRadioGroup.Indicator>
-          </RadixRadioGroup.Item>
-          {s.name}
-        </label>
+      {sections.map((s, index) => (
+        <Fragment key={s.slug}>
+          <label
+            className={classnames(
+              "radio-group__label",
+              s.uuid === selected
+                ? "radio-group__label--selected"
+                : "radio-group__label--unselected"
+            )}
+          >
+            <RadixRadioGroup.Item value={s.uuid} className="radio-group__radio">
+              {s.uuid !== selected ? (
+                <NewIcon csMode="inline" noWrapper>
+                  <FontAwesomeIcon icon={faCircle} />
+                </NewIcon>
+              ) : undefined}
+              <RadixRadioGroup.Indicator asChild>
+                <NewIcon csMode="inline" noWrapper>
+                  <FontAwesomeIcon icon={faCircleDot} />
+                </NewIcon>
+              </RadixRadioGroup.Indicator>
+            </RadixRadioGroup.Item>
+            {s.name}
+          </label>
+          {s.uuid === dividerAfterUuid && index < sections.length - 1 ? (
+            <div className="radio-group__divider" role="presentation" />
+          ) : null}
+        </Fragment>
       ))}
     </RadixRadioGroup.Root>
   );

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/section.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/section.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { getSectionDefault } from "../section";
+import { getSectionDefault, getSectionSelection } from "../section";
+
+const sections = [
+  { uuid: "a", priority: 1 },
+  { uuid: "b", priority: 3 },
+  { uuid: "c", priority: 2 },
+];
 
 describe("utils.section.getSectionDefault", () => {
-  const sections = [
-    { uuid: "a", priority: 1 },
-    { uuid: "b", priority: 3 },
-    { uuid: "c", priority: 2 },
-  ];
-
   it('clears the section filter for "all"', () => {
     expect(getSectionDefault("all", sections)).toBe("");
   });
@@ -32,5 +32,27 @@ describe("utils.section.getSectionDefault", () => {
   it("returns empty string when there are no sections", () => {
     expect(getSectionDefault(null, [])).toBe("");
     expect(getSectionDefault("x", [])).toBe("");
+  });
+});
+
+describe("utils.section.getSectionSelection", () => {
+  it('keeps "all" selectable instead of collapsing it to no filter', () => {
+    expect(getSectionSelection("all", sections)).toBe("all");
+    expect(getSectionSelection("all", undefined)).toBe("all");
+  });
+
+  it('selects "all" when the community has no sections', () => {
+    expect(getSectionSelection(null, [])).toBe("all");
+    expect(getSectionSelection("x", [])).toBe("all");
+  });
+
+  it("otherwise resolves the same as getSectionDefault", () => {
+    expect(getSectionSelection("c", sections)).toBe("c");
+    expect(getSectionSelection("nonexistent", sections)).toBe("b");
+    expect(getSectionSelection(null, sections)).toBe("b");
+  });
+
+  it("returns empty string while the section list is unknown", () => {
+    expect(getSectionSelection(null, undefined)).toBe("");
   });
 });

--- a/apps/cyberstorm-remix/cyberstorm/utils/section.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/section.ts
@@ -1,3 +1,5 @@
+export const ALL_SECTIONS = "all";
+
 // Calculates the final section UUID based on an optionally requested section
 // and the community filters, defaulting to the highest priority section or
 // an empty string if "all" is explicitly passed.
@@ -5,7 +7,7 @@ export function getSectionDefault(
   section: string | null,
   sections?: { uuid: string; priority: number }[]
 ): string {
-  if (section === "all") return "";
+  if (section === ALL_SECTIONS) return "";
 
   // Honour a requested section only if the community actually has it — a stale
   // or junk uuid would 400 the listing API, so ignore it and fall through to
@@ -26,4 +28,13 @@ export function getSectionDefault(
   }
 
   return "";
+}
+
+export function getSectionSelection(
+  section: string | null,
+  sections?: { uuid: string; priority: number }[]
+): string {
+  if (sections && sections.length === 0) return ALL_SECTIONS;
+  if (section === ALL_SECTIONS) return ALL_SECTIONS;
+  return getSectionDefault(section, sections);
 }


### PR DESCRIPTION
- Lists "All" at the top of the Sections filter, separated from the community's own sections by a divider.
- Fixes ?section=all on communities that have sections.
- Tests cover the new resolver, the blob round-trip and the URL sync.