### PR TITLE
Pre-select community on upload page

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -225,6 +225,7 @@ function CommunityMainHeader({
           primitiveType="cyberstormLink"
           linkId="PackageUpload"
           rootClasses="community__upload-button"
+          community={resolvedCommunity.identifier}
         >
           <NewIcon noWrapper csMode="inline">
             <FontAwesomeIcon icon={faDownload} />

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/Navigation.tsx
@@ -360,6 +360,7 @@ export function Navigation(props: {
                 csSize="small"
                 aria-label="Upload"
                 tooltipText="Upload"
+                community={communityId}
               >
                 <NewIcon csMode="inline" noWrapper>
                   <FontAwesomeIcon icon={faUpload} />
@@ -914,8 +915,9 @@ function MobileDevelopersMenu({ domain }: { domain: string }) {
 export function MobileNavigationMenu(props: {
   domain: string;
   currentUser?: CurrentUser;
+  communityId?: string;
 }) {
-  const { domain, currentUser } = props;
+  const { domain, currentUser, communityId } = props;
   const location = useLocation();
 
   useEffect(() => {
@@ -1011,6 +1013,7 @@ export function MobileNavigationMenu(props: {
               csVariant="secondary"
               csSize="small"
               tooltipText="Upload"
+              community={communityId}
             >
               <NewIcon csMode="inline" noWrapper>
                 <FontAwesomeIcon icon={faUpload} />

--- a/apps/cyberstorm-remix/app/commonComponents/Navigation/NavigationWrapper.tsx
+++ b/apps/cyberstorm-remix/app/commonComponents/Navigation/NavigationWrapper.tsx
@@ -82,7 +82,11 @@ export function NavigationWrapper({
         domain={domain}
         communityId={communityId}
       />
-      <MobileNavigationMenu domain={domain} currentUser={currentUser} />
+      <MobileNavigationMenu
+        domain={domain}
+        currentUser={currentUser}
+        communityId={communityId}
+      />
     </>
   );
 }

--- a/apps/cyberstorm-remix/app/upload/__tests__/uploadUtils.test.ts
+++ b/apps/cyberstorm-remix/app/upload/__tests__/uploadUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCommunityOptions,
+  buildSelectedCommunities,
   formatBytes,
   getSubmissionErrorMessages,
   getSubmissionErrorsBySection,
@@ -101,6 +102,31 @@ describe("buildCommunityOptions", () => {
       { value: "risk-of-rain", label: "Risk of Rain" },
       { value: "valheim", label: "Valheim" },
     ]);
+  });
+});
+
+describe("buildSelectedCommunities", () => {
+  const communityOptions = [
+    { value: "risk-of-rain", label: "Risk of Rain" },
+    { value: "valheim", label: "Valheim" },
+  ];
+
+  it("selects the community when it matches an available option", () => {
+    expect(buildSelectedCommunities(communityOptions, "valheim")).toEqual([
+      "valheim",
+    ]);
+  });
+
+  it("returns an empty array when the community param is null", () => {
+    expect(buildSelectedCommunities(communityOptions, null)).toEqual([]);
+  });
+
+  it("returns an empty array when the community param is unknown", () => {
+    expect(buildSelectedCommunities(communityOptions, "unknown")).toEqual([]);
+  });
+
+  it("returns an empty array when there are no community options", () => {
+    expect(buildSelectedCommunities([], "valheim")).toEqual([]);
   });
 });
 

--- a/apps/cyberstorm-remix/app/upload/upload.tsx
+++ b/apps/cyberstorm-remix/app/upload/upload.tsx
@@ -5,7 +5,7 @@ import { getApiHostForSsr } from "cyberstorm/utils/env";
 import { createSeo } from "cyberstorm/utils/meta";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { useEffect, useMemo, useReducer, useState } from "react";
-import { useLoaderData, useOutletContext } from "react-router";
+import { useLoaderData, useOutletContext, useSearchParams } from "react-router";
 
 import { NewAlert, NewLink } from "@thunderstore/cyberstorm";
 import {
@@ -41,6 +41,7 @@ import {
 import {
   type UploadFormFieldAction,
   buildCommunityOptions,
+  buildSelectedCommunities,
   getSubmissionErrorMessages,
   getSubmissionErrorsBySection,
   getUploadProgressPercent,
@@ -105,6 +106,9 @@ export default function Upload() {
   const currentUser = outletContext.currentUser;
   const dapper = outletContext.dapper;
 
+  const [searchParams] = useSearchParams();
+  const community = searchParams.get("community");
+
   const communityOptions = useMemo(
     () => buildCommunityOptions(uploadData.results),
     [uploadData.results]
@@ -156,10 +160,10 @@ export default function Upload() {
     [submissionErrorMessages]
   );
 
-  const [formInputs, dispatchForm] = useReducer(
-    uploadFormFieldReducer,
-    initialUploadFormInputs
-  );
+  const [formInputs, dispatchForm] = useReducer(uploadFormFieldReducer, {
+    ...initialUploadFormInputs,
+    communities: buildSelectedCommunities(communityOptions, community),
+  });
 
   const updateFormFieldState = (action: UploadFormFieldAction) => {
     dispatchForm(action);

--- a/apps/cyberstorm-remix/app/upload/uploadUtils.ts
+++ b/apps/cyberstorm-remix/app/upload/uploadUtils.ts
@@ -54,6 +54,15 @@ export function buildCommunityOptions(
   }));
 }
 
+export function buildSelectedCommunities(
+  communityOptions: CommunityOption[],
+  community: string | null
+): string[] {
+  if (!community) return [];
+  const isValid = communityOptions.some((c) => c.value === community);
+  return isValid ? [community] : [];
+}
+
 export function formatBytes(bytes: number, decimals = 2) {
   if (!+bytes) return "0 Bytes";
 

--- a/apps/cyberstorm-remix/cyberstorm/utils/LinkLibrary.tsx
+++ b/apps/cyberstorm-remix/cyberstorm/utils/LinkLibrary.tsx
@@ -220,9 +220,20 @@ const library: LinkLibrary = {
       ref={p.customRef}
     />
   ),
-  PackageUpload: (p) => (
-    <Link {...p} url={"/package/create/"} ref={p.customRef} />
-  ),
+  PackageUpload: (p) => {
+    const queryParams = new URLSearchParams();
+    if (p.community) {
+      queryParams.set("community", p.community);
+    }
+    return (
+      <Link
+        {...p}
+        url={"/package/create/"}
+        queryParams={queryParams.toString()}
+        ref={p.customRef}
+      />
+    );
+  },
   Settings: (p) => <Link {...p} url={`/settings/`} ref={p.customRef} />,
   SettingsAccount: (p) => (
     <Link {...p} url={`/settings/account/`} ref={p.customRef} />

--- a/apps/storybook/LinkLibrary.tsx
+++ b/apps/storybook/LinkLibrary.tsx
@@ -200,9 +200,20 @@ const library: LinkLibrary = {
       ref={p.customRef}
     />
   ),
-  PackageUpload: (p) => (
-    <Link {...p} url={"/package/create/"} ref={p.customRef} />
-  ),
+  PackageUpload: (p) => {
+    const queryParams = new URLSearchParams();
+    if (p.community) {
+      queryParams.set("community", p.community);
+    }
+    return (
+      <Link
+        {...p}
+        url={"/package/create/"}
+        queryParams={queryParams.toString()}
+        ref={p.customRef}
+      />
+    );
+  },
   Settings: (p) => <Link {...p} url={`/settings/`} ref={p.customRef} />,
   SettingsAccount: (p) => (
     <Link {...p} url={`/settings/account/`} ref={p.customRef} />


### PR DESCRIPTION
It's cumbersome to select the community when updating a mod.

This adds the optional community parameter to the url when clicking an upload button. This is only set, if the user is navigated in a community.
I.e. `href="/package/create/?community=riskofrain2"`

On the upload page, this parameter is read and sets the community, if valid.

The AI review will probably complain about not handling the reset etc but that's fine. Just setting the community once already makes it way easier to upload.