### PR TITLE
Match ad hosts as tokens, not substrings, in Sentry message fallback (TS-3973)

### DIFF
--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/sentry.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/sentry.test.ts
@@ -171,6 +171,34 @@ describe("utils.sentry.beforeSend", () => {
     expect(beforeSend(event)).toBe(event);
   });
 
+  it("keeps a frameless message where an ad domain abuts an underscore", () => {
+    // "_" is a token character: "foo_media.net" and "media.net_extra" are
+    // identifiers of their own, not the ad host.
+    for (const value of [
+      "Failed to fetch. (foo_media.net)",
+      "Failed to fetch. (media.net_extra)",
+    ]) {
+      const event = {
+        exception: { values: [{ type: "TypeError", value }] },
+      } as ErrorEvent;
+      expect(beforeSend(event), value).toBe(event);
+    }
+  });
+
+  it("drops a frameless message where an ad host ends a sentence with a period", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Failed to load script from media.net.",
+          },
+        ],
+      },
+    } as ErrorEvent;
+    expect(beforeSend(event)).toBeNull();
+  });
+
   it("passes through frameless events whose message is unrelated", () => {
     const event = {
       exception: {

--- a/apps/cyberstorm-remix/cyberstorm/utils/__tests__/sentry.test.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/__tests__/sentry.test.ts
@@ -140,6 +140,37 @@ describe("utils.sentry.beforeSend", () => {
     expect(beforeSend(event)).toBeNull();
   });
 
+  it("drops a frameless message naming an ad host as a subdomain token", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Failed to fetch. (cdn.media.net)",
+          },
+        ],
+      },
+    } as ErrorEvent;
+    expect(beforeSend(event)).toBeNull();
+  });
+
+  it("keeps a frameless message where an ad domain only appears as a prefix of another word", () => {
+    // "media.net" must match as a host token, not a bare substring:
+    // "media.network" is a different domain.
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "NetworkError when attempting to fetch resource. (media.network)",
+          },
+        ],
+      },
+    } as ErrorEvent;
+    expect(beforeSend(event)).toBe(event);
+  });
+
   it("passes through frameless events whose message is unrelated", () => {
     const event = {
       exception: {

--- a/apps/cyberstorm-remix/cyberstorm/utils/sentry.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/sentry.ts
@@ -166,20 +166,22 @@ function matchesDenyUrl(text: string): boolean {
 }
 
 // denyUrls string entries compiled to match as host/filename tokens inside
-// free-form message text (case-insensitive). An entry matches when it is:
-//   - preceded by start-of-text or any char outside [a-z0-9-] — "." counts,
-//     so subdomains match: "(diagnostics.id5-sync.com)" matches "id5-sync.com"
-//   - followed by end-of-text or any char outside [a-z0-9.-] — so longer
-//     domains don't: neither "media.network" nor "cdn.media.net.evil.com"
-//     matches "media.net"
+// free-form message text (case-insensitive). Token chars are [a-z0-9_-];
+// an entry matches when it is:
+//   - preceded by start-of-text or any char outside the token set — "."
+//     counts, so subdomains match: "(diagnostics.id5-sync.com)" matches
+//     "id5-sync.com" — while "foo_media.net" does not match "media.net"
+//   - not followed by a token char ("media.net_extra", "media.network")
+//     nor by a "." that continues the hostname ("cdn.media.net.evil.com");
+//     a terminal "." ending a sentence is fine: "media.net." matches
 // RegExp entries are used as-is.
 const denyUrlTokenPatterns: RegExp[] = denyUrls.map((pattern) =>
   typeof pattern === "string"
     ? new RegExp(
-        `(^|[^a-z0-9-])${pattern.replace(
+        `(^|[^a-z0-9_-])${pattern.replace(
           /[.*+?^${}()|[\]\\]/g,
           "\\$&"
-        )}($|[^a-z0-9.-])`,
+        )}(?!\\.?[a-z0-9_-])`,
         "i"
       )
     : pattern

--- a/apps/cyberstorm-remix/cyberstorm/utils/sentry.ts
+++ b/apps/cyberstorm-remix/cyberstorm/utils/sentry.ts
@@ -165,6 +165,30 @@ function matchesDenyUrl(text: string): boolean {
   );
 }
 
+// denyUrls string entries compiled to match as host/filename tokens inside
+// free-form message text (case-insensitive). An entry matches when it is:
+//   - preceded by start-of-text or any char outside [a-z0-9-] — "." counts,
+//     so subdomains match: "(diagnostics.id5-sync.com)" matches "id5-sync.com"
+//   - followed by end-of-text or any char outside [a-z0-9.-] — so longer
+//     domains don't: neither "media.network" nor "cdn.media.net.evil.com"
+//     matches "media.net"
+// RegExp entries are used as-is.
+const denyUrlTokenPatterns: RegExp[] = denyUrls.map((pattern) =>
+  typeof pattern === "string"
+    ? new RegExp(
+        `(^|[^a-z0-9-])${pattern.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          "\\$&"
+        )}($|[^a-z0-9.-])`,
+        "i"
+      )
+    : pattern
+);
+
+function matchesDenyUrlToken(text: string): boolean {
+  return denyUrlTokenPatterns.some((re) => re.test(text));
+}
+
 /**
  * A stack frame only attributes an error to a real script if it has a concrete
  * filename. Browser extensions and opaque cross-origin scripts surface as
@@ -203,7 +227,7 @@ function isAdScriptError(event: ErrorEvent): boolean {
     return namedFrames.some((frame) => matchesDenyUrl(frame.filename ?? ""));
   }
 
-  return values.some((v) => matchesDenyUrl(v.value ?? ""));
+  return values.some((v) => matchesDenyUrlToken(v.value ?? ""));
 }
 
 /**


### PR DESCRIPTION
Frameless ad errors are dropped by matching denyUrls domains against the error message text. A bare substring check ("media.net" also matches "media.network") could drop a real app error that merely mentions a similar-looking domain. Compile the domains into boundary-aware patterns so only the actual ad host matches.

Refs. TS-3973