### PR TITLE
Prevent layout shifts on community and packages

### DIFF
--- a/apps/cyberstorm-remix/app/c/Community.tsx
+++ b/apps/cyberstorm-remix/app/c/Community.tsx
@@ -137,14 +137,14 @@ function CommunityMainHeroBackground({
 }) {
   return (
     <div className="community__background">
-      {resolvedCommunity.hero_image_url ? (
-        <div className="community__background-image">
+      <div className="community__background-image">
+        {resolvedCommunity.hero_image_url ? (
           <img
             src={resolvedCommunity.hero_image_url}
             alt={resolvedCommunity.name}
           />
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -239,7 +239,18 @@ function CommunityMainHeader({
 function CommunityMainHeaderSkeleton() {
   return (
     <div className="community__header">
-      <SkeletonBox />
+      <div className="community__background">
+        <div className="community__background-image">
+          <SkeletonBox />
+        </div>
+      </div>
+      <div className="community__content-header-wrapper">
+        <div className="community__content-header">
+          <div className="community__game-icon">
+            <SkeletonBox className="community__game-icon-image" />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/cyberstorm-remix/app/c/CommunityPackageListingSubpath.tsx
+++ b/apps/cyberstorm-remix/app/c/CommunityPackageListingSubpath.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from "react-router";
 
+import { SkeletonBox } from "@thunderstore/cyberstorm";
+
 import { type OutletContextShape } from "../root";
 import type { loader } from "./Community";
 import "./CommunityPackageListingSubpath.css";
@@ -55,6 +57,18 @@ export function CommunityPackageListingHeader({
       <CommunityPackageListingHeroBackground
         resolvedCommunity={resolvedCommunity}
       />
+    </div>
+  );
+}
+
+export function CommunityPackageListingHeaderSkeleton() {
+  return (
+    <div className="community__header community__header--compact">
+      <div className="community__background community__background--packagePage">
+        <div className="community__background-image">
+          <SkeletonBox />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
+++ b/apps/cyberstorm-remix/app/p/dependants/Dependants.tsx
@@ -13,7 +13,10 @@ import { getSectionDefault } from "cyberstorm/utils/section";
 import { ssrLoader } from "cyberstorm/utils/ssrLoader";
 import { Suspense } from "react";
 import { Await, useLoaderData, useOutletContext } from "react-router";
-import { CommunityPackageListingHeader } from "~/c/CommunityPackageListingSubpath";
+import {
+  CommunityPackageListingHeader,
+  CommunityPackageListingHeaderSkeleton,
+} from "~/c/CommunityPackageListingSubpath";
 import { SidebarAd } from "~/commonComponents/Ads/SidebarAd";
 import { DEPENDANTS_SIDEBAR_AD } from "~/commonComponents/Ads/nitroAds";
 import { PackageSearch } from "~/commonComponents/PackageSearch/PackageSearch";
@@ -245,7 +248,7 @@ export default function Dependants() {
 
   return (
     <Page as="section" rootClasses="dependants">
-      <Suspense fallback={null}>
+      <Suspense fallback={<CommunityPackageListingHeaderSkeleton />}>
         <Await resolve={community}>
           {(resolvedCommunity) => (
             <CommunityPackageListingHeader

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -6,7 +6,10 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { faArrowUpRight, faLips } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { CommunityPackageListingHeader } from "app/c/CommunityPackageListingSubpath";
+import {
+  CommunityPackageListingHeader,
+  CommunityPackageListingHeaderSkeleton,
+} from "app/c/CommunityPackageListingSubpath";
 import { SidebarAd } from "app/commonComponents/Ads/SidebarAd";
 import { PACKAGE_SIDEBAR_AD } from "app/commonComponents/Ads/nitroAds";
 import { CommunityPromo } from "app/commonComponents/CommunityPromo/CommunityPromo";
@@ -374,7 +377,7 @@ export default function PackageListing() {
           Install lines up with the page header below it (see
           .layout__main--package-detail). Null when the community has no hero. */}
       <div className="package-listing__banner">
-        <Suspense fallback={null}>
+        <Suspense fallback={<CommunityPackageListingHeaderSkeleton />}>
           <Await resolve={community}>
             {(resolvedCommunity) => (
               <CommunityPackageListingHeader

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -16,7 +16,10 @@ import {
   useLocation,
   useOutletContext,
 } from "react-router";
-import { CommunityPackageListingHeader } from "~/c/CommunityPackageListingSubpath";
+import {
+  CommunityPackageListingHeader,
+  CommunityPackageListingHeaderSkeleton,
+} from "~/c/CommunityPackageListingSubpath";
 import { CommunityPromo } from "~/commonComponents/CommunityPromo/CommunityPromo";
 import { PageHeader } from "~/commonComponents/PageHeader/PageHeader";
 import { type OutletContextShape } from "~/root";
@@ -208,7 +211,7 @@ export default function PackageListingVersion() {
     <>
       {/* Community hero banner — its own grid row (see
           .layout__main--package-detail). */}
-      <Suspense fallback={null}>
+      <Suspense fallback={<CommunityPackageListingHeaderSkeleton />}>
         <Await resolve={community}>
           {(resolvedCommunity) => (
             <CommunityPackageListingHeader


### PR DESCRIPTION
The client side loading didn't take into account the community hero image, causing a layout shift when the community loads.

This now assumes each community has a hero image and renders a skeleton for it, keeping the layout intact.

Now looks like this while the data is fetched:
<img width="1917" height="936" alt="image" src="https://github.com/user-attachments/assets/9402d637-4caf-4657-8e35-0f32619c192d" />
<img width="1915" height="933" alt="image" src="https://github.com/user-attachments/assets/a399be52-b5a0-472a-b405-b8941d460a88" />
