### PR TITLE
[TS-4002] Improve package metadata display

### DIFF
--- a/apps/cyberstorm-remix/app/p/packageListing.css
+++ b/apps/cyberstorm-remix/app/p/packageListing.css
@@ -75,6 +75,10 @@
     width: 100%;
   }
 
+  .package-listing__drawer {
+    color: inherit;
+  }
+
   /* One combined dashed box of moderator actions (the Island "special" variant
      supplies the flex row + border + background). fit-content so the box hugs
      its buttons; it sits right-aligned in the breadcrumb row (see layout.css). */

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -51,8 +51,9 @@ import {
   RelativeTime,
   SkeletonBox,
   Tabs,
+  TooltipWrapper,
   formatFileSize,
-  formatInteger,
+  formatAsCount,
   formatToDisplayName,
   useToast,
 } from "@thunderstore/cyberstorm";
@@ -341,12 +342,28 @@ export default function PackageListing() {
 
     setLastUpdated(
       lastUpdatedTime ? (
-        <RelativeTime time={lastUpdatedTime} suppressHydrationWarning />
+        <TooltipWrapper tooltipText={new Date(lastUpdatedTime).toUTCString()}>
+          <span>
+            <RelativeTime
+              time={lastUpdatedTime}
+              disableTitle={true}
+              suppressHydrationWarning
+            />
+          </span>
+        </TooltipWrapper>
       ) : undefined
     );
     setFirstUploaded(
       firstUploadedTime ? (
-        <RelativeTime time={firstUploadedTime} suppressHydrationWarning />
+        <TooltipWrapper tooltipText={new Date(firstUploadedTime).toUTCString()}>
+          <span>
+            <RelativeTime
+              time={firstUploadedTime}
+              disableTitle={true}
+              suppressHydrationWarning
+            />
+          </span>
+        </TooltipWrapper>
       ) : undefined
     );
   }, []);
@@ -746,6 +763,20 @@ function packageBoxes(
   );
 }
 
+function downloadsTooltipText(
+  listing: Awaited<ReturnType<DapperTsInterface["getPackageListingDetails"]>>
+) {
+  const suffix = listing.download_count === 1 ? "download" : "downloads";
+  return `${listing.download_count} ${suffix}`;
+}
+
+function likesTooltipText(
+  listing: Awaited<ReturnType<DapperTsInterface["getPackageListingDetails"]>>
+) {
+  const suffix = listing.rating_count === 1 ? "like" : "likes";
+  return `${listing.rating_count} ${suffix}`;
+}
+
 function packageMeta(
   lastUpdated: ReactElement | undefined,
   firstUploaded: ReactElement | undefined,
@@ -764,13 +795,17 @@ function packageMeta(
       <div className="package-listing-sidebar__item">
         <div className="package-listing-sidebar__label">Downloads</div>
         <div className="package-listing-sidebar__content">
-          {formatInteger(listing.download_count)}
+          <TooltipWrapper tooltipText={downloadsTooltipText(listing)}>
+            <span>{formatAsCount(listing.download_count)}</span>
+          </TooltipWrapper>
         </div>
       </div>
       <div className="package-listing-sidebar__item">
         <div className="package-listing-sidebar__label">Likes</div>
         <div className="package-listing-sidebar__content">
-          {formatInteger(listing.rating_count)}
+          <TooltipWrapper tooltipText={likesTooltipText(listing)}>
+            <span>{formatAsCount(listing.rating_count)}</span>
+          </TooltipWrapper>
         </div>
       </div>
       <div className="package-listing-sidebar__item">

--- a/apps/cyberstorm-remix/app/p/packageListing.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListing.tsx
@@ -52,8 +52,8 @@ import {
   SkeletonBox,
   Tabs,
   TooltipWrapper,
-  formatFileSize,
   formatAsCount,
+  formatFileSize,
   formatToDisplayName,
   useToast,
 } from "@thunderstore/cyberstorm";

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -31,8 +31,9 @@ import {
   RelativeTime,
   SkeletonBox,
   Tabs,
+  TooltipWrapper,
   formatFileSize,
-  formatInteger,
+  formatAsCount,
   formatToDisplayName,
 } from "@thunderstore/cyberstorm";
 import { DapperTs } from "@thunderstore/dapper-ts";
@@ -48,6 +49,11 @@ import {
 import "./packageListing.css";
 
 export { RouteErrorBoundary as ErrorBoundary } from "app/commonComponents/ErrorBoundary";
+
+function downloadsTooltipText(listing: PackageListingDetails) {
+  const suffix = listing.download_count === 1 ? "download" : "downloads";
+  return `${listing.download_count} ${suffix}`;
+}
 
 // Browser-tab title + share metadata, shared by the SSR loader and the
 // clientLoader so the title doesn't collapse to the root "Thunderstore"
@@ -407,14 +413,24 @@ function packageMeta(listing: PackageListingDetails) {
         <div className="package-listing-sidebar__label">Date Uploaded</div>
         <div className="package-listing-sidebar__content">
           {dateUploaded ? (
-            <RelativeTime time={dateUploaded} suppressHydrationWarning />
+            <TooltipWrapper tooltipText={new Date(dateUploaded).toUTCString()}>
+              <span>
+                <RelativeTime
+                  time={dateUploaded}
+                  disableTitle={true}
+                  suppressHydrationWarning
+                />
+              </span>
+            </TooltipWrapper>
           ) : null}
         </div>
       </div>
       <div className="package-listing-sidebar__item">
         <div className="package-listing-sidebar__label">Downloads</div>
         <div className="package-listing-sidebar__content">
-          {formatInteger(listing.download_count)}
+          <TooltipWrapper tooltipText={downloadsTooltipText(listing)}>
+            <span>{formatAsCount(listing.download_count)}</span>
+          </TooltipWrapper>
         </div>
       </div>
       <div className="package-listing-sidebar__item">

--- a/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
+++ b/apps/cyberstorm-remix/app/p/packageListingVersion.tsx
@@ -32,8 +32,8 @@ import {
   SkeletonBox,
   Tabs,
   TooltipWrapper,
-  formatFileSize,
   formatAsCount,
+  formatFileSize,
   formatToDisplayName,
 } from "@thunderstore/cyberstorm";
 import { DapperTs } from "@thunderstore/dapper-ts";

--- a/packages/cyberstorm/src/index.ts
+++ b/packages/cyberstorm/src/index.ts
@@ -143,6 +143,7 @@ export {
   numberWithSpaces,
   formatFileSize,
   formatInteger,
+  formatAsCount,
   formatToDisplayName,
 } from "./utils/utils";
 

--- a/packages/cyberstorm/src/utils/__tests__/utils.test.ts
+++ b/packages/cyberstorm/src/utils/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAsCount } from "../utils";
+
+describe("formatAsCount", () => {
+  it("leaves counts below the compact threshold untouched", () => {
+    expect(formatAsCount(0)).toBe("0");
+    expect(formatAsCount(1)).toBe("1");
+    expect(formatAsCount(999)).toBe("999");
+  });
+
+  it("keeps at most one decimal at the K boundaries", () => {
+    expect(formatAsCount(1_000)).toBe("1K");
+    expect(formatAsCount(1_234)).toBe("1.2K");
+    expect(formatAsCount(9_999)).toBe("9.9K");
+    expect(formatAsCount(12_345)).toBe("12.3K");
+    expect(formatAsCount(99_999)).toBe("99.9K");
+    expect(formatAsCount(123_456)).toBe("123.4K");
+    expect(formatAsCount(999_999)).toBe("999.9K");
+  });
+
+  it("keeps at most one decimal at the M and B boundaries", () => {
+    expect(formatAsCount(1_234_567)).toBe("1.2M");
+    expect(formatAsCount(12_345_678)).toBe("12.3M");
+    expect(formatAsCount(999_999_999)).toBe("999.9M");
+    expect(formatAsCount(1_000_000_000)).toBe("1B");
+  });
+
+  it("truncates instead of rounding up", () => {
+    expect(formatAsCount(1_999)).toBe("1.9K");
+    expect(formatAsCount(1_099)).toBe("1K");
+  });
+
+  it("never renders more than one decimal place", () => {
+    for (let exponent = 0; exponent < 12; exponent++) {
+      for (const digits of [1, 2345, 6789, 9999]) {
+        const formatted = formatAsCount(digits * 10 ** exponent);
+        expect(formatted).toMatch(/^\d{1,3}(\.\d)?[KMBT]?$/);
+      }
+    }
+  });
+});

--- a/packages/cyberstorm/src/utils/utils.ts
+++ b/packages/cyberstorm/src/utils/utils.ts
@@ -17,7 +17,6 @@ export const formatInteger = (
 export const formatAsCount = (inputNumber: number) => {
   return formatInteger(inputNumber, "compact", {
     maximumFractionDigits: 1,
-    maximumSignificantDigits: 4,
     roundingMode: "trunc",
   });
 };

--- a/packages/cyberstorm/src/utils/utils.ts
+++ b/packages/cyberstorm/src/utils/utils.ts
@@ -5,9 +5,21 @@ export const range = (start: number, end: number) => {
 
 export const formatInteger = (
   inputNumber: number,
-  notation: "standard" | "scientific" | "engineering" | "compact" = "compact"
+  notation: "standard" | "scientific" | "engineering" | "compact" = "compact",
+  formatOptions: Intl.NumberFormatOptions = {}
 ) => {
-  return Intl.NumberFormat("en", { notation: notation }).format(inputNumber);
+  return Intl.NumberFormat("en", {
+    notation: notation,
+    ...formatOptions,
+  }).format(inputNumber);
+};
+
+export const formatAsCount = (inputNumber: number) => {
+  return formatInteger(inputNumber, "compact", {
+    maximumFractionDigits: 1,
+    maximumSignificantDigits: 4,
+    roundingMode: "trunc",
+  });
 };
 
 export const numberWithSpaces = (x: number) => {


### PR DESCRIPTION
Resolves:
- Download count missing tooltip on hover
- Date meta info isn't a tooltip on hover, uses currently the browser native tooltip thing
- The download count and like counts rounding on bigger numbers could be changed to "round to closest first decimal" instead of full digit. On packages with higher download counts it can be the difference of +400k downloads